### PR TITLE
Canonical Leaflet point editing

### DIFF
--- a/apps/stylebook-ui/src/components/Layout.tsx
+++ b/apps/stylebook-ui/src/components/Layout.tsx
@@ -41,7 +41,7 @@ export default function Layout({ children, headerContent }: LayoutProps) {
 
   return (
     <div className="min-h-screen bg-background">
-      <header className="border-b shrink-0 bg-background sticky top-0 z-[100] overflow-visible">
+      <header className="border-b shrink-0 bg-background sticky top-0 z-[5000] overflow-visible">
         <div className="px-4 py-4 flex justify-between items-center overflow-visible">
           <ShellProductBrand
             to={indexPath}
@@ -60,7 +60,7 @@ export default function Layout({ children, headerContent }: LayoutProps) {
           </div>
         </div>
       </header>
-      <main className="container mx-auto px-4 py-8 overflow-visible">{children}</main>
+      <main className="container relative z-0 mx-auto px-4 py-8 overflow-visible">{children}</main>
     </div>
   )
 }

--- a/apps/stylebook-ui/src/pages/LocationDetail.tsx
+++ b/apps/stylebook-ui/src/pages/LocationDetail.tsx
@@ -82,6 +82,17 @@ type GeoJsonGeometry =
   | { type: "Polygon"; coordinates: [number, number][][] }
   | { type: "MultiPolygon"; coordinates: [number, number][][][] }
 
+function isPointGeometry(geometry: Record<string, unknown> | null): geometry is {
+  type: "Point"
+  coordinates: [number, number]
+} {
+  if (!geometry || typeof geometry !== "object") return false
+  const g = geometry as Record<string, unknown>
+  if (g.type !== "Point") return false
+  const c = g.coordinates
+  return Array.isArray(c) && c.length === 2 && typeof c[0] === "number" && typeof c[1] === "number"
+}
+
 function geometryToFeatureCollections(
   geometry: Record<string, unknown> | null,
 ): { points: unknown; polygons: unknown } {
@@ -464,7 +475,30 @@ export default function LocationDetail() {
             points={geometryToFeatureCollections(geometryEditing ? geometryDraft : geometry).points as any}
             polygons={geometryToFeatureCollections(geometryEditing ? geometryDraft : geometry).polygons as any}
             showPopups={false}
+            onMapClick={
+              geometryEditing && (!geometryDraft || isPointGeometry(geometryDraft))
+                ? ({ latlng }) => {
+                    setGeometryDraft({ type: "Point", coordinates: [latlng.lng, latlng.lat] })
+                  }
+                : undefined
+            }
+            editablePoint={
+              geometryEditing && isPointGeometry(geometryDraft)
+                ? {
+                    featureId: "canonical",
+                    onChange: ({ lng, lat }) =>
+                      setGeometryDraft({ type: "Point", coordinates: [lng, lat] }),
+                  }
+                : null
+            }
           />
+          {geometryEditing && isPointGeometry(geometryDraft) ? (
+            <div className="flex items-center justify-end">
+              <Button variant="outline" onClick={() => setGeometryDraft(null)} disabled={geometrySaving}>
+                Clear point
+              </Button>
+            </div>
+          ) : null}
           {geometryEditing ? (
             <SimpleGeoJsonGeometry value={geometryDraft} onChange={setGeometryDraft} />
           ) : null}

--- a/apps/stylebook-ui/src/pages/LocationDetail.tsx
+++ b/apps/stylebook-ui/src/pages/LocationDetail.tsx
@@ -486,7 +486,7 @@ export default function LocationDetail() {
           <div
             className={cn(
               "rounded-md overflow-hidden",
-              geometryEditing && "ring-1 ring-foreground/25 border border-foreground/30",
+              geometryEditing && "bg-white ring-1 ring-foreground/25 border border-foreground/30",
             )}
           >
             <LeafletMap

--- a/apps/stylebook-ui/src/pages/LocationDetail.tsx
+++ b/apps/stylebook-ui/src/pages/LocationDetail.tsx
@@ -432,10 +432,22 @@ export default function LocationDetail() {
         </CardContent>
       </Card>
 
-      <Card>
+      <Card
+        className={cn(
+          geometryEditing &&
+            "border-primary/40 bg-primary/5 shadow-sm ring-1 ring-primary/20 transition-colors",
+        )}
+      >
         <CardHeader className="flex flex-row items-center justify-between gap-3 space-y-0">
           <div>
-            <CardTitle>Geography</CardTitle>
+            <CardTitle className="flex items-center gap-2">
+              <span>Geography</span>
+              {geometryEditing ? (
+                <Badge variant="secondary" className="font-normal">
+                  Editing draft
+                </Badge>
+              ) : null}
+            </CardTitle>
             <CardDescription>
               {geometryEditing ? "Edit canonical geometry (draft) and save or cancel." : "View canonical geometry."}
             </CardDescription>

--- a/apps/stylebook-ui/src/pages/LocationDetail.tsx
+++ b/apps/stylebook-ui/src/pages/LocationDetail.tsx
@@ -435,7 +435,7 @@ export default function LocationDetail() {
       <Card
         className={cn(
           geometryEditing &&
-            "border-2 border-foreground/80 bg-primary/5 shadow-sm transition-colors",
+            "border-2 border-foreground/80 bg-white shadow-sm transition-colors",
         )}
       >
         <CardHeader className="flex flex-row items-center justify-between gap-3 space-y-0">

--- a/apps/stylebook-ui/src/pages/LocationDetail.tsx
+++ b/apps/stylebook-ui/src/pages/LocationDetail.tsx
@@ -435,7 +435,7 @@ export default function LocationDetail() {
       <Card
         className={cn(
           geometryEditing &&
-            "border-primary/40 bg-primary/5 shadow-sm ring-1 ring-primary/20 transition-colors",
+            "border-2 border-foreground/80 bg-primary/5 shadow-sm transition-colors",
         )}
       >
         <CardHeader className="flex flex-row items-center justify-between gap-3 space-y-0">
@@ -483,27 +483,44 @@ export default function LocationDetail() {
           </div>
         </CardHeader>
         <CardContent className="space-y-3">
-          <LeafletMap
-            points={geometryToFeatureCollections(geometryEditing ? geometryDraft : geometry).points as any}
-            polygons={geometryToFeatureCollections(geometryEditing ? geometryDraft : geometry).polygons as any}
-            showPopups={false}
-            onMapClick={
-              geometryEditing && (!geometryDraft || isPointGeometry(geometryDraft))
-                ? ({ latlng }) => {
-                    setGeometryDraft({ type: "Point", coordinates: [latlng.lng, latlng.lat] })
-                  }
-                : undefined
-            }
-            editablePoint={
-              geometryEditing && isPointGeometry(geometryDraft)
-                ? {
-                    featureId: "canonical",
-                    onChange: ({ lng, lat }) =>
-                      setGeometryDraft({ type: "Point", coordinates: [lng, lat] }),
-                  }
-                : null
-            }
-          />
+          <div
+            className={cn(
+              "rounded-md overflow-hidden",
+              geometryEditing && "ring-1 ring-foreground/25 border border-foreground/30",
+            )}
+          >
+            <LeafletMap
+              points={geometryToFeatureCollections(geometryEditing ? geometryDraft : geometry).points as any}
+              polygons={geometryToFeatureCollections(geometryEditing ? geometryDraft : geometry).polygons as any}
+              showPopups={false}
+              tileUrl={
+                geometryEditing
+                  ? "https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png"
+                  : undefined
+              }
+              tileAttribution={
+                geometryEditing
+                  ? '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/attributions">CARTO</a>'
+                  : undefined
+              }
+              onMapClick={
+                geometryEditing && (!geometryDraft || isPointGeometry(geometryDraft))
+                  ? ({ latlng }) => {
+                      setGeometryDraft({ type: "Point", coordinates: [latlng.lng, latlng.lat] })
+                    }
+                  : undefined
+              }
+              editablePoint={
+                geometryEditing && isPointGeometry(geometryDraft)
+                  ? {
+                      featureId: "canonical",
+                      onChange: ({ lng, lat }) =>
+                        setGeometryDraft({ type: "Point", coordinates: [lng, lat] }),
+                    }
+                  : null
+              }
+            />
+          </div>
           {geometryEditing && isPointGeometry(geometryDraft) ? (
             <div className="flex items-center justify-end">
               <Button variant="outline" onClick={() => setGeometryDraft(null)} disabled={geometrySaving}>

--- a/packages/backfield-ui/src/LeafletMap.test.tsx
+++ b/packages/backfield-ui/src/LeafletMap.test.tsx
@@ -14,5 +14,26 @@ describe("LeafletMap", () => {
     // It may render empty-state after normalization; the key is “no crash”.
     expect(getAllByText("No geographic features.").length).toBeGreaterThan(0)
   })
+
+  it("renders with point editing enabled", () => {
+    const points: any = {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          properties: { id: "canonical", label: "Canonical" },
+          geometry: { type: "Point", coordinates: [-87.6298, 41.8781] },
+        },
+      ],
+    }
+    render(
+      <LeafletMap
+        points={points}
+        polygons={null}
+        showPopups={false}
+        editablePoint={{ featureId: "canonical", onChange: () => {} }}
+      />,
+    )
+  })
 })
 

--- a/packages/backfield-ui/src/LeafletMap.tsx
+++ b/packages/backfield-ui/src/LeafletMap.tsx
@@ -45,6 +45,8 @@ export type LeafletMapProps = {
     featureId: string
     onChange: (next: { lng: number; lat: number }) => void
   } | null
+  tileUrl?: string
+  tileAttribution?: string
 }
 
 const DEFAULT_CENTER: LatLng = [39.8283, -98.5795] // continental US
@@ -187,6 +189,8 @@ export function LeafletMap({
   showPopups = true,
   onMapClick,
   editablePoint = null,
+  tileUrl = "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+  tileAttribution = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
 }: LeafletMapProps) {
   const [error, setError] = useState<string | null>(null)
   const clickHandlerRef = useRef(onFeatureClick)
@@ -295,10 +299,7 @@ export function LeafletMap({
       {error ? <div className="p-3 text-sm text-destructive">{error}</div> : null}
       <MapContainer center={DEFAULT_CENTER as any} zoom={DEFAULT_ZOOM} style={{ height: "100%", width: "100%" }}>
         <MapClickHandler />
-        <TileLayer
-          attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
-          url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-        />
+        <TileLayer attribution={tileAttribution} url={tileUrl} />
         {fitToData ? <FitToData bounds={bounds} /> : null}
         {polygonPaths.map((feature, idx) => {
           const coords = feature.geometry.coordinates?.[0]

--- a/packages/backfield-ui/src/LeafletMap.tsx
+++ b/packages/backfield-ui/src/LeafletMap.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react"
 import type { ReactNode } from "react"
 import * as L from "leaflet"
-import { CircleMarker, MapContainer, Polygon, Popup, TileLayer, useMap } from "react-leaflet"
+import { CircleMarker, MapContainer, Marker, Polygon, Popup, TileLayer, useMap, useMapEvents } from "react-leaflet"
 import "leaflet/dist/leaflet.css"
 
 type LngLat = [number, number] // [lng, lat]
@@ -40,6 +40,11 @@ export type LeafletMapProps = {
   onFeatureClick?: (event: LeafletMapFeatureClick) => void
   fitToData?: boolean
   showPopups?: boolean
+  onMapClick?: (event: { latlng: { lat: number; lng: number } }) => void
+  editablePoint?: {
+    featureId: string
+    onChange: (next: { lng: number; lat: number }) => void
+  } | null
 }
 
 const DEFAULT_CENTER: LatLng = [39.8283, -98.5795] // continental US
@@ -180,6 +185,8 @@ export function LeafletMap({
   onFeatureClick,
   fitToData = true,
   showPopups = true,
+  onMapClick,
+  editablePoint = null,
 }: LeafletMapProps) {
   const [error, setError] = useState<string | null>(null)
   const clickHandlerRef = useRef(onFeatureClick)
@@ -239,10 +246,55 @@ export function LeafletMap({
     })
     .flat()
 
+  const editablePointFeature = useMemo(() => {
+    if (!editablePoint) return null
+    return normalizedPoints.features.find((f) => featureIdOf(f) === editablePoint.featureId) ?? null
+  }, [editablePoint, normalizedPoints.features])
+
+  const editablePointCenter = useMemo((): [number, number] | null => {
+    if (!editablePointFeature) return null
+    const c = editablePointFeature.geometry.coordinates
+    if (!Array.isArray(c) || c.length < 2) return null
+    const lng = c[0]
+    const lat = c[1]
+    if (!isFiniteNumber(lng) || !isFiniteNumber(lat)) return null
+    return [lat, lng]
+  }, [editablePointFeature])
+
+  const editablePointIcon = useMemo(() => {
+    if (!editablePointCenter) return null
+    return L.divIcon({
+      className: "",
+      html: `<div style="
+        width: 14px;
+        height: 14px;
+        border-radius: 9999px;
+        background: #ef4444;
+        border: 2px solid #ffffff;
+        box-shadow: 0 1px 2px rgba(0,0,0,0.25);
+      "></div>`,
+      iconSize: [14, 14],
+      iconAnchor: [7, 7],
+    })
+  }, [editablePointCenter])
+
+  function MapClickHandler() {
+    useMapEvents({
+      click: (e) => {
+        if (!onMapClick) return
+        const latlng = e?.latlng
+        if (!latlng || !isFiniteNumber(latlng.lat) || !isFiniteNumber(latlng.lng)) return
+        onMapClick({ latlng: { lat: latlng.lat, lng: latlng.lng } })
+      },
+    })
+    return null
+  }
+
   return (
     <div className="rounded-md overflow-hidden border border-border" style={{ height }}>
       {error ? <div className="p-3 text-sm text-destructive">{error}</div> : null}
       <MapContainer center={DEFAULT_CENTER as any} zoom={DEFAULT_ZOOM} style={{ height: "100%", width: "100%" }}>
+        <MapClickHandler />
         <TileLayer
           attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
@@ -281,6 +333,7 @@ export function LeafletMap({
         })}
 
         {normalizedPoints.features.map((feature, idx) => {
+          if (editablePoint && featureIdOf(feature) === editablePoint.featureId) return null
           const c = feature.geometry.coordinates
           if (!Array.isArray(c) || c.length < 2) return null
           const lng = c[0]
@@ -311,6 +364,21 @@ export function LeafletMap({
             />
           )
         })}
+
+        {editablePoint && editablePointCenter && editablePointIcon ? (
+          <Marker
+            position={editablePointCenter}
+            draggable
+            icon={editablePointIcon as any}
+            eventHandlers={{
+              dragend: (e: any) => {
+                const latlng = e?.target?.getLatLng?.()
+                if (!latlng || !isFiniteNumber(latlng.lat) || !isFiniteNumber(latlng.lng)) return
+                editablePoint.onChange({ lng: latlng.lng, lat: latlng.lat })
+              },
+            }}
+          />
+        ) : null}
 
         {showPopups && popup ? (
           <Popup


### PR DESCRIPTION
## Summary
- Add interactive **point placement + drag** for canonical geography editing in Stylebook.
- Extend `@backfield/ui` `LeafletMap` with optional **map click**, **draggable point marker**, and **configurable basemap tiles**.
- Polish edit-mode visuals (white surfaces, light basemap while editing) and prevent Leaflet layers from painting over the sticky shell header.

## Test plan
- [ ] `make stylebook-ui-build`
- [ ] Open a canonical location detail page: map renders; header stays above map while scrolling.
- [ ] Enter geography edit mode: light basemap + white surfaces; click map to set point; drag point; clear point; save/cancel flows still work.

Made with [Cursor](https://cursor.com)