### PR TITLE
Local dev bootstrap, Docker trim, CI smoke secrets

### DIFF
--- a/.cursor/skills/run-agate-smoke/SKILL.md
+++ b/.cursor/skills/run-agate-smoke/SKILL.md
@@ -8,7 +8,7 @@ description: Validate the Backfield golden path against a live stack. Use when r
 ## Quick Start
 
 1. Ensure the stack is running (`make up` or `make up-detached`).
-2. Export `OPENAI_API_KEY` (and optional geocoder keys) on the host so Compose can pass them into the `worker` service; the starter flow runs LLM PlaceExtract and GeocodeAgent.
+2. Put `OPENAI_API_KEY` and/or `ANTHROPIC_API_KEY` (and optional geocoder keys) in **repo-root `.env`** so Compose loads them into `worker` and `agate-api` (and into General project secrets when `BACKFIELD_LOCAL_BOOTSTRAP=1`).
 3. Run `make smoke` (uses `SMOKE_POLL_TIMEOUT_SECONDS`, default 180s).
 4. If it fails, inspect `make logs` and the relevant service logs.
 
@@ -16,11 +16,10 @@ description: Validate the Backfield golden path against a live stack. Use when r
 
 - Agate API health
 - Stylebook API health
-- Temp project creation
-- Template instantiation into a graph
-- Run enqueue on the `agate` queue
+- **General** project (slug `general`) and **Starter flow** graph present
+- Run enqueue on the `agate` queue for that graph
 - Worker completion and terminal run status
-- Cleanup of smoke-created resources
+- Does **not** delete General or the starter graph
 
 ## When To Use It
 

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,18 @@
+# Build context is the repo root (see infra/docker-compose.yml build.context).
+
+.git
+.venv
+.env
+.env.local
+**/__pycache__
+**/*.py[cod]
+**/.pytest_cache
+**/.ruff_cache
+**/.mypy_cache
+**/node_modules
+**/dist
+**/*.egg-info
+
+# Who's On First SQLite (multi-GB; not in git — see geocoding/data/README.md).
+# Excluding prevents "no space left on device" during image build if present locally.
+packages/agate-runtime/src/agate_utils/geocoding/data/*.db

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# Copy to `.env` in the repo root (gitignored). Used by Docker Compose `env_file` for
+# agate-api and worker (paths in infra/docker-compose.yml).
+
+# Optional: disable DB sync + starter graph creation on agate-api startup (default is on in compose).
+# BACKFIELD_LOCAL_BOOTSTRAP=0
+
+# Fernet key for encrypting agate_project_secret (compose provides a dev default if unset).
+# MASTER_ENCRYPTION_KEY=
+
+# Required for PlaceExtract + real GeocodeAgent runs (set at least one).
+# OPENAI_API_KEY=
+# ANTHROPIC_API_KEY=
+
+# Optional geocoding / search providers.
+# PELIAS_API_KEY=
+# GEOCODIO_API_KEY=
+# BRAVE_SEARCH_API_KEY=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,19 @@ jobs:
       - name: Install workspace dependencies
         run: uv sync --all-packages
       - name: Start runtime services
-        run: docker compose -f infra/docker-compose.yml up -d --build postgres redis stylebook-api agate-api worker
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${OPENAI_API_KEY:-}" ] && [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+            echo "::error::CI smoke needs at least one repository secret: OPENAI_API_KEY or ANTHROPIC_API_KEY (Compose loads repo-root .env into agate-api/worker)."
+            exit 1
+          fi
+          : > .env
+          [ -n "${OPENAI_API_KEY:-}" ] && printf 'OPENAI_API_KEY=%s\n' "$OPENAI_API_KEY" >> .env
+          [ -n "${ANTHROPIC_API_KEY:-}" ] && printf 'ANTHROPIC_API_KEY=%s\n' "$ANTHROPIC_API_KEY" >> .env
+          docker compose -f infra/docker-compose.yml up -d --build postgres redis stylebook-api agate-api worker
       - name: Wait for API health
         run: |
           for _ in $(seq 1 60); do
@@ -58,8 +70,9 @@ jobs:
           done
           docker compose -f infra/docker-compose.yml logs
           exit 1
+      # Run the script directly so the job exit code matches Python (make maps recipe failures to exit 2).
       - name: Golden-path smoke
-        run: make smoke
+        run: uv run python -u scripts/smoke_agate_stack.py
       - name: Dump compose logs on failure
         if: failure()
         run: docker compose -f infra/docker-compose.yml logs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ Use this file as the entry point for working in this repository. Keep it short, 
 ## Canonical commands
 
 - `make bootstrap`: install Python workspace dependencies with `uv` (does not seed DB data; local seeding runs when the stack starts — see `BACKFIELD_LOCAL_BOOTSTRAP` in [docs/OPERATIONS.md](docs/OPERATIONS.md)).
-- `make up` / `make down`: start and stop the local stack.
+- `make up` / `make down`: start and stop the local stack (`down` also runs Docker build-cache and unused-volume prune).
 - `make logs`: follow compose logs.
 - `make migrate`: run Alembic in the `agate-api` container.
 - `make lint`: run Ruff checks.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ Use this file as the entry point for working in this repository. Keep it short, 
 
 ## Canonical commands
 
-- `make bootstrap`: install Python workspace dependencies with `uv`.
+- `make bootstrap`: install Python workspace dependencies with `uv` (does not seed DB data; local seeding runs when the stack starts — see `BACKFIELD_LOCAL_BOOTSTRAP` in [docs/OPERATIONS.md](docs/OPERATIONS.md)).
 - `make up` / `make down`: start and stop the local stack.
 - `make logs`: follow compose logs.
 - `make migrate`: run Alembic in the `agate-api` container.

--- a/Makefile
+++ b/Makefile
@@ -2,16 +2,19 @@
 COMPOSE_FILE := infra/docker-compose.yml
 DC := docker compose -f $(COMPOSE_FILE)
 
-.PHONY: help up up-detached down logs migrate reset-db test test-unit test-integration lint format bootstrap smoke
+.PHONY: help up up-detached down logs migrate reset-db docker-prune-build docker-prune-volumes docker-trim test test-unit test-integration lint format bootstrap smoke
 
 help:
 	@echo "Backfield"
 	@echo "  make up          - Start stack in foreground (logs attached; Ctrl+C stops)"
 	@echo "  make up-detached - Same as up but background (-d)"
-	@echo "  make down        - Stop stack"
+	@echo "  make down        - Stop stack, then docker-trim (build cache + unused volumes)"
 	@echo "  make logs        - Follow compose logs"
 	@echo "  make migrate     - Run Alembic (agate-api container)"
-	@echo "  make reset-db    - Drop compose volumes (destructive)"
+	@echo "  make reset-db    - Stop stack and remove compose volumes (Postgres data, etc.)"
+	@echo "  make docker-prune-build   - Free build cache (docker builder prune -f)"
+	@echo "  make docker-prune-volumes - Remove unused anonymous volumes (docker volume prune -f)"
+	@echo "  make docker-trim          - Prune build cache then unused volumes"
 	@echo "  make test        - Unit + integration tests"
 	@echo "  make test-unit   - Python unit tests (backfield-core)"
 	@echo "  make test-integration - API smoke tests"
@@ -34,6 +37,7 @@ up-detached:
 down:
 	@echo "Stopping Backfield stack..."
 	$(DC) down --remove-orphans
+	@$(MAKE) --no-print-directory docker-trim
 
 logs:
 	$(DC) logs -f
@@ -44,6 +48,17 @@ migrate:
 reset-db:
 	@echo "Removing Postgres volume (all local Backfield data)."
 	$(DC) down -v
+
+docker-prune-build:
+	@echo "Pruning Docker build cache..."
+	docker builder prune -f
+
+docker-prune-volumes:
+	@echo "Pruning unused Docker volumes (named compose volumes in use are kept)..."
+	docker volume prune -f
+
+docker-trim: docker-prune-build docker-prune-volumes
+	@echo "docker-trim done."
 
 test: test-unit test-integration
 

--- a/Makefile
+++ b/Makefile
@@ -75,4 +75,4 @@ format:
 	uv run ruff format packages apps tests
 
 smoke:
-	uv run python scripts/smoke_agate_stack.py
+	uv run python -u scripts/smoke_agate_stack.py

--- a/README.md
+++ b/README.md
@@ -24,14 +24,17 @@ Reconstruction of the Agate-style platform focused on **Agate** (visual pipeline
 ## Quick start
 
 ```bash
-make bootstrap   # once: uv sync --all-packages (Python tooling + libs)
-make up          # Docker Compose (foreground; Ctrl+C stops all services)
+cp .env.example .env   # optional: add OPENAI_API_KEY / ANTHROPIC_API_KEY (gitignored)
+make bootstrap         # once: uv sync --all-packages (Python tooling + libs)
+make up                # Docker Compose (foreground; Ctrl+C stops all services)
 ```
 
-- Agate: http://localhost:5173 — use **Run pipeline** (saves graph, enqueues Celery run, polls result).  
+- Agate: http://localhost:5173 — home opens the **General** project; a **Starter flow** graph is created on first API boot when `BACKFIELD_LOCAL_BOOTSTRAP=1` (default in Compose).  
 - Stylebook UI: http://localhost:5175  
 
-`agate-api` runs `alembic upgrade head` on container start so migrations apply.
+`agate-api` runs `alembic upgrade head` on container start so migrations apply, then (when bootstrap is enabled) syncs API keys from the repo-root `.env` into encrypted **General** project secrets and ensures the starter graph exists.
+
+`make bootstrap` installs Python dependencies only; it does **not** seed the database (that happens when the stack starts).
 
 ## Validation
 
@@ -43,7 +46,8 @@ make smoke   # requires a live local stack
 
 ### Environment
 
-Optional shared secret for service calls (set the same value on agate-api, worker, stylebook-api):
+- **LLM / geocoder keys**: add to repo-root `.env` (see [.env.example](.env.example)). Compose loads that file into `agate-api` and `worker` so PlaceExtract and GeocodeAgent can run. The same values are copied into **General** project secrets when local bootstrap runs (Fernet-encrypted in Postgres).
+- **Shared service token** (optional): set the same value on agate-api, worker, and stylebook-api:
 
 ```bash
 export SERVICE_API_TOKEN=your-token
@@ -82,6 +86,6 @@ If unset, Stylebook geocode accepts unauthenticated requests (dev only).
 ```
 apps/agate-api    apps/agate-ui
 apps/worker       apps/stylebook-api    apps/stylebook-ui
-packages/backfield-core   packages/backfield-db
-infra/docker-compose.yml
+packages/backfield-core   packages/backfield-db   packages/agate-runtime
+infra/docker-compose.yml   .env.example
 ```

--- a/README.md
+++ b/README.md
@@ -61,10 +61,11 @@ If unset, Stylebook geocode accepts unauthenticated requests (dev only).
 | Target | Purpose |
 |--------|---------|
 | `make help` | List commands |
-| `make up` / `make down` | Compose |
+| `make up` / `make down` | Compose (`down` then prunes build cache and unused volumes) |
 | `make logs` | Tail logs |
 | `make migrate` | Re-run Alembic inside `agate-api` |
-| `make reset-db` | `docker compose down -v` |
+| `make reset-db` | `docker compose down -v` (removes Postgres volume) |
+| `make docker-trim` | Prune build cache + unused volumes when Docker is low on disk |
 | `make test` | All tests |
 | `make lint` / `make format` | Ruff |
 

--- a/apps/agate-api/scripts/entrypoint.sh
+++ b/apps/agate-api/scripts/entrypoint.sh
@@ -4,4 +4,7 @@ export PYTHONPATH="/app/packages/backfield-db/src:${PYTHONPATH:-}"
 cd /app/packages/backfield-db
 python -m alembic upgrade head
 cd /app/apps/agate-api
+if [ "${BACKFIELD_LOCAL_BOOTSTRAP:-0}" = "1" ]; then
+  python -m api.local_bootstrap
+fi
 exec uvicorn api.main:app --host 0.0.0.0 --port 8000 --reload

--- a/apps/agate-api/src/api/local_bootstrap.py
+++ b/apps/agate-api/src/api/local_bootstrap.py
@@ -1,0 +1,130 @@
+"""Idempotent local dev seed: General project secrets from env + Starter flow graph.
+
+Invoked from entrypoint when BACKFIELD_LOCAL_BOOTSTRAP=1 (not FastAPI lifespan).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import UTC, datetime
+
+from backfield_core import STARTER_FLOW_GRAPH_DISPLAY_NAME, starter_geocode_flow_graph_spec
+from backfield_db import AgateGraph, AgateProject, AgateProjectSecret
+from backfield_db.crypto import encrypt_secret, fernet_from_env
+from backfield_db.session import get_engine
+from sqlmodel import Session, select
+
+logger = logging.getLogger(__name__)
+
+GENERAL_SLUG = "general"
+
+# Keys mirrored from host/.env into agate_project_secret for the General project.
+_BOOTSTRAP_SECRET_KEYS: tuple[str, ...] = (
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "PELIAS_API_KEY",
+    "GEOCODIO_API_KEY",
+    "BRAVE_SEARCH_API_KEY",
+)
+
+
+def _sync_secrets(session: Session, project_id: int) -> int:
+    f = fernet_from_env()
+    if f is None:
+        logger.warning(
+            "local_bootstrap: MASTER_ENCRYPTION_KEY not set; skipping project secret sync"
+        )
+        return 0
+    now = datetime.now(UTC)
+    n = 0
+    for key in _BOOTSTRAP_SECRET_KEYS:
+        value = os.environ.get(key, "").strip()
+        if not value:
+            continue
+        try:
+            enc = encrypt_secret(value)
+        except RuntimeError as e:
+            logger.warning("local_bootstrap: encrypt failed for %s: %s", key, e)
+            continue
+        existing = session.exec(
+            select(AgateProjectSecret).where(
+                AgateProjectSecret.project_id == project_id,
+                AgateProjectSecret.key == key,
+            )
+        ).first()
+        if existing:
+            existing.value_encrypted = enc
+            existing.updated_at = now
+            session.add(existing)
+        else:
+            session.add(
+                AgateProjectSecret(
+                    project_id=project_id,
+                    key=key,
+                    value_encrypted=enc,
+                    created_at=now,
+                    updated_at=now,
+                )
+            )
+        n += 1
+    return n
+
+
+def _ensure_starter_graph(session: Session, project_id: int) -> bool:
+    existing = session.exec(
+        select(AgateGraph).where(
+            AgateGraph.project_id == project_id,
+            AgateGraph.name == STARTER_FLOW_GRAPH_DISPLAY_NAME,
+        )
+    ).first()
+    if existing:
+        return False
+    spec = starter_geocode_flow_graph_spec()
+    session.add(
+        AgateGraph(
+            name=STARTER_FLOW_GRAPH_DISPLAY_NAME,
+            spec_json=spec.model_dump_json(),
+            project_id=project_id,
+        )
+    )
+    return True
+
+
+def run_local_bootstrap() -> int:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+    engine = get_engine()
+    with Session(engine) as session:
+        project = session.exec(
+            select(AgateProject).where(AgateProject.slug == GENERAL_SLUG)
+        ).first()
+        if project is None or project.id is None:
+            logger.warning(
+                "local_bootstrap: no project with slug %r (run migrations); skipping",
+                GENERAL_SLUG,
+            )
+            return 0
+        pid = int(project.id)
+        secret_count = _sync_secrets(session, pid)
+        added_graph = _ensure_starter_graph(session, pid)
+        session.commit()
+        if secret_count:
+            logger.info("local_bootstrap: upserted %d project secret(s) for General", secret_count)
+        if added_graph:
+            logger.info(
+                "local_bootstrap: created graph %r for General",
+                STARTER_FLOW_GRAPH_DISPLAY_NAME,
+            )
+        if not secret_count and not added_graph:
+            logger.info(
+                "local_bootstrap: no env secrets to sync and starter graph already exists"
+            )
+    return 0
+
+
+def main() -> int:
+    return run_local_bootstrap()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -21,7 +21,7 @@ Do **not** run multiple services that each invoke `alembic upgrade` on startup f
 - `agate_template` — curated template flows (`spec_json`); instantiated as new `agate_graph` rows.
 - `agate_project_secret` — per-project encrypted env-style secrets (`key` + `value_encrypted`); decrypted by the worker at run time when `MASTER_ENCRYPTION_KEY` is set.
 
-Schema is defined by a single baseline revision, `001_agate_baseline`, which creates the `agate_`* tables and seed rows (General project, Geocode pipeline template).
+Schema is defined by a single baseline revision, `001_agate_baseline`, which creates the `agate_`* tables and seed rows (General project, Geocode pipeline template). The **Starter flow** graph row for General is created at runtime when `BACKFIELD_LOCAL_BOOTSTRAP=1` on `agate-api` startup (see [docs/OPERATIONS.md](OPERATIONS.md)), not by the baseline migration.
 
 **Existing databases** that already applied the old `001`–`004` chain: if the live schema already matches the `agate_`* layout above, point `alembic_version` at the new head. Alembic cannot `stamp` from a revision id that no longer exists in the repo, so use SQL once:
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -15,11 +15,16 @@ Primary local services are defined in `infra/docker-compose.yml`:
 ## Canonical commands
 
 - `make up`: bring up the local stack in the foreground.
-- `make down`: stop the stack and remove orphans.
+- `make down`: stop the stack and remove orphans, then run `docker-trim` (build-cache and unused-volume prune).
 - `make logs`: inspect compose logs.
 - `make migrate`: run Alembic inside `agate-api`.
 - `make reset-db`: tear down containers and volumes.
 - `make smoke`: run the HTTP golden-path smoke against a live stack.
+- `make docker-prune-build`: reclaim disk from Docker build cache (`docker builder prune -f`).
+- `make docker-prune-volumes`: remove **unused** anonymous volumes (`docker volume prune -f`); does not remove named volumes while containers still reference them.
+- `make docker-trim`: runs both prunes above (handy before `make up` when the daemon is low on disk).
+
+Docker builds use the repo root as context; [.dockerignore](../.dockerignore) excludes large local files such as Who's On First `*.db` under `packages/agate-runtime/.../geocoding/data/` so images do not try to copy multi-gigabyte databases.
 
 ## Runtime contracts
 
@@ -71,3 +76,4 @@ For `make smoke`, set at least `OPENAI_API_KEY` and/or `ANTHROPIC_API_KEY` in re
 - If secrets calls fail, verify `MASTER_ENCRYPTION_KEY`.
 - If geocode calls fail, check `stylebook-api`, `STYLEBOOK_API_URL`, and `SERVICE_API_TOKEN`.
 - If PlaceExtract or GeocodeAgent fail with auth errors, verify LLM and geocoder keys on the worker (Compose env or project secrets).
+- If `make up` / image build fails with **no space left on device**, run `make docker-trim` (and remove any huge local `.db` under `packages/agate-runtime/.../geocoding/data/` if you do not need it). The WOF database must not live in the image; [.dockerignore](../.dockerignore) keeps it out of the build context.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -38,6 +38,11 @@ Primary local services are defined in `infra/docker-compose.yml`:
 - `SERVICE_API_TOKEN`: optional shared token between Agate and Stylebook services.
 - `MASTER_ENCRYPTION_KEY`: required for encrypted project-secret storage.
 - `UI_ORIGIN`: allowed browser origin for local UI access.
+- `BACKFIELD_LOCAL_BOOTSTRAP`: when `1`, `agate-api` entrypoint (after Alembic) syncs allowlisted keys from the container environment into **General** (`agate_project_secret`) and creates the **Starter flow** graph if missing. Default in Compose is `1`; set `0` to disable (see repo-root `.env.example`).
+
+### Repo-root `.env` (local only)
+
+`agate-api` and `worker` use Compose `env_file: ../.env` (relative to `infra/docker-compose.yml`, i.e. the repository root). Copy [.env.example](../.env.example) to `.env` and add keys there; the file is gitignored. Variables are injected into the containers (Compose `required: false` so a missing `.env` does not fail the bring-up).
 
 ### Flow execution (PlaceExtract, GeocodeAgent)
 
@@ -48,9 +53,9 @@ Graph nodes are executed in the worker using the vendored `agate-runtime` packag
 - **Who's On First SQLite** (parent lookups in `wof.py`): the database file is not in git (size). Install under `packages/agate-runtime/.../geocoding/data/` or set **`WOF_SQLITE_DB_PATH`** to the `.db` file. See `packages/agate-runtime/src/agate_utils/geocoding/data/README.md`.
 - **Celery limits**: `TASK_SOFT_TIME_LIMIT` / `TASK_HARD_TIME_LIMIT` (defaults `3600` / `4200` seconds on the worker service in Compose) mirror agate-ai-platform worker defaults for long-running geocode flows.
 
-For `make smoke`, export at least `OPENAI_API_KEY` if the golden-path graph includes PlaceExtract, or the run will fail when the LLM is invoked.
+For `make smoke`, set at least `OPENAI_API_KEY` and/or `ANTHROPIC_API_KEY` in repo-root `.env` (or ensure they exist in the worker environment) so PlaceExtract can call the LLM; otherwise the run fails when those nodes execute.
 
-Docker Compose passes through `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `PELIAS_API_KEY`, `GEOCODIO_API_KEY`, `BRAVE_SEARCH_API_KEY`, and `PROJECT_SLUG` from the host environment into the `worker` service.
+`PROJECT_SLUG` can still be set via Compose interpolation on the worker service for Stylebook cache scoping.
 
 ## Database guidance
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -36,4 +36,6 @@ make lint
 make test
 ```
 
-Recommended follow-up job: bring up the runtime stack in CI and run `make smoke`.
+The GitHub Actions **smoke** job brings up Compose and runs `scripts/smoke_agate_stack.py`. Configure at least one of **`OPENAI_API_KEY`** or **`ANTHROPIC_API_KEY`** as a [repository secret](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions); the workflow writes a short-lived repo-root `.env` so `agate-api` / `worker` receive keys (same mechanism as local dev). Fork PRs from outside contributors typically cannot read those secrets, so smoke may be skipped or failed by policy.
+
+**Note:** `make smoke` runs the same script; GNU Make reports **exit code 2** when the recipe fails even if Python exited 1, which can obscure logs in some UIs—prefer invoking `uv run python -u scripts/smoke_agate_stack.py` in automation when you need a clear process exit code.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -7,7 +7,7 @@
 2. **Integration / API smoke**
   FastAPI apps mounted via `TestClient` where no Docker is required. Run: `make test-integration`.
 3. **End-to-end (manual or CI)**
-  `make up`, then run `make smoke` or open Agate UI and **Run pipeline**. Validates Postgres, Redis, Celery, and the four starter nodes together. The starter flow uses LLM PlaceExtract and GeocodeAgent; export `OPENAI_API_KEY` (and optional geocoder keys) for the worker before `make smoke`, or the run will fail when those nodes call external APIs.
+  `make up`, then run `make smoke` or open Agate UI and **Run pipeline**. Validates Postgres, Redis, Celery, and the four starter nodes together. `make smoke` runs the **General** project’s **Starter flow** graph (created by local bootstrap on first API start). Put `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` (and optional geocoder keys) in repo-root `.env` so the worker and encrypted project secrets receive them, or the run will fail when those nodes call external APIs.
 
 ## Validation ladder
 
@@ -17,7 +17,7 @@
 2. **Structural checks**
   Runtime contract and schema-prefix assertions live in the test suite and run as part of `make test`.
 3. **Golden-path smoke**
-  `make smoke` against a live stack. This checks Agate and Stylebook health, creates a temp project, instantiates the starter template, enqueues a run, and polls for completion (default poll window allows slow LLM/geocode; override with `SMOKE_POLL_TIMEOUT_SECONDS`).
+  `make smoke` against a live stack. This checks Agate and Stylebook health, finds the seeded **General** project and **Starter flow** graph, enqueues a run, and polls for completion (default poll window allows slow LLM/geocode; override with `SMOKE_POLL_TIMEOUT_SECONDS`). It does not delete General or the starter graph.
 4. **Manual UI pass**
   Use the Agate UI when the task changes browser-facing behavior or flowbuilder interactions.
 

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -41,6 +41,9 @@ services:
     build:
       context: ..
       dockerfile: apps/agate-api/Dockerfile
+    env_file:
+      - path: ../.env
+        required: false
     ports:
       - "8000:8000"
     environment:
@@ -52,6 +55,9 @@ services:
       STYLEBOOK_API_URL: http://stylebook-api:8003
       # Dev-only Fernet key for encrypting agate_project_secret; override in production.
       MASTER_ENCRYPTION_KEY: ${MASTER_ENCRYPTION_KEY:-qhgUjRZ2WpPE9rP3viewNrKOmKQDvXbXzHCPxgrrZyI=}
+      # After migrations: sync .env API keys into General + create Starter flow graph.
+      BACKFIELD_LOCAL_BOOTSTRAP: ${BACKFIELD_LOCAL_BOOTSTRAP:-1}
+      # LLM / geocoder keys: set in repo-root .env (see .env.example); loaded via env_file above.
     depends_on:
       postgres:
         condition: service_healthy
@@ -64,6 +70,9 @@ services:
     build:
       context: ..
       dockerfile: apps/worker/Dockerfile
+    env_file:
+      - path: ../.env
+        required: false
     environment:
       <<: *shared-env
       REDIS_URL: redis://redis:6379/0
@@ -71,12 +80,7 @@ services:
       DATABASE_URL: postgresql+psycopg://postgres:postgres@postgres:5432/backfield
       STYLEBOOK_API_URL: http://stylebook-api:8003
       MASTER_ENCRYPTION_KEY: ${MASTER_ENCRYPTION_KEY:-qhgUjRZ2WpPE9rP3viewNrKOmKQDvXbXzHCPxgrrZyI=}
-      # LLM / geocoding (optional; required for PlaceExtract + GeocodeAgent in real runs)
-      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
-      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
-      PELIAS_API_KEY: ${PELIAS_API_KEY:-}
-      GEOCODIO_API_KEY: ${GEOCODIO_API_KEY:-}
-      BRAVE_SEARCH_API_KEY: ${BRAVE_SEARCH_API_KEY:-}
+      # LLM / geocoder keys: repo-root .env via env_file above.
       PROJECT_SLUG: ${PROJECT_SLUG:-}
       TASK_SOFT_TIME_LIMIT: ${TASK_SOFT_TIME_LIMIT:-3600}
       TASK_HARD_TIME_LIMIT: ${TASK_HARD_TIME_LIMIT:-4200}

--- a/packages/backfield-core/src/backfield_core/__init__.py
+++ b/packages/backfield-core/src/backfield_core/__init__.py
@@ -1,6 +1,10 @@
 """Backfield Agate core: graph spec and node execution."""
 
 from backfield_core.executor import execute_graph
+from backfield_core.starter_flow import (
+    STARTER_FLOW_GRAPH_DISPLAY_NAME,
+    starter_geocode_flow_graph_spec,
+)
 from backfield_core.types import Edge, GraphSpec, NodeConfig, RunStatus
 
 __all__ = [
@@ -8,5 +12,7 @@ __all__ = [
     "GraphSpec",
     "NodeConfig",
     "RunStatus",
+    "STARTER_FLOW_GRAPH_DISPLAY_NAME",
     "execute_graph",
+    "starter_geocode_flow_graph_spec",
 ]

--- a/packages/backfield-core/src/backfield_core/starter_flow.py
+++ b/packages/backfield-core/src/backfield_core/starter_flow.py
@@ -1,0 +1,56 @@
+"""Canonical four-node geocode starter graph (TextInput through Output) for bootstrap and smoke."""
+
+from __future__ import annotations
+
+from backfield_core.types import Edge, GraphSpec, NodeConfig
+
+# Stored graph name in agate_graph.name (UI + smoke lookup).
+STARTER_FLOW_GRAPH_DISPLAY_NAME = "Starter flow"
+
+
+def starter_geocode_flow_graph_spec() -> GraphSpec:
+    """Same topology as the golden-path smoke flow (includes edge handles)."""
+    return GraphSpec(
+        name="starter_geocode_flow",
+        nodes=[
+            NodeConfig(
+                id="n1",
+                type="TextInput",
+                params={"text": "We visited Chicago, IL and Austin, TX."},
+                position={"x": 0, "y": 0},
+            ),
+            NodeConfig(
+                id="n2",
+                type="PlaceExtract",
+                params={},
+                position={"x": 220, "y": 0},
+            ),
+            NodeConfig(
+                id="n3",
+                type="GeocodeAgent",
+                params={},
+                position={"x": 440, "y": 0},
+            ),
+            NodeConfig(
+                id="n4",
+                type="Output",
+                params={},
+                position={"x": 660, "y": 0},
+            ),
+        ],
+        edges=[
+            Edge(source="n1", target="n2", sourceHandle="text", targetHandle="text"),
+            Edge(
+                source="n2",
+                target="n3",
+                sourceHandle="locations",
+                targetHandle="locations",
+            ),
+            Edge(
+                source="n3",
+                target="n4",
+                sourceHandle="locations",
+                targetHandle="data",
+            ),
+        ],
+    )

--- a/packages/backfield-core/tests/test_starter_flow.py
+++ b/packages/backfield-core/tests/test_starter_flow.py
@@ -1,0 +1,13 @@
+"""Starter flow graph spec sanity checks."""
+
+from backfield_core import GraphSpec, starter_geocode_flow_graph_spec
+
+
+def test_starter_geocode_flow_graph_spec_round_trip() -> None:
+    spec = starter_geocode_flow_graph_spec()
+    raw = spec.model_dump(mode="json")
+    again = GraphSpec.model_validate(raw)
+    assert again.name == "starter_geocode_flow"
+    assert len(again.nodes) == 4
+    assert len(again.edges) == 3
+    assert {n.type for n in again.nodes} == {"TextInput", "PlaceExtract", "GeocodeAgent", "Output"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "pytest>=8.0",
     "httpx>=0.27.0",
     "ruff>=0.6.0",
+    "backfield-core",
 ]
 
 [tool.uv.workspace]

--- a/scripts/smoke_agate_stack.py
+++ b/scripts/smoke_agate_stack.py
@@ -6,9 +6,9 @@ from __future__ import annotations
 import os
 import sys
 import time
-import uuid
 
 import httpx
+from backfield_core import STARTER_FLOW_GRAPH_DISPLAY_NAME, starter_geocode_flow_graph_spec
 
 AGATE_API_BASE = os.environ.get("AGATE_API_BASE", "http://localhost:8000")
 STYLEBOOK_API_BASE = os.environ.get("STYLEBOOK_API_BASE", "http://localhost:8003")
@@ -36,58 +36,7 @@ def _wait_for_terminal_run(client: httpx.Client, run_id: str) -> dict:
     raise RuntimeError(f"Timed out waiting for run {run_id} to finish")
 
 
-def _fallback_graph_spec() -> dict:
-    return {
-        "name": "smoke_flow",
-        "nodes": [
-            {
-                "id": "n1",
-                "type": "TextInput",
-                "params": {"text": "We visited Chicago, IL and Austin, TX."},
-                "position": {"x": 0, "y": 0},
-            },
-            {
-                "id": "n2",
-                "type": "PlaceExtract",
-                "params": {},
-                "position": {"x": 220, "y": 0},
-            },
-            {
-                "id": "n3",
-                "type": "GeocodeAgent",
-                "params": {},
-                "position": {"x": 440, "y": 0},
-            },
-            {
-                "id": "n4",
-                "type": "Output",
-                "params": {},
-                "position": {"x": 660, "y": 0},
-            },
-        ],
-        "edges": [
-            {"source": "n1", "target": "n2", "sourceHandle": "text", "targetHandle": "text"},
-            {
-                "source": "n2",
-                "target": "n3",
-                "sourceHandle": "locations",
-                "targetHandle": "locations",
-            },
-            {
-                "source": "n3",
-                "target": "n4",
-                "sourceHandle": "locations",
-                "targetHandle": "data",
-            },
-        ],
-    }
-
-
 def main() -> int:
-    slug = f"smoke-{uuid.uuid4().hex[:8]}"
-    created_project_id: int | None = None
-    created_graph_id: str | None = None
-
     with httpx.Client(base_url=AGATE_API_BASE, timeout=10.0) as agate_client:
         stylebook_client = httpx.Client(base_url=STYLEBOOK_API_BASE, timeout=10.0)
         try:
@@ -98,40 +47,44 @@ def main() -> int:
             if stylebook_health.get("ok") is not True:
                 raise RuntimeError(f"Stylebook health failed: {stylebook_health}")
 
-            project = _assert_ok(
-                agate_client.post("/projects", json={"name": "Smoke Project", "slug": slug}),
-                "create project",
-            )
-            created_project_id = int(project["id"])
+            projects = agate_client.get("/projects")
+            projects.raise_for_status()
+            plist = projects.json()
+            if not isinstance(plist, list):
+                raise RuntimeError(f"list projects: expected list, got {type(plist)}")
+            general = next((p for p in plist if p.get("slug") == "general"), None)
+            if general is None:
+                raise RuntimeError(
+                    "Smoke needs the seeded 'General' project (slug general). "
+                    "Run migrations (agate-api entrypoint or make migrate)."
+                )
+            project_id = int(general["id"])
 
-            templates_response = agate_client.get("/templates")
-            templates_response.raise_for_status()
-            templates = templates_response.json()
-            if templates:
-                template_id = templates[0]["id"]
-                graph = _assert_ok(
-                    agate_client.post(
-                        f"/templates/{template_id}/instantiate",
-                        json={"project_id": created_project_id, "name": "Smoke Flow"},
-                    ),
-                    "instantiate template",
+            graphs = agate_client.get("/graphs")
+            graphs.raise_for_status()
+            glist = graphs.json()
+            if not isinstance(glist, list):
+                raise RuntimeError(f"list graphs: expected list, got {type(glist)}")
+            starter = next(
+                (
+                    g
+                    for g in glist
+                    if g.get("project_id") == project_id
+                    and g.get("name") == STARTER_FLOW_GRAPH_DISPLAY_NAME
+                ),
+                None,
+            )
+            if starter is None:
+                spec = starter_geocode_flow_graph_spec()
+                raise RuntimeError(
+                    f"Smoke needs graph named {STARTER_FLOW_GRAPH_DISPLAY_NAME!r} on General. "
+                    "Start the stack with BACKFIELD_LOCAL_BOOTSTRAP=1 (see docker-compose) "
+                    f"or create it with spec name {spec.name!r}."
                 )
-            else:
-                graph = _assert_ok(
-                    agate_client.post(
-                        "/graphs",
-                        json={
-                            "name": "Smoke Flow",
-                            "project_id": created_project_id,
-                            "spec": _fallback_graph_spec(),
-                        },
-                    ),
-                    "create fallback graph",
-                )
-            created_graph_id = str(graph["id"])
+            graph_id = str(starter["id"])
 
             run = _assert_ok(
-                agate_client.post("/runs", json={"graph_id": created_graph_id}),
+                agate_client.post("/runs", json={"graph_id": graph_id}),
                 "create run",
             )
             terminal_run = _wait_for_terminal_run(agate_client, str(run["id"]))
@@ -142,15 +95,11 @@ def main() -> int:
                 )
 
             print("Smoke passed.")
-            print(f"Project: {created_project_id}")
-            print(f"Graph: {created_graph_id}")
+            print(f"Project: {project_id} (general)")
+            print(f"Graph: {graph_id} ({STARTER_FLOW_GRAPH_DISPLAY_NAME})")
             print(f"Run: {terminal_run['id']}")
             return 0
         finally:
-            if created_graph_id is not None:
-                agate_client.delete(f"/graphs/{created_graph_id}")
-            if created_project_id is not None:
-                agate_client.delete(f"/projects/{created_project_id}")
             stylebook_client.close()
 
 

--- a/scripts/smoke_agate_stack.py
+++ b/scripts/smoke_agate_stack.py
@@ -17,6 +17,18 @@ POLL_TIMEOUT_SECONDS = float(os.environ.get("SMOKE_POLL_TIMEOUT_SECONDS", "180")
 POLL_INTERVAL_SECONDS = float(os.environ.get("SMOKE_POLL_INTERVAL_SECONDS", "1.5"))
 
 
+def _log(msg: str) -> None:
+    print(msg, flush=True)
+
+
+def _http_error_detail(exc: httpx.HTTPError) -> str:
+    if isinstance(exc, httpx.HTTPStatusError) and exc.response is not None:
+        r = exc.response
+        body = (r.text or "")[:4000]
+        return f"{r.status_code} {r.request.method} {r.request.url!s}\n{body}"
+    return str(exc)
+
+
 def _assert_ok(response: httpx.Response, context: str) -> dict:
     response.raise_for_status()
     payload = response.json()
@@ -37,6 +49,7 @@ def _wait_for_terminal_run(client: httpx.Client, run_id: str) -> dict:
 
 
 def main() -> int:
+    _log(f"Smoke: AGATE_API_BASE={AGATE_API_BASE} STYLEBOOK_API_BASE={STYLEBOOK_API_BASE}")
     with httpx.Client(base_url=AGATE_API_BASE, timeout=10.0) as agate_client:
         stylebook_client = httpx.Client(base_url=STYLEBOOK_API_BASE, timeout=10.0)
         try:
@@ -94,10 +107,10 @@ def main() -> int:
                     f"status={terminal_run.get('status')} error={terminal_run.get('error_message')}"
                 )
 
-            print("Smoke passed.")
-            print(f"Project: {project_id} (general)")
-            print(f"Graph: {graph_id} ({STARTER_FLOW_GRAPH_DISPLAY_NAME})")
-            print(f"Run: {terminal_run['id']}")
+            _log("Smoke passed.")
+            _log(f"Project: {project_id} (general)")
+            _log(f"Graph: {graph_id} ({STARTER_FLOW_GRAPH_DISPLAY_NAME})")
+            _log(f"Run: {terminal_run['id']}")
             return 0
         finally:
             stylebook_client.close()
@@ -107,8 +120,8 @@ if __name__ == "__main__":
     try:
         raise SystemExit(main())
     except httpx.HTTPError as exc:
-        print(f"HTTP smoke failure: {exc}", file=sys.stderr)
+        print(f"HTTP smoke failure: {_http_error_detail(exc)}", file=sys.stderr, flush=True)
         raise SystemExit(1) from exc
     except Exception as exc:
-        print(f"Smoke failure: {exc}", file=sys.stderr)
+        print(f"Smoke failure: {exc}", file=sys.stderr, flush=True)
         raise SystemExit(1) from exc

--- a/uv.lock
+++ b/uv.lock
@@ -5,8 +5,8 @@ requires-python = ">=3.11"
 [manifest]
 members = [
     "agate-api",
-    "agate-worker",
     "agate-runtime",
+    "agate-worker",
     "backfield-core",
     "backfield-db",
     "backfield-workspace",
@@ -36,6 +36,39 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "redis", specifier = ">=5.0.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.27.0" },
+]
+
+[[package]]
+name = "agate-runtime"
+version = "0.1.0"
+source = { editable = "packages/agate-runtime" }
+dependencies = [
+    { name = "anthropic" },
+    { name = "duckduckgo-search" },
+    { name = "geopy" },
+    { name = "h3" },
+    { name = "httpx" },
+    { name = "langgraph" },
+    { name = "openai" },
+    { name = "overpy" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "shapely" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "anthropic", specifier = ">=0.18.0" },
+    { name = "duckduckgo-search", specifier = ">=7.0.0" },
+    { name = "geopy", specifier = ">=2.4.0" },
+    { name = "h3", specifier = ">=4.3.1" },
+    { name = "httpx", specifier = ">=0.27.0" },
+    { name = "langgraph", specifier = ">=0.2.0" },
+    { name = "openai", specifier = ">=1.12.0" },
+    { name = "overpy", specifier = ">=0.7" },
+    { name = "pydantic", specifier = ">=2.0.0" },
+    { name = "requests", specifier = ">=2.31.0" },
+    { name = "shapely", specifier = ">=2.0.0" },
 ]
 
 [[package]]
@@ -143,39 +176,6 @@ wheels = [
 ]
 
 [[package]]
-name = "agate-runtime"
-version = "0.1.0"
-source = { editable = "packages/agate-runtime" }
-dependencies = [
-    { name = "anthropic" },
-    { name = "duckduckgo-search" },
-    { name = "geopy" },
-    { name = "h3" },
-    { name = "httpx" },
-    { name = "langgraph" },
-    { name = "openai" },
-    { name = "overpy" },
-    { name = "pydantic" },
-    { name = "requests" },
-    { name = "shapely" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "anthropic", specifier = ">=0.18.0" },
-    { name = "duckduckgo-search", specifier = ">=7.0.0" },
-    { name = "geopy", specifier = ">=2.4.0" },
-    { name = "h3", specifier = ">=4.3.1" },
-    { name = "httpx", specifier = ">=0.27.0" },
-    { name = "langgraph", specifier = ">=0.2.0" },
-    { name = "openai", specifier = ">=1.12.0" },
-    { name = "overpy", specifier = ">=0.7" },
-    { name = "pydantic", specifier = ">=2.0.0" },
-    { name = "requests", specifier = ">=2.31.0" },
-    { name = "shapely", specifier = ">=2.0.0" },
-]
-
-[[package]]
 name = "backfield-core"
 version = "0.1.0"
 source = { editable = "packages/backfield-core" }
@@ -218,6 +218,7 @@ name = "backfield-workspace"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "backfield-core" },
     { name = "httpx" },
     { name = "pytest" },
     { name = "ruff" },
@@ -225,6 +226,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "backfield-core", editable = "packages/backfield-core" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "ruff", specifier = ">=0.6.0" },


### PR DESCRIPTION
## Summary

- **Local bootstrap** (`BACKFIELD_LOCAL_BOOTSTRAP`): after migrations, sync allowlisted API keys from env into **General** project secrets and ensure **Starter flow** graph (`starter_geocode_flow_graph_spec` in backfield-core).
- **Compose**: repo-root `.env` via `env_file`; `.env.example`; smoke uses General + Starter flow (no temp project).
- **Docker**: root `.dockerignore` excludes WOF `*.db` from build context; `make down` runs `docker-trim`; `docker-prune-*` targets.
- **CI smoke**: write `.env` from `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` secrets before `docker compose up`; run smoke with `python -u` for clearer logs/exit codes; richer HTTP errors in script.

## Validation

- `make lint` / `make test`
- Configure repo Actions secrets for smoke job.

Made with [Cursor](https://cursor.com)