### PR TITLE
Leaflet map layers + header polish

### DIFF
--- a/apps/agate-ui/src/nodes/geocode_agent/VisualizationComponent.tsx
+++ b/apps/agate-ui/src/nodes/geocode_agent/VisualizationComponent.tsx
@@ -40,11 +40,10 @@ const nodeMetadata = {
   }
 };
 
-import React from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
 import { LeafletMap, LayerFilterPopover, layersFromFeatures, defaultVisibility } from '@backfield/ui'
 import type { MapPointFeature, MapBoundingBoxFeature, VisualizationProps, VisualizationDescriptor } from '@/lib/visualizations'
-import { useEffect, useMemo, useState } from 'react'
 
 /**
  * Build visualization descriptor for GeocodeAgent node output.
@@ -303,53 +302,53 @@ export function buildVisualization(
     return null
   }
 
-  function pointsToGeoJSON(features: MapPointFeature[]) {
-    return {
-      type: 'FeatureCollection' as const,
-      features: features.map((p) => ({
-        type: 'Feature' as const,
-        properties: {
-          id: p.id,
-          label: p.label ?? '',
-          description: p.description ?? '',
-          group: p.group ?? 'points',
-        },
-        geometry: { type: 'Point' as const, coordinates: p.coordinates },
-      })),
-    }
-  }
-
-  function polygonsToGeoJSON(features: MapBoundingBoxFeature[]) {
-    const ringFromBbox = (bbox: [number, number, number, number]) => {
-      const [w, s, e, n] = bbox
-      return [
-        [w, s],
-        [e, s],
-        [e, n],
-        [w, n],
-        [w, s],
-      ] as [number, number][]
-    }
-    return {
-      type: 'FeatureCollection' as const,
-      features: features.map((p) => ({
-        type: 'Feature' as const,
-        properties: {
-          id: p.id,
-          label: p.label ?? '',
-          description: p.description ?? '',
-          group: p.group ?? 'areas',
-        },
-        geometry: (p.geometry
-          ? p.geometry
-          : { type: 'Polygon' as const, coordinates: [ringFromBbox(p.bbox)] }) as any,
-      })),
-    }
-  }
-
   // Visualization component
   const GeocodeVisualization: React.FC<VisualizationProps> = ({ data }) => {
     if (!data) return null
+
+    function pointsToGeoJSON(features: MapPointFeature[]) {
+      return {
+        type: 'FeatureCollection' as const,
+        features: features.map((p) => ({
+          type: 'Feature' as const,
+          properties: {
+            id: p.id,
+            label: p.label ?? '',
+            description: p.description ?? '',
+            group: p.group ?? 'points',
+          },
+          geometry: { type: 'Point' as const, coordinates: p.coordinates },
+        })),
+      }
+    }
+
+    function polygonsToGeoJSON(features: MapBoundingBoxFeature[]) {
+      const ringFromBbox = (bbox: [number, number, number, number]) => {
+        const [w, s, e, n] = bbox
+        return [
+          [w, s],
+          [e, s],
+          [e, n],
+          [w, n],
+          [w, s],
+        ] as [number, number][]
+      }
+      return {
+        type: 'FeatureCollection' as const,
+        features: features.map((p) => ({
+          type: 'Feature' as const,
+          properties: {
+            id: p.id,
+            label: p.label ?? '',
+            description: p.description ?? '',
+            group: p.group ?? 'areas',
+          },
+          geometry: (p.geometry
+            ? p.geometry
+            : { type: 'Polygon' as const, coordinates: [ringFromBbox(p.bbox)] }) as any,
+        })),
+      }
+    }
 
     const layers = useMemo(() => {
       return layersFromFeatures([
@@ -361,7 +360,6 @@ export function buildVisualization(
     const [visibility, setVisibility] = useState(() => defaultVisibility(layers))
     useEffect(() => {
       setVisibility((prev) => {
-        // Merge: keep existing toggles, default new layers to visible
         const next = { ...prev }
         for (const layer of layers) {
           if (!(layer.id in next)) next[layer.id] = true
@@ -389,7 +387,10 @@ export function buildVisualization(
         <CardContent>
           <div className="space-y-3">
             <LayerFilterPopover layers={layers} visibility={visibility} onChange={setVisibility} />
-            <LeafletMap points={pointsToGeoJSON(filteredPoints) as any} polygons={polygonsToGeoJSON(filteredPolygons) as any} />
+            <LeafletMap
+              points={pointsToGeoJSON(filteredPoints) as any}
+              polygons={polygonsToGeoJSON(filteredPolygons) as any}
+            />
           </div>
         </CardContent>
       </Card>

--- a/apps/agate-ui/src/nodes/geocode_agent/VisualizationComponent.tsx
+++ b/apps/agate-ui/src/nodes/geocode_agent/VisualizationComponent.tsx
@@ -42,9 +42,9 @@ const nodeMetadata = {
 
 import React from 'react'
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
-import { Alert, AlertDescription } from '@/components/ui/alert'
-import MapboxMap from '@/components/visualizations/MapboxMap'
+import { LeafletMap, LayerFilterPopover, layersFromFeatures, defaultVisibility } from '@backfield/ui'
 import type { MapPointFeature, MapBoundingBoxFeature, VisualizationProps, VisualizationDescriptor } from '@/lib/visualizations'
+import { useEffect, useMemo, useState } from 'react'
 
 /**
  * Build visualization descriptor for GeocodeAgent node output.
@@ -303,10 +303,81 @@ export function buildVisualization(
     return null
   }
 
+  function pointsToGeoJSON(features: MapPointFeature[]) {
+    return {
+      type: 'FeatureCollection' as const,
+      features: features.map((p) => ({
+        type: 'Feature' as const,
+        properties: {
+          id: p.id,
+          label: p.label ?? '',
+          description: p.description ?? '',
+          group: p.group ?? 'points',
+        },
+        geometry: { type: 'Point' as const, coordinates: p.coordinates },
+      })),
+    }
+  }
+
+  function polygonsToGeoJSON(features: MapBoundingBoxFeature[]) {
+    const ringFromBbox = (bbox: [number, number, number, number]) => {
+      const [w, s, e, n] = bbox
+      return [
+        [w, s],
+        [e, s],
+        [e, n],
+        [w, n],
+        [w, s],
+      ] as [number, number][]
+    }
+    return {
+      type: 'FeatureCollection' as const,
+      features: features.map((p) => ({
+        type: 'Feature' as const,
+        properties: {
+          id: p.id,
+          label: p.label ?? '',
+          description: p.description ?? '',
+          group: p.group ?? 'areas',
+        },
+        geometry: (p.geometry
+          ? p.geometry
+          : { type: 'Polygon' as const, coordinates: [ringFromBbox(p.bbox)] }) as any,
+      })),
+    }
+  }
+
   // Visualization component
-  const GeocodeVisualization: React.FC<VisualizationProps> = ({ mapboxToken, data }) => {
+  const GeocodeVisualization: React.FC<VisualizationProps> = ({ data }) => {
     if (!data) return null
-    
+
+    const layers = useMemo(() => {
+      return layersFromFeatures([
+        ...data.points.map((p) => ({ group: p.group ?? 'points' })),
+        ...data.polygons.map((p) => ({ group: p.group ?? 'areas' })),
+      ])
+    }, [data.points, data.polygons])
+
+    const [visibility, setVisibility] = useState(() => defaultVisibility(layers))
+    useEffect(() => {
+      setVisibility((prev) => {
+        // Merge: keep existing toggles, default new layers to visible
+        const next = { ...prev }
+        for (const layer of layers) {
+          if (!(layer.id in next)) next[layer.id] = true
+        }
+        return next
+      })
+    }, [layers])
+
+    const filteredPoints = useMemo(() => {
+      return data.points.filter((p) => visibility[p.group ?? 'points'] ?? true)
+    }, [data.points, visibility])
+
+    const filteredPolygons = useMemo(() => {
+      return data.polygons.filter((p) => visibility[p.group ?? 'areas'] ?? true)
+    }, [data.polygons, visibility])
+
     return (
       <Card>
         <CardHeader>
@@ -316,19 +387,10 @@ export function buildVisualization(
           )}
         </CardHeader>
         <CardContent>
-          {mapboxToken ? (
-            <MapboxMap
-              accessToken={mapboxToken}
-              points={data.points}
-              polygons={data.polygons}
-            />
-          ) : (
-            <Alert>
-              <AlertDescription>
-                A Mapbox API token is required to view this map. Add a <code>MAPBOX_API_TOKEN</code> in the project settings to enable map visualizations.
-              </AlertDescription>
-            </Alert>
-          )}
+          <div className="space-y-3">
+            <LayerFilterPopover layers={layers} visibility={visibility} onChange={setVisibility} />
+            <LeafletMap points={pointsToGeoJSON(filteredPoints) as any} polygons={polygonsToGeoJSON(filteredPolygons) as any} />
+          </div>
         </CardContent>
       </Card>
     )
@@ -340,7 +402,7 @@ export function buildVisualization(
     title: 'Locations',
     description: nodeLabel !== nodeId ? nodeLabel : undefined,
     component: GeocodeVisualization,
-    requiresMapboxToken: true,
+    requiresMapboxToken: false,
     data: {
       points,
       polygons,

--- a/apps/agate-ui/src/nodes/geocode_agent/VisualizationComponent.tsx
+++ b/apps/agate-ui/src/nodes/geocode_agent/VisualizationComponent.tsx
@@ -302,6 +302,9 @@ export function buildVisualization(
     return null
   }
 
+  const displayNodeLabel =
+    nodeLabel !== nodeId ? nodeLabel.replace(/\s*\(n\d+\)\s*$/, '') : null
+
   // Visualization component
   const GeocodeVisualization: React.FC<VisualizationProps> = ({ data }) => {
     if (!data) return null
@@ -378,20 +381,26 @@ export function buildVisualization(
 
     return (
       <Card>
-        <CardHeader>
-          <CardTitle>Locations</CardTitle>
-          {nodeLabel !== nodeId && (
-            <CardDescription>{nodeLabel}</CardDescription>
-          )}
+        <CardHeader className="flex flex-row items-center justify-between gap-3 space-y-0">
+          <CardTitle className="flex items-baseline gap-3">
+            <span>Locations</span>
+            {displayNodeLabel && (
+              <span className="text-sm font-normal text-muted-foreground">{displayNodeLabel}</span>
+            )}
+          </CardTitle>
+
+          <LayerFilterPopover
+            layers={layers}
+            visibility={visibility}
+            onChange={setVisibility}
+            buttonLabel="Layers"
+          />
         </CardHeader>
         <CardContent>
-          <div className="space-y-3">
-            <LayerFilterPopover layers={layers} visibility={visibility} onChange={setVisibility} />
-            <LeafletMap
-              points={pointsToGeoJSON(filteredPoints) as any}
-              polygons={polygonsToGeoJSON(filteredPolygons) as any}
-            />
-          </div>
+          <LeafletMap
+            points={pointsToGeoJSON(filteredPoints) as any}
+            polygons={polygonsToGeoJSON(filteredPolygons) as any}
+          />
         </CardContent>
       </Card>
     )

--- a/packages/backfield-core/src/backfield_core/nodes/geocode_agent/ui/VisualizationComponent.tsx
+++ b/packages/backfield-core/src/backfield_core/nodes/geocode_agent/ui/VisualizationComponent.tsx
@@ -260,6 +260,9 @@ export function buildVisualization(
     return null
   }
 
+  const displayNodeLabel =
+    nodeLabel !== nodeId ? nodeLabel.replace(/\s*\(n\d+\)\s*$/, '') : null
+
   // Visualization component
   const GeocodeVisualization: React.FC<VisualizationProps> = ({ data }) => {
     if (!data) return null
@@ -336,20 +339,26 @@ export function buildVisualization(
 
     return (
       <Card>
-        <CardHeader>
-          <CardTitle>Locations</CardTitle>
-          {nodeLabel !== nodeId && (
-            <CardDescription>{nodeLabel}</CardDescription>
-          )}
+        <CardHeader className="flex flex-row items-center justify-between gap-3 space-y-0">
+          <CardTitle className="flex items-baseline gap-3">
+            <span>Locations</span>
+            {displayNodeLabel && (
+              <span className="text-sm font-normal text-muted-foreground">{displayNodeLabel}</span>
+            )}
+          </CardTitle>
+
+          <LayerFilterPopover
+            layers={layers}
+            visibility={visibility}
+            onChange={setVisibility}
+            buttonLabel="Layers"
+          />
         </CardHeader>
         <CardContent>
-          <div className="space-y-3">
-            <LayerFilterPopover layers={layers} visibility={visibility} onChange={setVisibility} />
-            <LeafletMap
-              points={pointsToGeoJSON(filteredPoints) as any}
-              polygons={polygonsToGeoJSON(filteredPolygons) as any}
-            />
-          </div>
+          <LeafletMap
+            points={pointsToGeoJSON(filteredPoints) as any}
+            polygons={polygonsToGeoJSON(filteredPolygons) as any}
+          />
         </CardContent>
       </Card>
     )

--- a/packages/backfield-core/src/backfield_core/nodes/geocode_agent/ui/VisualizationComponent.tsx
+++ b/packages/backfield-core/src/backfield_core/nodes/geocode_agent/ui/VisualizationComponent.tsx
@@ -1,7 +1,6 @@
-import React from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
-import { Alert, AlertDescription } from '@/components/ui/alert'
-import MapboxMap from '@/components/visualizations/MapboxMap'
+import { LeafletMap, LayerFilterPopover, layersFromFeatures, defaultVisibility } from '@backfield/ui'
 import type { MapPointFeature, MapBoundingBoxFeature, VisualizationProps, VisualizationDescriptor } from '@/lib/visualizations'
 
 /**
@@ -262,9 +261,79 @@ export function buildVisualization(
   }
 
   // Visualization component
-  const GeocodeVisualization: React.FC<VisualizationProps> = ({ mapboxToken, data }) => {
+  const GeocodeVisualization: React.FC<VisualizationProps> = ({ data }) => {
     if (!data) return null
-    
+
+    function pointsToGeoJSON(features: MapPointFeature[]) {
+      return {
+        type: 'FeatureCollection' as const,
+        features: features.map((p) => ({
+          type: 'Feature' as const,
+          properties: {
+            id: p.id,
+            label: p.label ?? '',
+            description: p.description ?? '',
+            group: p.group ?? 'points',
+          },
+          geometry: { type: 'Point' as const, coordinates: p.coordinates },
+        })),
+      }
+    }
+
+    function polygonsToGeoJSON(features: MapBoundingBoxFeature[]) {
+      const ringFromBbox = (bbox: [number, number, number, number]) => {
+        const [w, s, e, n] = bbox
+        return [
+          [w, s],
+          [e, s],
+          [e, n],
+          [w, n],
+          [w, s],
+        ] as [number, number][]
+      }
+      return {
+        type: 'FeatureCollection' as const,
+        features: features.map((p) => ({
+          type: 'Feature' as const,
+          properties: {
+            id: p.id,
+            label: p.label ?? '',
+            description: p.description ?? '',
+            group: p.group ?? 'areas',
+          },
+          geometry: (p.geometry
+            ? p.geometry
+            : { type: 'Polygon' as const, coordinates: [ringFromBbox(p.bbox)] }) as any,
+        })),
+      }
+    }
+
+    const layers = useMemo(() => {
+      return layersFromFeatures([
+        ...data.points.map((p) => ({ group: p.group ?? 'points' })),
+        ...data.polygons.map((p) => ({ group: p.group ?? 'areas' })),
+      ])
+    }, [data.points, data.polygons])
+
+    const [visibility, setVisibility] = useState(() => defaultVisibility(layers))
+    useEffect(() => {
+      setVisibility((prev) => {
+        const next = { ...prev }
+        for (const layer of layers) {
+          if (!(layer.id in next)) next[layer.id] = true
+        }
+        return next
+      })
+    }, [layers])
+
+    const filteredPoints = useMemo(() => {
+      return data.points.filter((p) => visibility[p.group ?? 'points'] ?? true)
+    }, [data.points, visibility])
+
+    const filteredPolygons = useMemo(() => {
+      return data.polygons.filter((p) => visibility[p.group ?? 'areas'] ?? true)
+    }, [data.polygons, visibility])
+
     return (
       <Card>
         <CardHeader>
@@ -274,19 +343,13 @@ export function buildVisualization(
           )}
         </CardHeader>
         <CardContent>
-          {mapboxToken ? (
-            <MapboxMap
-              accessToken={mapboxToken}
-              points={data.points}
-              polygons={data.polygons}
+          <div className="space-y-3">
+            <LayerFilterPopover layers={layers} visibility={visibility} onChange={setVisibility} />
+            <LeafletMap
+              points={pointsToGeoJSON(filteredPoints) as any}
+              polygons={polygonsToGeoJSON(filteredPolygons) as any}
             />
-          ) : (
-            <Alert>
-              <AlertDescription>
-                A Mapbox API token is required to view this map. Add a <code>MAPBOX_API_TOKEN</code> in the project settings to enable map visualizations.
-              </AlertDescription>
-            </Alert>
-          )}
+          </div>
         </CardContent>
       </Card>
     )
@@ -298,7 +361,7 @@ export function buildVisualization(
     title: 'Locations',
     description: nodeLabel !== nodeId ? nodeLabel : undefined,
     component: GeocodeVisualization,
-    requiresMapboxToken: true,
+    requiresMapboxToken: false,
     data: {
       points,
       polygons,

--- a/packages/backfield-ui/src/LayerFilterPopover.tsx
+++ b/packages/backfield-ui/src/LayerFilterPopover.tsx
@@ -1,0 +1,95 @@
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu"
+import { Layers } from "lucide-react"
+import { cn } from "./cn"
+import type { LayerOption, LayerVisibility } from "./layerVisibility"
+import { hideAll, isLayerVisible, showAll, toggleLayer } from "./layerVisibility"
+
+export type LayerFilterPopoverProps = {
+  layers: LayerOption[]
+  visibility: LayerVisibility
+  onChange: (next: LayerVisibility) => void
+  className?: string
+  buttonLabel?: string
+}
+
+export function LayerFilterPopover({
+  layers,
+  visibility,
+  onChange,
+  className,
+  buttonLabel = "Layers",
+}: LayerFilterPopoverProps) {
+  if (layers.length <= 1) return null
+
+  return (
+    <div className={cn("flex items-center justify-end", className)}>
+      <DropdownMenu.Root>
+        <DropdownMenu.Trigger asChild>
+          <button
+            type="button"
+            className={cn(
+              "inline-flex items-center gap-2 rounded-md border border-input bg-background px-3 py-2 text-sm",
+              "hover:bg-accent hover:text-accent-foreground",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+            )}
+          >
+            <Layers className="h-4 w-4" />
+            <span>{buttonLabel}</span>
+          </button>
+        </DropdownMenu.Trigger>
+
+        <DropdownMenu.Portal>
+          <DropdownMenu.Content
+            sideOffset={8}
+            align="end"
+            className={cn(
+              "z-50 min-w-[15rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md",
+            )}
+          >
+            <div className="flex items-center justify-between gap-2 px-2 py-1.5">
+              <div className="text-xs font-medium text-muted-foreground">Visible layers</div>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  className="text-xs text-primary hover:underline"
+                  onClick={() => onChange(showAll(layers))}
+                >
+                  Show all
+                </button>
+                <button
+                  type="button"
+                  className="text-xs text-primary hover:underline"
+                  onClick={() => onChange(hideAll(layers))}
+                >
+                  Hide all
+                </button>
+              </div>
+            </div>
+
+            <DropdownMenu.Separator className="-mx-1 my-1 h-px bg-muted" />
+
+            {layers.map((layer) => (
+              <DropdownMenu.CheckboxItem
+                key={layer.id}
+                className={cn(
+                  "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none",
+                  "transition-colors focus:bg-accent focus:text-accent-foreground",
+                )}
+                checked={isLayerVisible(visibility, layer.id)}
+                onCheckedChange={() => onChange(toggleLayer(visibility, layer.id))}
+              >
+                <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+                  <DropdownMenu.ItemIndicator>
+                    <span className="text-xs">✓</span>
+                  </DropdownMenu.ItemIndicator>
+                </span>
+                <span className="capitalize">{layer.label}</span>
+              </DropdownMenu.CheckboxItem>
+            ))}
+          </DropdownMenu.Content>
+        </DropdownMenu.Portal>
+      </DropdownMenu.Root>
+    </div>
+  )
+}
+

--- a/packages/backfield-ui/src/LayerFilterPopover.tsx
+++ b/packages/backfield-ui/src/LayerFilterPopover.tsx
@@ -43,7 +43,8 @@ export function LayerFilterPopover({
             sideOffset={8}
             align="end"
             className={cn(
-              "z-50 min-w-[15rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md",
+              // Leaflet panes use high z-index values; ensure this renders above the map.
+              "z-[2000] min-w-[15rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md",
             )}
           >
             <div className="flex items-center justify-between gap-2 px-2 py-1.5">

--- a/packages/backfield-ui/src/LeafletMap.tsx
+++ b/packages/backfield-ui/src/LeafletMap.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react"
 import type { ReactNode } from "react"
 import * as L from "leaflet"
-import { CircleMarker, MapContainer, Polygon, TileLayer, useMap } from "react-leaflet"
+import { CircleMarker, MapContainer, Polygon, Popup, TileLayer, useMap } from "react-leaflet"
 import "leaflet/dist/leaflet.css"
 
 type LngLat = [number, number] // [lng, lat]
@@ -29,6 +29,7 @@ type GeoJsonFeatureCollection = {
 export type LeafletMapFeatureClick = {
   featureId: string | null
   feature: GeoJsonFeature
+  latlng: { lat: number; lng: number }
 }
 
 export type LeafletMapProps = {
@@ -150,6 +151,26 @@ function featureIdOf(feature: GeoJsonFeature): string | null {
   return null
 }
 
+function featureLabelOf(feature: GeoJsonFeature): string {
+  const props = (feature.properties ?? {}) as Record<string, unknown>
+  const label = typeof props.label === "string" ? props.label.trim() : ""
+  if (label) return label
+  const id = featureIdOf(feature)
+  return id ?? "Feature"
+}
+
+function featureRoleOf(feature: GeoJsonFeature): string | null {
+  const props = (feature.properties ?? {}) as Record<string, unknown>
+  const role = typeof props.group === "string" ? props.group.trim() : ""
+  return role || null
+}
+
+function featureDescriptionOf(feature: GeoJsonFeature): string | null {
+  const props = (feature.properties ?? {}) as Record<string, unknown>
+  const desc = typeof props.description === "string" ? props.description.trim() : ""
+  return desc || null
+}
+
 export function LeafletMap({
   points,
   polygons,
@@ -163,6 +184,14 @@ export function LeafletMap({
   useEffect(() => {
     clickHandlerRef.current = onFeatureClick
   }, [onFeatureClick])
+
+  const [popup, setPopup] = useState<{
+    latlng: { lat: number; lng: number }
+    title: string
+    role: string | null
+    description: string | null
+    feature: GeoJsonFeature
+  } | null>(null)
 
   const normalizedPoints = useMemo(() => normalizeFeatureCollection(points), [points])
   const normalizedPolygons = useMemo(() => normalizeFeatureCollection(polygons), [polygons])
@@ -226,8 +255,17 @@ export function LeafletMap({
               positions={positions}
               pathOptions={{ color: "#1d4ed8", weight: 2, fillColor: "#3b82f6", fillOpacity: 0.2 }}
               eventHandlers={{
-                click: () => {
-                  clickHandlerRef.current?.({ featureId: featureIdOf(feature), feature })
+                click: (e: any) => {
+                  const latlng = e?.latlng
+                  if (!latlng || !isFiniteNumber(latlng.lat) || !isFiniteNumber(latlng.lng)) return
+                  setPopup({
+                    latlng: { lat: latlng.lat, lng: latlng.lng },
+                    title: featureLabelOf(feature),
+                    role: featureRoleOf(feature),
+                    description: featureDescriptionOf(feature),
+                    feature,
+                  })
+                  clickHandlerRef.current?.({ featureId: featureIdOf(feature), feature, latlng })
                 },
               }}
             />
@@ -247,13 +285,46 @@ export function LeafletMap({
               radius={6}
               pathOptions={{ color: "#ffffff", weight: 2, fillColor: "#ef4444", fillOpacity: 0.9 }}
               eventHandlers={{
-                click: () => {
-                  clickHandlerRef.current?.({ featureId: featureIdOf(feature), feature })
+                click: (e: any) => {
+                  const latlng = e?.latlng
+                  if (!latlng || !isFiniteNumber(latlng.lat) || !isFiniteNumber(latlng.lng)) return
+                  setPopup({
+                    latlng: { lat: latlng.lat, lng: latlng.lng },
+                    title: featureLabelOf(feature),
+                    role: featureRoleOf(feature),
+                    description: featureDescriptionOf(feature),
+                    feature,
+                  })
+                  clickHandlerRef.current?.({ featureId: featureIdOf(feature), feature, latlng })
                 },
               }}
             />
           )
         })}
+
+        {popup ? (
+          <Popup
+            position={[popup.latlng.lat, popup.latlng.lng]}
+            closeButton
+            closeOnClick
+            autoPan
+            eventHandlers={{
+              remove: () => setPopup(null),
+            }}
+          >
+            <div className="text-sm">
+              <div className="font-medium">{popup.title}</div>
+              {popup.role ? (
+                <div className="mt-0.5 text-xs text-muted-foreground">
+                  Role: <span className="capitalize">{popup.role}</span>
+                </div>
+              ) : null}
+              {popup.description ? (
+                <div className="mt-1 text-xs text-muted-foreground">{popup.description}</div>
+              ) : null}
+            </div>
+          </Popup>
+        ) : null}
       </MapContainer>
     </div>
   )

--- a/packages/backfield-ui/src/LeafletMap.tsx
+++ b/packages/backfield-ui/src/LeafletMap.tsx
@@ -5,6 +5,7 @@ import { CircleMarker, MapContainer, Polygon, TileLayer, useMap } from "react-le
 import "leaflet/dist/leaflet.css"
 
 type LngLat = [number, number] // [lng, lat]
+type LatLng = [number, number] // [lat, lng]
 
 type FeatureId = string
 
@@ -39,7 +40,7 @@ export type LeafletMapProps = {
   fitToData?: boolean
 }
 
-const DEFAULT_CENTER: LngLat = [-98.5795, 39.8283] // continental US
+const DEFAULT_CENTER: LatLng = [39.8283, -98.5795] // continental US
 const DEFAULT_ZOOM = 3
 
 function isFiniteNumber(v: unknown): v is number {
@@ -70,7 +71,7 @@ function normalizeFeatureCollection(input: unknown): GeoJsonFeatureCollection {
   return { type: "FeatureCollection", features }
 }
 
-function extractLngLatBounds(collections: GeoJsonFeatureCollection[]): [LngLat, LngLat] | null {
+function extractLatLngBounds(collections: GeoJsonFeatureCollection[]): [LatLng, LatLng] | null {
   let minLng = Infinity
   let minLat = Infinity
   let maxLng = -Infinity
@@ -124,12 +125,12 @@ function extractLngLatBounds(collections: GeoJsonFeatureCollection[]): [LngLat, 
 
   if (!has) return null
   return [
-    [minLng, minLat],
-    [maxLng, maxLat],
+    [minLat, minLng],
+    [maxLat, maxLng],
   ]
 }
 
-function FitToData({ bounds }: { bounds: [LngLat, LngLat] | null }) {
+function FitToData({ bounds }: { bounds: [LatLng, LatLng] | null }) {
   const map = useMap()
   useEffect(() => {
     if (!bounds) return
@@ -169,7 +170,7 @@ export function LeafletMap({
   const hasAny = normalizedPoints.features.length > 0 || normalizedPolygons.features.length > 0
 
   const bounds = useMemo(
-    () => (fitToData ? extractLngLatBounds([normalizedPoints, normalizedPolygons]) : null),
+    () => (fitToData ? extractLatLngBounds([normalizedPoints, normalizedPolygons]) : null),
     [fitToData, normalizedPoints, normalizedPolygons],
   )
 

--- a/packages/backfield-ui/src/index.ts
+++ b/packages/backfield-ui/src/index.ts
@@ -2,6 +2,19 @@ export { UserAccountMenu, type UserAccountMenuProps } from "./UserAccountMenu"
 export { ShellProductBrand, type ShellProductBrandProps } from "./ShellProductBrand"
 export { cn } from "./cn"
 export { LeafletMap, type LeafletMapProps, type LeafletMapFeatureClick } from "./LeafletMap"
+export { LayerFilterPopover, type LayerFilterPopoverProps } from "./LayerFilterPopover"
+export {
+  layersFromFeatures,
+  defaultVisibility,
+  toggleLayer,
+  showAll,
+  hideAll,
+  isLayerVisible,
+  type LayerId,
+  type LayerVisibility,
+  type LayerOption,
+  type GroupedFeature,
+} from "./layerVisibility"
 export {
   NODE_OUTPUT_KEY_INDEX,
   buildNodeIdToPublicOutputKey,

--- a/packages/backfield-ui/src/layerVisibility.test.ts
+++ b/packages/backfield-ui/src/layerVisibility.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest"
+import { defaultVisibility, hideAll, layersFromFeatures, showAll, toggleLayer } from "./layerVisibility"
+
+describe("layerVisibility", () => {
+  it("extracts distinct layer ids from feature groups", () => {
+    const layers = layersFromFeatures([{ group: "place" }, { group: "address" }, { group: "place" }, { group: "" }])
+    expect(layers.map((l) => l.id)).toEqual(["address", "place"])
+  })
+
+  it("defaults to all visible", () => {
+    const layers = [{ id: "a", label: "a" }, { id: "b", label: "b" }]
+    expect(defaultVisibility(layers)).toEqual({ a: true, b: true })
+  })
+
+  it("toggles a layer without affecting others", () => {
+    const vis = { a: true, b: true }
+    expect(toggleLayer(vis, "a")).toEqual({ a: false, b: true })
+  })
+
+  it("showAll/hideAll set all known layers", () => {
+    const layers = [{ id: "a", label: "a" }, { id: "b", label: "b" }]
+    expect(hideAll(layers)).toEqual({ a: false, b: false })
+    expect(showAll(layers)).toEqual({ a: true, b: true })
+  })
+})
+

--- a/packages/backfield-ui/src/layerVisibility.ts
+++ b/packages/backfield-ui/src/layerVisibility.ts
@@ -1,0 +1,61 @@
+export type LayerId = string
+
+export type LayerVisibility = Record<LayerId, boolean>
+
+export type GroupedFeature = {
+  group?: string | null
+}
+
+export type LayerOption = {
+  id: LayerId
+  label: string
+}
+
+function normalizeLayerId(raw: string): string {
+  return raw.trim()
+}
+
+export function layersFromFeatures(features: GroupedFeature[]): LayerOption[] {
+  const seen = new Set<string>()
+  const out: LayerOption[] = []
+
+  for (const f of features) {
+    const g = (f.group ?? "").trim()
+    if (!g) continue
+    const id = normalizeLayerId(g)
+    if (!id || seen.has(id)) continue
+    seen.add(id)
+    out.push({ id, label: id })
+  }
+
+  // Stable ordering: alphabetical, case-insensitive
+  out.sort((a, b) => a.label.toLowerCase().localeCompare(b.label.toLowerCase()))
+  return out
+}
+
+export function defaultVisibility(layers: LayerOption[]): LayerVisibility {
+  const vis: LayerVisibility = {}
+  for (const layer of layers) vis[layer.id] = true
+  return vis
+}
+
+export function toggleLayer(visibility: LayerVisibility, layerId: LayerId): LayerVisibility {
+  return { ...visibility, [layerId]: !(visibility[layerId] ?? true) }
+}
+
+export function showAll(layers: LayerOption[]): LayerVisibility {
+  const vis: LayerVisibility = {}
+  for (const layer of layers) vis[layer.id] = true
+  return vis
+}
+
+export function hideAll(layers: LayerOption[]): LayerVisibility {
+  const vis: LayerVisibility = {}
+  for (const layer of layers) vis[layer.id] = false
+  return vis
+}
+
+export function isLayerVisible(visibility: LayerVisibility, layerId: LayerId): boolean {
+  return visibility[layerId] ?? true
+}
+


### PR DESCRIPTION
## Summary
- Replace GeocodeAgent Mapbox map with Leaflet and add layer filtering popover.
- Ensure the Layers popover renders above Leaflet panes.
- Inline the visualization header and drop the trailing (nX) suffix from the node label.

## Test plan
- [ ] Open a run item with GeocodeAgent output and confirm the Leaflet map renders.
- [ ] Click **Layers** and toggle groups; confirm features show/hide.
- [ ] Click a feature; confirm the popup shows name + role.

Made with [Cursor](https://cursor.com)