### PR TITLE
docs(cursor): expand agentic workflow and pre-PR review guidance

### DIFF
--- a/.cursor/skills/grill-me/SKILL.md
+++ b/.cursor/skills/grill-me/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: grill-me
+description: >-
+  Stress-tests plans and designs through sequential Q&A until decisions align; explores the codebase when facts live in code. Use in Cursor Plan mode, when the user wants to stress-test a plan, get grilled on a design, or says "grill me".
+---
+
+# Grill me (plan stress-test)
+
+## When to apply
+
+- The session is in **Plan mode**, or the user is explicitly **planning** before implementation.
+- The user asks to **stress-test** a plan, **interrogate** a design, or says **"grill me"** (or similar).
+
+## Behavior
+
+1. **One question at a time.** Do not list a batch of questions; wait for an answer (or confirmation) before the next question.
+2. **Walk the decision tree.** Cover branches in a sensible order so earlier answers **unlock** dependent questions. Call out when a later choice would invalidate an earlier one.
+3. **Recommended answer:** After each question, state a **concise recommended option** and why it fits this repo (point to `AGENTS.md`, `docs/`, or code when useful).
+4. **Codebase over guessing:** If the answer depends on how Backfield is structured, **read or search the repo** (files, patterns, existing APIs) instead of assuming. Summarize what you found in one or two sentences, then ask or decide.
+5. **Shared understanding:** Continue until major forks are resolved or the user stops the loop. Offer a short **recap** of agreed decisions before handing off to implementation.
+
+## Out of scope
+
+- This skill does **not** replace `docs/PLANS.md` or project planning docs; it sharpens the plan interactively.
+- Once the user switches to implementation-only work, default back to normal agent behavior unless they invoke grilling again.

--- a/.cursor/skills/pre-pr-architecture-review/SKILL.md
+++ b/.cursor/skills/pre-pr-architecture-review/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: pre-pr-architecture-review
+description: Review whether a branch still fits Backfield's architecture before opening a pull request. Use proactively before creating PRs, or when asked for an architecture review, design review, layering review, package-boundary review, or bigger-picture fit check.
+---
+
+# Pre-PR Architecture Review
+
+Run this before creating a pull request.
+
+## Goal
+
+Check that the change still fits the repo's intended shape: package boundaries, service responsibilities, data ownership, runtime flow, and parity expectations.
+
+## Review priorities
+
+1. Boundary fit: does code live in the right app/package/doc, or is logic leaking across layers?
+2. Dependency direction: are new imports, APIs, or shared utilities preserving the intended architecture?
+3. Operational fit: does the change add env vars, queues, migrations, bootstrap logic, or runtime coupling that should be documented or reconsidered?
+4. Long-term shape: does this move the codebase toward a cleaner system, or add incidental complexity that should be challenged now?
+
+## How to run the review
+
+1. Read the relevant source-of-truth docs first (`AGENTS.md`, `docs/ARCHITECTURE.md`, plus API/DB/FRONTEND/OPERATIONS as needed).
+2. Inspect the diff and map it to affected layers.
+3. Compare to existing repo conventions and, when parity matters, agate-ai-platform.
+4. Identify architectural mismatches, missing doc updates, hidden coupling, or misplaced ownership.
+5. Raise concerns interactively before PR creation when the right answer is not obvious.
+
+## Output expectations
+
+- Surface bigger-picture findings first, not file-by-file commentary.
+- Explain what architectural rule or repo convention is being strained.
+- Recommend the simplest change that restores alignment.
+- If the architecture still holds, say so explicitly and mention any assumptions that future work should revisit.
+
+## Interactive questions
+
+Ask focused questions when a design choice is unresolved. Good examples:
+- Should this live in `backfield-core`, or is it really app-specific behavior?
+- Is this a one-off env var, or should it be part of a documented operational contract?
+- Are we intentionally diverging from agate-ai-platform here, and if so where should that be recorded?

--- a/.cursor/skills/pre-pr-code-review/SKILL.md
+++ b/.cursor/skills/pre-pr-code-review/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: pre-pr-code-review
+description: Review a branch or diff for cleanup opportunities before opening a pull request. Use proactively before creating PRs, or when asked for a code review, cleanup pass, simplification review, dead-code review, or readability review.
+---
+
+# Pre-PR Code Review
+
+Run this before creating a pull request.
+
+## Goal
+
+Make the change set cleaner, smaller, and easier to understand before anyone else reviews it.
+
+## Review priorities
+
+1. Look for simplifications: smaller helpers, clearer names, less branching, less duplication.
+2. Look for removable code: dead paths, obsolete comments, stale helpers, redundant tests, unused imports or fields.
+3. Look for readability and style issues: oversized functions, awkward control flow, inconsistent naming, unclear docs, formatting or typing slips.
+4. Look for correctness and regression risk: edge cases, missing validation, contract drift, untested behavior.
+
+## How to run the review
+
+1. Inspect the actual diff first. Confirm it matches the task and does not include unrelated cleanup.
+2. Compare against nearby patterns in Backfield and, when relevant, agate-ai-platform.
+3. Prefer actionable findings over broad praise.
+4. If a cleanup is obviously correct and local, propose or make it before PR creation.
+5. If intent is unclear or the cleanup has trade-offs, raise it interactively before proceeding.
+
+## Output expectations
+
+- Present findings ordered by impact.
+- For each finding, explain why it matters and what cleaner shape you recommend.
+- If no findings remain, say that explicitly and mention any residual risks or test gaps.
+
+## Interactive questions
+
+When you need user input, ask focused questions one at a time. Good examples:
+- Should we delete this compatibility path now or keep it for a follow-up?
+- Do you want this helper inlined, or reused by a second caller first?
+- Is this extra abstraction intentional, or can we collapse it into one readable function?

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,3 +85,4 @@ See also `docs/ARCHITECTURE.md` (reference section).
 - Work from a clean working tree when you branch; keep one coherent task per branch and per diff.
 - Prefer short-lived branches and small diffs over stacking unrelated changes.
 - Use `git status` and `git diff` frequently to confirm the task boundary before finishing.
+- Before creating a PR, run a code review and an architecture review using the project skills in `.cursor/skills/`, and address the findings or open questions first.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,7 @@ See also `docs/ARCHITECTURE.md` (reference section).
 
 ## Docs map
 
+- `docs/AGENTIC.md`: orientation for agentic workflows (rules, skills, branch/validation habits); links here and to task checklists.
 - `README.md`: quick start, ports, and top-level layout.
 - `docs/ARCHITECTURE.md`: package boundaries, runtime flow, and dependency direction.
 - `docs/API.md`: Agate API conventions, route responsibilities, and run orchestration.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ If unset, Stylebook geocode accepts unauthenticated requests (dev only).
 - [docs/OPERATIONS.md](docs/OPERATIONS.md) — compose, env vars, and troubleshooting  
 - [docs/TESTING.md](docs/TESTING.md) — testing layers  
 - [docs/AGENT_WORKFLOWS.md](docs/AGENT_WORKFLOWS.md) — task-specific validation guidance  
+- [docs/AGENTIC.md](docs/AGENTIC.md) — agentic workflow orientation (rules, skills, branch/validation habits)  
 - [docs/PLANS.md](docs/PLANS.md) — planning expectations for larger changes  
 
 ## Layout

--- a/docs/AGENTIC.md
+++ b/docs/AGENTIC.md
@@ -12,7 +12,7 @@ This page orients **people and coding assistants** on how work is organized in B
 ## Cursor / IDE conventions
 
 - **Rules:** [`.cursor/rules/`](../.cursor/rules/) — workspace rules (workflow, Python, DB, frontend, docs freshness). Treat them as binding alongside `AGENTS.md`.
-- **Skills:** [`.cursor/skills/`](../.cursor/skills/) — optional playbooks (e.g. DB changes, smoke, doc updates, self-review). Use when the task matches the skill’s description.
+- **Skills:** [`.cursor/skills/`](../.cursor/skills/) — optional playbooks (e.g. DB changes, smoke, doc updates, self-review). Use when the task matches the skill’s description. For **Plan mode** or explicit design stress-tests, see [`grill-me`](../.cursor/skills/grill-me/SKILL.md).
 
 ## Recommended workflow
 

--- a/docs/AGENTIC.md
+++ b/docs/AGENTIC.md
@@ -1,0 +1,31 @@
+# Agentic development (humans and assistants)
+
+This page orients **people and coding assistants** on how work is organized in Backfield: where rules live, how tasks are scoped, and what to run before you finish.
+
+## Start here
+
+1. **[`AGENTS.md`](../AGENTS.md)** — Primary guide: repo map, commands, style, validation defaults, and Git workflow (including **fresh branch when you begin implementation** unless told otherwise).
+2. **[`docs/AGENT_WORKFLOWS.md`](AGENT_WORKFLOWS.md)** — Task-type checklists (backend, DB, frontend, runtime, review): what to read and which checks to run.
+3. **[`docs/TESTING.md`](TESTING.md)** — Validation ladder (`make lint`, `make test`, `make smoke`, etc.).
+4. **[`docs/PLANS.md`](PLANS.md)** — When and how to plan multi-step or risky work.
+
+## Cursor / IDE conventions
+
+- **Rules:** [`.cursor/rules/`](../.cursor/rules/) — workspace rules (workflow, Python, DB, frontend, docs freshness). Treat them as binding alongside `AGENTS.md`.
+- **Skills:** [`.cursor/skills/`](../.cursor/skills/) — optional playbooks (e.g. DB changes, smoke, doc updates, self-review). Use when the task matches the skill’s description.
+
+## Recommended workflow
+
+1. **Branch:** When you start writing code, use a **fresh branch** from the task base (usually `main`) unless the instructions say to continue on an existing branch. One coherent task per branch and per PR.
+2. **Read first:** Open the source-of-truth doc for the area you touch (`docs/ARCHITECTURE.md`, `docs/DATABASE.md`, `docs/API.md`, etc.).
+3. **Implement:** Prefer surgical diffs; match existing patterns; update docs when behavior or operations change.
+4. **Validate:** Follow [`docs/TESTING.md`](TESTING.md) and [`AGENTS.md`](../AGENTS.md) → **Validation defaults**.
+
+## Reference implementation
+
+For parity with the legacy stack, consult **agate-ai-platform** as described in [`AGENTS.md`](../AGENTS.md) → **Reference implementation**.
+
+## See also
+
+- [`docs/OPERATIONS.md`](OPERATIONS.md) — Compose, env vars, local bootstrap.
+- [`README.md`](../README.md) — Quick start and ports.

--- a/docs/AGENTIC.md
+++ b/docs/AGENTIC.md
@@ -12,7 +12,7 @@ This page orients **people and coding assistants** on how work is organized in B
 ## Cursor / IDE conventions
 
 - **Rules:** [`.cursor/rules/`](../.cursor/rules/) — workspace rules (workflow, Python, DB, frontend, docs freshness). Treat them as binding alongside `AGENTS.md`.
-- **Skills:** [`.cursor/skills/`](../.cursor/skills/) — optional playbooks (e.g. DB changes, smoke, doc updates, self-review). Use when the task matches the skill’s description. For **Plan mode** or explicit design stress-tests, see [`grill-me`](../.cursor/skills/grill-me/SKILL.md).
+- **Skills:** [`.cursor/skills/`](../.cursor/skills/) — optional playbooks (e.g. DB changes, smoke, doc updates, self-review). Use when the task matches the skill’s description. For **Plan mode** or explicit design stress-tests, see [`grill-me`](../.cursor/skills/grill-me/SKILL.md). Before opening a PR, run [`pre-pr-code-review`](../.cursor/skills/pre-pr-code-review/SKILL.md) and [`pre-pr-architecture-review`](../.cursor/skills/pre-pr-architecture-review/SKILL.md).
 
 ## Recommended workflow
 
@@ -20,6 +20,7 @@ This page orients **people and coding assistants** on how work is organized in B
 2. **Read first:** Open the source-of-truth doc for the area you touch (`docs/ARCHITECTURE.md`, `docs/DATABASE.md`, `docs/API.md`, etc.).
 3. **Implement:** Prefer surgical diffs; match existing patterns; update docs when behavior or operations change.
 4. **Validate:** Follow [`docs/TESTING.md`](TESTING.md) and [`AGENTS.md`](../AGENTS.md) → **Validation defaults**.
+5. **Pre-PR review:** Run both [`pre-pr-code-review`](../.cursor/skills/pre-pr-code-review/SKILL.md) and [`pre-pr-architecture-review`](../.cursor/skills/pre-pr-architecture-review/SKILL.md) before creating a PR; address findings or questions interactively first.
 
 ## Reference implementation
 

--- a/docs/AGENT_WORKFLOWS.md
+++ b/docs/AGENT_WORKFLOWS.md
@@ -50,7 +50,9 @@ Backfield is a refactor of **agate-ai-platform** (`/Users/cjdd3b/apps/agate-ai-p
 
 ## Review workflow
 
+- Before creating a PR, run both [`pre-pr-code-review`](../.cursor/skills/pre-pr-code-review/SKILL.md) and [`pre-pr-architecture-review`](../.cursor/skills/pre-pr-architecture-review/SKILL.md).
 - Confirm the diff is scoped to the task.
 - Check docs when behavior changed.
 - Check tests and smoke coverage for meaningful runtime changes.
 - Flag oversized functions, unclear naming, or mismatched cross-layer contracts.
+- Raise cleanup or architecture concerns interactively before proceeding to PR creation.

--- a/docs/AGENT_WORKFLOWS.md
+++ b/docs/AGENT_WORKFLOWS.md
@@ -2,6 +2,8 @@
 
 Use this file to decide what to read and which checks to run for common task types.
 
+For a short overview of how agentic work is organized in this repo (entry points, Cursor rules/skills, branch habits), see [`docs/AGENTIC.md`](AGENTIC.md).
+
 ## agate-ai-platform parity
 
 Backfield is a refactor of **agate-ai-platform** (`/Users/cjdd3b/apps/agate-ai-platform` on this machine, or your local clone). For non-trivial features and fixes, **open the corresponding files there** and aim for **maximum fidelity** when copying or adapting. See `AGENTS.md` → **Reference implementation**.


### PR DESCRIPTION
## Summary

- add  as the agentic workflow hub and cross-link it from the main docs
- add project skills for planning stress-tests plus pre-PR code and architecture review
- document branch-first implementation and the pre-PR review checkpoint in agent workflow guidance

## Validation

- docs-only changes; no runtime validation required

Made with [Cursor](https://cursor.com)