### PR TITLE
feat: Stylebook location canonical UUID + PRD workflow skills

### DIFF
--- a/.cursor/skills/issues-to-tasks/SKILL.md
+++ b/.cursor/skills/issues-to-tasks/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: issues-to-tasks
+description: >-
+  Breaks a single vertical-slice issue into concrete, ordered, AI-executable
+  tasks. Saves one task.md per task under prd/<slug>/issues/<issue-dir>/tasks/
+  in the gitignored prd/ tree. Use when the user wants to implement an issue,
+  start work on a ticket, or break down an issue into smaller steps.
+---
+
+# Issues to Tasks
+
+Break a **single** vertical-slice issue into concrete, ordered tasks that can each be completed in one focused AI session.
+
+## Output location
+
+Tasks live **under the issue directory**, each task in its **own subdirectory** with a markdown file (parallel to how each issue has **`issues/<issue-dir>/issue.md`**):
+
+**`prd/<slug>/issues/<issue-dir>/tasks/<task-dir>/task.md`**
+
+- **`<slug>`** and **`<issue-dir>`** match the layout from [`prd-to-issues`](../prd-to-issues/SKILL.md) (e.g. `prd/make-map-interface/issues/02-draw-pins/`).
+- **`<task-dir>`** is **`MM-kebab-short-title`** where **`MM`** is zero-padded order (`01`, `02`, …) and **`kebab-short-title`** summarizes the task.
+- Each task is exactly **`task.md`** inside its **`tasks/<task-dir>/`** folder.
+
+Create `prd/<slug>/issues/<issue-dir>/tasks/` and each task subdirectory when saving.
+
+Do not write tasks outside this layout unless the user explicitly directs a one-off exception.
+
+## When to apply
+
+- The user wants to **implement an issue**, **start work on a ticket**, or **break an issue into smaller steps**.
+- The issue is typically **`prd/<slug>/issues/<issue-dir>/issue.md`** from **prd-to-issues**.
+
+## Process
+
+### 1. Locate the issue
+
+Ask the user which issue to decompose: path to **`prd/<slug>/issues/<issue-dir>/issue.md`**, or **`slug` + `issue-dir`**, or enough context (URL, pasted header) to identify it.
+
+Read that **`issue.md`**.
+
+Infer the PRD path **`prd/<slug>/prd.md`** (parent of `issues/` is `prd/<slug>/`). Read the PRD for context. Do **not** edit the PRD.
+
+If **`issue.md`** still has a **Parent PRD** field pointing at **`../../prd.md`**, treat that as confirmation of layout.
+
+### 2. Explore the codebase
+
+Explore the parts of the codebase this issue touches. Focus on:
+
+- Files and modules that will be created or modified
+- Existing patterns to follow (naming, error handling, test layout)
+- Interfaces or contracts this issue must respect
+
+### 3. Draft the task list
+
+Break the issue into **ordered** tasks. Each task must:
+
+- Be completable in a **single AI session** (one focused prompt exchange)
+- Have a **clear, verifiable output** (a file, a passing test, a working endpoint)
+- Respect **dependency order**: schema before logic, logic before API, API before UI; tests **alongside** or **immediately after** each layer
+
+Label each task with its **type**:
+
+- **WRITE**: create or modify production code
+- **TEST**: write or update tests
+- **MIGRATE**: schema or data migration
+- **CONFIG**: environment, tooling, or infrastructure change
+- **REVIEW**: human decision required before proceeding
+
+Prefer **WRITE** and **TEST** tasks **interleaved** over a block of WRITE then a block of TEST.
+
+### 4. Quiz the user
+
+Present the proposed task list as a **numbered list**. For each task show:
+
+- **Title**: short imperative description (e.g. “Add `user_id` column to `sessions` table”)
+- **Proposed directory**: `tasks/<MM-kebab-short-title>/`
+- **Type**: WRITE / TEST / MIGRATE / CONFIG / REVIEW
+- **Output**: what exists or passes when this task is done
+- **Depends on**: task numbers that must complete first
+
+Ask the user:
+
+- Does the **order** feel right?
+- Are any tasks **too large** for one session?
+- Are any tasks **too small** and should be merged?
+- Are all **REVIEW** tasks correctly identified?
+
+Iterate until the user **approves** the list.
+
+### 5. Write the task files
+
+For each approved task, write **`prd/<slug>/issues/<issue-dir>/tasks/<task-dir>/task.md`** using the template below. **Number tasks** sequentially; use those numbers in **Depends on** (reference sibling task numbers; optionally add sibling **`task-dir`** names for clarity).
+
+**Do not** modify **`issue.md`** or **`prd.md`**.
+
+## Task file template
+
+Each **`task.md`** describes **one** task:
+
+```markdown
+# Task <n>: <Task title>
+
+**Parent issue**: `../../issue.md` (Issue <issue-number>: <short issue title>)
+**Parent PRD**: `../../../prd.md`
+**Type**: WRITE / TEST / MIGRATE / CONFIG / REVIEW
+**Output**: <what exists or passes when done>
+**Depends on**: Task <m> / none
+
+<A short paragraph describing exactly what to do. Written as an instruction to the AI that will execute it. Include: which files to touch, which pattern to follow, which existing code to use as reference. Do NOT include code snippets — describe intent, not implementation.>
+```
+
+## Out of scope for this skill
+
+- Editing **`issue.md`** or **`prd.md`** — read-only.
+- Executing tasks (implementation is separate work).

--- a/.cursor/skills/prd-to-issues/SKILL.md
+++ b/.cursor/skills/prd-to-issues/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: prd-to-issues
+description: >-
+  Breaks a PRD into independently-grabbable issues using tracer-bullet vertical
+  slices. Writes one issue.md per slice under prd/<slug>/issues/<dir>/ within
+  the gitignored prd/ tree. Use when the user wants to convert a PRD to issues,
+  create implementation tickets, or break down a PRD into work items.
+---
+
+# PRD to Issues
+
+Break a PRD into independently-grabbable issues using **vertical slices** (tracer bullets).
+
+## Output location
+
+Issues live **under the same initiative directory as the PRD**:
+
+**`prd/<slug>/issues/<issue-dir>/issue.md`**
+
+- `<slug>` matches the PRD folder (PRD file is **`prd/<slug>/prd.md`** — see [`write-a-prd`](../write-a-prd/SKILL.md)).
+- **`<issue-dir>`** is one directory per vertical slice, named **`NN-kebab-short-title`** where **`NN`** is a zero-padded sequence number (`01`, `02`, …) for stable ordering and **`kebab-short-title`** summarizes the slice (e.g. `01-map-shell`, `02-draw-pins`).
+- Each slice is exactly **`issue.md`** inside its directory (not one combined issues file).
+
+Create `prd/<slug>/issues/` and each `prd/<slug>/issues/<issue-dir>/` when writing.
+
+Do not write issues outside this layout unless the user explicitly directs a one-off exception.
+
+## When to apply
+
+- The user wants to **convert a PRD to issues**, **create implementation tickets**, or **break a PRD into work items**.
+- The PRD is often **`prd/<slug>/prd.md`**; it may live elsewhere if the user points to another path (still mirror the **`issues/<issue-dir>/issue.md`** pattern under that PRD’s parent when possible).
+
+## Process
+
+### 1. Locate the PRD
+
+Ask the user for the **PRD file** path (read it; do not edit it). Default: **`prd/<slug>/prd.md`**.
+
+Confirm **`<slug>`** (the parent directory name of `prd.md`) so issue paths stay consistent.
+
+### 2. Explore the codebase (optional)
+
+If the codebase has not already been explored for this workstream, explore it to understand the current implementation. Focus on modules called out in the PRD’s **Module Design** section.
+
+### 3. Draft vertical slices
+
+Break the PRD into **tracer bullet** issues. Each issue is a **thin vertical slice** that cuts through **all** relevant integration layers end-to-end — for example schema, logic, API, UI, and tests — not a horizontal slice of a single layer.
+
+Slices may be **HITL** or **AFK**:
+
+- **HITL** (Human In The Loop): requires a human decision or review during implementation — e.g. architectural choice, design review, or approval of a schema migration.
+- **AFK** (Away From Keyboard): can be implemented and merged without that human gate.
+
+Prefer **AFK** over **HITL** wherever possible.
+
+**Vertical slice rules**
+
+- Each slice delivers a narrow but **complete** path through every relevant layer.
+- A completed slice is **demoable** or **independently verifiable**.
+- Prefer **many thin** slices over few thick ones.
+- Slices that **cannot** be verified on their own are too coarse.
+
+### 4. Quiz the user
+
+Present the proposed breakdown as a **numbered list**. For each slice show:
+
+- **Title**: short descriptive name
+- **Proposed directory**: `issues/<NN-kebab-short-title>/`
+- **Type**: HITL / AFK
+- **Blocked by**: which other slices (by **issue number** or **`NN`** / directory name) must complete first
+- **User stories covered**: which **numbered** user stories from the PRD this addresses
+
+Ask the user:
+
+- Does the granularity feel right? (too coarse / too fine)
+- Are the dependency relationships correct?
+- Should any slices be merged or split further?
+- Are all HITL slices correctly identified?
+
+**Heuristic:** Flag any slice that addresses **more than 2–3** user stories or would likely take **more than half a day** — it is probably too coarse; propose a split.
+
+Iterate until the user **approves** the breakdown.
+
+### 5. Write the issue files
+
+For each approved slice, write **`prd/<slug>/issues/<issue-dir>/issue.md`** using the template below. **Number issues sequentially** (`# Issue 1:`, `# Issue 2:`, …); use those numbers in **Blocked by** and in cross-references. Order creation follows **dependency order** (blockers first).
+
+**Parent PRD** in each `issue.md`: use the path **`../../prd.md`** (relative from `issues/<issue-dir>/issue.md` up to `prd/<slug>/prd.md`).
+
+**Do not** modify the PRD file.
+
+## Issue file template
+
+Each `issue.md` uses this structure (one file per vertical slice):
+
+```markdown
+# Issue <n>: <title>
+
+**Type**: HITL / AFK
+**Blocked by**: Issue <m> / None — can start immediately
+
+### Parent PRD
+
+`../../prd.md`
+
+### What to build
+
+A concise description of this vertical slice. Describe the end-to-end behaviour, not layer-by-layer implementation steps. Reference sections of the PRD rather than duplicating content.
+
+### How to verify
+
+Exactly how a developer (or the AI implementing this) confirms the slice is complete:
+
+- **Manual**: step-by-step instructions to demo it
+- **Automated**: what the test asserts
+
+### Acceptance criteria
+
+- [ ] Given <context>, when <action>, then <outcome>
+- [ ] Given <failure condition>, then <expected behaviour>
+
+### User stories addressed
+
+- User story <n>: <short title>
+- User story <n>: <short title>
+```
+
+## Out of scope for this skill
+
+- Changing or “fixing” the PRD — read-only for the PRD path the user gave.
+- Executing the issues (implementation belongs in normal dev workflow).

--- a/.cursor/skills/write-a-prd/SKILL.md
+++ b/.cursor/skills/write-a-prd/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: write-a-prd
+description: >-
+  Creates a PRD through user interview, codebase exploration, and module design,
+  then saves it under prd/<slug>/prd.md at the repo root (gitignored). Use when
+  the user wants to write a PRD, create a product requirements document, or plan
+  a new feature.
+---
+
+# Write a PRD
+
+Turn a free-form description of a problem into a structured PRD file through codebase exploration and a thorough user interview.
+
+## Output location
+
+Each initiative lives in its **own directory** under **`prd/`** at the **repository root** (same level as `Makefile` / `AGENTS.md`):
+
+**`prd/<slug>/prd.md`**
+
+- `<slug>` is a **kebab-case** directory name (e.g. `make-map-interface`).
+- The **`prd/`** tree is **gitignored** so local PRDs stay out of version control.
+- Create `prd/<slug>/` when saving if it does not exist.
+
+Downstream work (**prd-to-issues**, **issues-to-tasks**) uses **`prd/<slug>/issues/…`** and per-issue **`tasks/…`** under the same slug — see those skills.
+
+Do not save under a different root layout unless the user explicitly directs a one-off exception for that session.
+
+## When to apply
+
+- The user wants a **PRD**, **product requirements document**, or structured **feature plan** before implementation.
+- The goal is a **saved artifact** at `prd/<slug>/prd.md` (usually Markdown), not just chat notes.
+
+## Process
+
+### 1. Collect the plan
+
+Ask the user for a long, detailed description of the problem they want to solve and any initial ideas for solutions. There is no required format — a brain dump is fine. The goal is to understand their thinking before touching the codebase.
+
+Also ask for the **slug**: the directory name **`prd/<slug>/`** (kebab-case, stable, URL-safe). Confirm the PRD file will be **`prd/<slug>/prd.md`** (format is almost always Markdown).
+
+### 2. Explore the codebase
+
+**Before** the deep interview pass, explore the repo to verify assertions and understand current implementation. Look for:
+
+- Modules and files that will be affected by this change
+- Existing patterns, conventions, and abstractions to follow or build on
+- Anything that contradicts or complicates the user's description of the current state
+
+Use `AGENTS.md`, `docs/`, and code search as needed. For Backfield, treat **agate-ai-platform** as the reference implementation when parity matters (see `AGENTS.md`).
+
+### 3. Interview the user
+
+Interview the user about every aspect of the plan until there is a **shared, unambiguous** understanding. Walk down each branch of the design tree; resolve dependencies between decisions **one by one**.
+
+- Do **not** move to the next branch until the current one is resolved.
+- Do **not** accept vague answers — if the user says "it depends", ask what it depends on and resolve **each** case.
+
+Cover at minimum:
+
+- Every **actor** who interacts with the feature and what they need
+- Every **failure mode** and what the correct behaviour is
+- Every **edge case** that the user stories imply
+- Every **integration** with existing modules or external systems
+- Any decisions that would be **difficult or expensive to reverse**
+
+### 4. Design the modules
+
+Sketch the major modules to be built or modified. Actively look for **deep modules** — significant functionality behind a simple, stable, testable interface (the opposite of shallow, leaky abstractions). Prefer **fewer, deeper** modules over many thin ones.
+
+For each module, confirm with the user:
+
+- Does this match their expectations?
+- Should tests be written for this module?
+- Which parts of its interface are likely to change, and which are stable?
+
+### 5. Write the PRD
+
+Once there is a complete shared understanding, write the PRD using the template below and **save it** to **`prd/<slug>/prd.md`** (create `prd/<slug>/` if needed).
+
+## PRD output template
+
+Use this structure for the saved document (replace placeholders; omit empty sections only if truly N/A):
+
+```markdown
+# PRD: <feature name>
+
+## Problem Statement
+
+The problem the user is facing, from the user's perspective. Not a technical description — describe the gap between what exists and what is needed.
+
+## Solution
+
+The solution to the problem, from the user's perspective. Not an implementation plan — describe what will be true when the feature is complete.
+
+## User Stories
+
+A long, numbered list of user stories covering all aspects of the feature. Each story follows the format:
+
+> As a `<actor>`, I want `<feature>`, so that `<benefit>`.
+
+Be exhaustive. Include stories for error states, edge cases, and secondary actors. A story that implies a behaviour should have a corresponding story for the failure case.
+
+## Implementation Decisions
+
+Decisions made during the interview that constrain or shape the implementation. Include:
+
+- Modules to be built or modified
+- Interfaces of those modules
+- Architectural decisions and their rationale
+- Schema changes
+- API contracts
+- Specific interaction patterns
+
+Do NOT include file paths or code snippets — these become outdated quickly.
+
+## Module Design
+
+For each module identified in step 4:
+
+- **Name**: what to call it
+- **Responsibility**: the single thing it owns
+- **Interface**: what callers need to know (inputs, outputs, failure modes)
+- **Tested**: yes / no
+
+## Testing Decisions
+
+- What makes a good test for this feature (test external behaviour, not implementation details)
+- Which modules will have tests written
+- Prior art in the codebase — similar tests to use as reference
+
+## Out of Scope
+
+Explicit list of things that will not be addressed in this PRD. Be specific — vague out-of-scope items create ambiguity later.
+
+## Open Questions
+
+Any unresolved questions that could not be answered during the interview. Each question should have an owner and a suggested resolution path.
+
+## Further Notes
+
+Any context, constraints, or decisions that do not fit the above sections.
+```
+
+## Out of scope for this skill
+
+- This skill produces **`prd/<slug>/prd.md`**, not production code or migrations.
+- It does **not** replace `docs/PLANS.md` for large refactors unless the user explicitly wants the PRD to live there or to align with it.

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Local PRD / issues / tasks trees (see .cursor/skills/write-a-prd, prd-to-issues, issues-to-tasks)
+prd/
+
 .venv/
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
## Summary

- Pushes `feat/stylebook-location-canonical-uuid` to remote.
- Draft PR against `main`.

Includes PRD workflow Cursor skills (`write-a-prd`, `prd-to-issues`, `issues-to-tasks`) and `.gitignore` for the local `prd/` tree, plus any Stylebook canonical UUID work already on this branch.

## Checklist

- [ ] Review scope vs branch name
- [ ] Run CI / validation as needed before undrafting

Made with [Cursor](https://cursor.com)