### PR TITLE
Order core-api and worker after agate-api migrations

### DIFF
--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -15,6 +15,8 @@ Primary local services are defined in `infra/docker-compose.yml`:
 
 `agate-ui` is ordered **after** `core-api` and `agate-api` report **healthy** (HTTP `/health` checks) so the Vite dev proxy does not hit `ECONNREFUSED` while Uvicorn is still binding (notably when `agate-api` uses the reload worker).
 
+`core-api` and the **`worker`** likewise wait until **`agate-api` is healthy** so its entrypoint has finished **`alembic upgrade head`** (and optional `BACKFIELD_LOCAL_BOOTSTRAP`) before those services touch the database. Otherwise `core-api` can log *Env bootstrap skipped: identity tables missing* on a cold volume because Postgres was ready while migrations had not run yet.
+
 ## Canonical commands
 
 - `make up`: bring up the local stack in the foreground.

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -68,6 +68,9 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      # Alembic runs in agate-api's entrypoint before uvicorn; core-api env bootstrap needs identity tables.
+      agate-api:
+        condition: service_healthy
 
   agate-api:
     build:
@@ -130,7 +133,7 @@ services:
       stylebook-api:
         condition: service_started
       agate-api:
-        condition: service_started
+        condition: service_healthy
 
   agate-ui:
     build:


### PR DESCRIPTION
Fixes a cold-start race: `core-api` only waited for Postgres while Alembic runs in `agate-api`'s entrypoint, so env admin bootstrap could log *identity tables missing* before schema existed.

- `core-api` now `depends_on` `agate-api` with `service_healthy`.
- `worker` uses `service_healthy` for `agate-api` instead of `service_started`.
- Document the ordering in `docs/OPERATIONS.md`.

Made with [Cursor](https://cursor.com)