### PR TITLE
docs: fresh-branch default for new implementation work

### DIFF
--- a/.cursor/rules/core-workflow.mdc
+++ b/.cursor/rules/core-workflow.mdc
@@ -13,4 +13,4 @@ alwaysApply: true
 - Run relevant validation before finishing:
   - default: `make lint` and `make test`
   - runtime changes: also run `make smoke`
-- Work in short-lived branches and keep one coherent task per diff; create a **new** branch for large or unrelated changes instead of continuing on whatever branch is checked out.
+- When implementation starts, **branch fresh** from the task’s base (usually `main`) unless directed otherwise. Work in short-lived branches and keep one coherent task per diff; create a **new** branch for large or unrelated changes instead of continuing on whatever branch is checked out.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,7 @@ See also `docs/ARCHITECTURE.md` (reference section).
 
 ## Git workflow
 
+- **When you begin writing code, use a fresh branch** (cut from the agreed base, usually `main`) unless the task explicitly says to continue on an existing branch. This is the default for humans and agents alike.
 - **Start a new branch for each task**—especially for large or unrelated changes. Do not pile new work onto whatever branch happens to be checked out (for example another feature or setup branch) unless it is explicitly the same task.
 - Work from a clean working tree when you branch; keep one coherent task per branch and per diff.
 - Prefer short-lived branches and small diffs over stacking unrelated changes.

--- a/docs/AGENT_WORKFLOWS.md
+++ b/docs/AGENT_WORKFLOWS.md
@@ -8,6 +8,7 @@ Backfield is a refactor of **agate-ai-platform** (`/Users/cjdd3b/apps/agate-ai-p
 
 ## Git and branches
 
+- **Default:** when you start writing code, check out a **fresh branch** from the task base (typically `main`) unless the instructions explicitly say to use or extend an existing branch.
 - Create a **new branch** for each distinct task. Large or unrelated work (new packages, migrations, multi-app changes) should not ride on an unrelated existing branch.
 - Name branches so the intent is obvious (for example `feat/agate-runtime-port`, `fix/worker-timeout`).
 - See `AGENTS.md` → **Git workflow** for the full convention.


### PR DESCRIPTION
## Summary

Documents the default that implementation should start on a **fresh branch** from the task base (usually `main`) unless instructions say otherwise.

- `AGENTS.md` → Git workflow
- `.cursor/rules/core-workflow.mdc`
- `docs/AGENT_WORKFLOWS.md`

Made with [Cursor](https://cursor.com)