### PR TITLE
Stylebook integration and canonical UX polish

### DIFF
--- a/apps/stylebook-api/src/stylebook_api/routers/locations.py
+++ b/apps/stylebook-api/src/stylebook_api/routers/locations.py
@@ -434,11 +434,6 @@ def list_canonical_locations(
     if type_filter is not None:
         tf = type_filter.strip()
         if tf:
-            if tf not in _ALLOWED_CANONICAL_LIST_TYPE_FILTER:
-                raise HTTPException(
-                    status_code=400,
-                    detail="Invalid type_filter for canonical list",
-                )
             filters.append(col(StylebookLocationCanonical.location_type) == tf)
 
     count_stmt = select(func.count()).select_from(StylebookLocationCanonical).where(*filters)
@@ -492,6 +487,30 @@ def list_canonical_locations(
         has_next=offset + len(out) < total,
         has_prev=offset > 0,
     )
+
+
+@router.get("/canonical-locations/types")
+def list_canonical_location_types(
+    project_slug: str = Query(...),
+    session: Session = Depends(get_session),
+    auth: dict[str, Any] = Depends(get_auth),
+) -> dict[str, Any]:
+    """Return distinct canonical ``location_type`` values for filter dropdowns.
+
+    Includes custom (non-PlaceExtract) types that may come from user uploads/imports.
+    """
+    proj = _project_by_slug(session, project_slug)
+    require_project_access(session, auth, int(proj.id))
+    stylebook_id = _require_stylebook_id(session, proj)
+    rows = session.exec(
+        select(func.distinct(StylebookLocationCanonical.location_type)).where(
+            StylebookLocationCanonical.stylebook_id == stylebook_id,
+            col(StylebookLocationCanonical.location_type).is_not(None),
+            func.length(func.trim(col(StylebookLocationCanonical.location_type))) > 0,
+        )
+    ).all()
+    types = sorted({str(r).strip() for r in rows if r is not None and str(r).strip()})
+    return {"types": types}
 
 
 @router.post("/canonical-locations", response_model=CanonicalLocationResponse)

--- a/apps/stylebook-ui/src/components/CanonicalLinkModal.tsx
+++ b/apps/stylebook-ui/src/components/CanonicalLinkModal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react"
 import {
   getCanonicalLocation,
+  getLocation,
   getSuggestedCanonicals,
   linkSubstrateToCanonical,
   listCanonicalLocations,
@@ -64,6 +65,8 @@ export function CanonicalLinkModal(props: {
   const [linkingCanonicalId, setLinkingCanonicalId] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [initialCanonExtra, setInitialCanonExtra] = useState<CanonicalLocation | null>(null)
+  const [linkedCanonicalId, setLinkedCanonicalId] = useState<string | null>(null)
+  const [linkedMetaLoaded, setLinkedMetaLoaded] = useState(false)
 
   useEffect(() => {
     if (!open) {
@@ -72,11 +75,45 @@ export function CanonicalLinkModal(props: {
       setError(null)
       setLinkingCanonicalId(null)
       setInitialCanonExtra(null)
+      setLinkedCanonicalId(null)
+      setLinkedMetaLoaded(false)
     }
   }, [open])
 
   useEffect(() => {
+    if (!open || !substrateLocationId || !projectSlug) {
+      setLinkedCanonicalId(null)
+      setLinkedMetaLoaded(false)
+      return
+    }
+    let cancelled = false
+    setLinkedMetaLoaded(false)
+    void (async () => {
+      try {
+        const loc = await getLocation(substrateLocationId, projectSlug)
+        const cid = (loc.stylebook_location_canonical_id ?? "").trim()
+        if (!cancelled) {
+          setLinkedCanonicalId(cid ? cid : null)
+          setLinkedMetaLoaded(true)
+        }
+      } catch {
+        if (!cancelled) {
+          setLinkedCanonicalId(null)
+          setLinkedMetaLoaded(true)
+        }
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [open, substrateLocationId, projectSlug])
+
+  useEffect(() => {
     if (!open || !initialCanonicalId || !projectSlug) {
+      setInitialCanonExtra(null)
+      return
+    }
+    if (linkedCanonicalId && initialCanonicalId === linkedCanonicalId) {
       setInitialCanonExtra(null)
       return
     }
@@ -96,10 +133,14 @@ export function CanonicalLinkModal(props: {
     return () => {
       cancelled = true
     }
-  }, [open, initialCanonicalId, projectSlug, suggestions])
+  }, [open, initialCanonicalId, projectSlug, suggestions, linkedCanonicalId])
 
   useEffect(() => {
     if (!open || !substrateLocationId || !projectSlug) {
+      setSuggestions([])
+      return
+    }
+    if (!linkedMetaLoaded) {
       setSuggestions([])
       return
     }
@@ -108,7 +149,11 @@ export function CanonicalLinkModal(props: {
       setLoadingSuggestions(true)
       try {
         const res = await getSuggestedCanonicals(projectSlug, substrateLocationId)
-        if (!cancelled) setSuggestions(res.suggestions)
+        if (!cancelled) {
+          const exclude = (linkedCanonicalId ?? "").trim()
+          const next = exclude ? res.suggestions.filter((s) => String(s.canonical_id) !== exclude) : res.suggestions
+          setSuggestions(next)
+        }
       } catch (e) {
         if (!cancelled) {
           setSuggestions([])
@@ -121,10 +166,15 @@ export function CanonicalLinkModal(props: {
     return () => {
       cancelled = true
     }
-  }, [open, substrateLocationId, projectSlug])
+  }, [open, substrateLocationId, projectSlug, linkedMetaLoaded, linkedCanonicalId])
 
   useEffect(() => {
     if (!open || !projectSlug) return
+    if (!linkedMetaLoaded) {
+      setSearchHits([])
+      setSearchLoading(false)
+      return
+    }
     const q = searchQ.trim()
     if (!q) {
       setSearchHits([])
@@ -137,7 +187,11 @@ export function CanonicalLinkModal(props: {
       void (async () => {
         try {
           const res = await listCanonicalLocations(projectSlug, q, 20, 0)
-          if (!cancelled) setSearchHits(res.canonicals)
+          if (!cancelled) {
+            const exclude = (linkedCanonicalId ?? "").trim()
+            const next = exclude ? res.canonicals.filter((c) => String(c.id) !== exclude) : res.canonicals
+            setSearchHits(next)
+          }
         } catch {
           if (!cancelled) setSearchHits([])
         } finally {
@@ -149,25 +203,32 @@ export function CanonicalLinkModal(props: {
       cancelled = true
       window.clearTimeout(t)
     }
-  }, [searchQ, open, projectSlug])
+  }, [searchQ, open, projectSlug, linkedCanonicalId, linkedMetaLoaded])
 
   const mergedSuggestions: SuggestedCanonicalItem[] = useMemo(() => {
-    const merged: SuggestedCanonicalItem[] = [...suggestions]
+    const exclude = (linkedCanonicalId ?? "").trim()
+    const merged: SuggestedCanonicalItem[] = exclude
+      ? suggestions.filter((s) => String(s.canonical_id) !== exclude)
+      : [...suggestions]
     if (initialCanonExtra) {
       const exId = initialCanonExtra.id
-      if (!merged.some((s) => s.canonical_id === exId)) {
-        merged.unshift(canonicalToSuggestedRow(initialCanonExtra))
+      if (!exclude || exId !== exclude) {
+        if (!merged.some((s) => s.canonical_id === exId)) {
+          merged.unshift(canonicalToSuggestedRow(initialCanonExtra))
+        }
       }
     }
     if (initialCanonicalId) {
-      const ix = merged.findIndex((s) => s.canonical_id === initialCanonicalId)
-      if (ix > 0) {
-        const [picked] = merged.splice(ix, 1)
-        merged.unshift(picked)
+      if (!exclude || initialCanonicalId !== exclude) {
+        const ix = merged.findIndex((s) => s.canonical_id === initialCanonicalId)
+        if (ix > 0) {
+          const [picked] = merged.splice(ix, 1)
+          merged.unshift(picked)
+        }
       }
     }
     return merged
-  }, [suggestions, initialCanonExtra, initialCanonicalId])
+  }, [suggestions, initialCanonExtra, initialCanonicalId, linkedCanonicalId, linkedMetaLoaded])
 
   const suggestionRows = useMemo(
     () => suggestedItemsToPickRows(mergedSuggestions),

--- a/apps/stylebook-ui/src/components/CanonicalLinkModal.tsx
+++ b/apps/stylebook-ui/src/components/CanonicalLinkModal.tsx
@@ -51,6 +51,7 @@ export function CanonicalLinkModal(props: {
   /** Substrate location id (open candidate or linked row for relink/move). */
   substrateLocationId: number | null
   onDone: () => void
+  onLinked?: (canonical: { id: string; label: string }) => void
   title?: string
   /** When set, surface this canonical first (e.g. pre-filled from row suggestion). */
   initialCanonicalId?: string | null
@@ -244,7 +245,12 @@ export function CanonicalLinkModal(props: {
     setLinkingCanonicalId(canonicalId)
     setError(null)
     try {
+      const pickedLabel =
+        mergedSuggestions.find((s) => String(s.canonical_id) === String(canonicalId))?.label ??
+        searchHits.find((s) => String(s.id) === String(canonicalId))?.label ??
+        (initialCanonExtra?.id === canonicalId ? initialCanonExtra.label : canonicalId)
       await linkSubstrateToCanonical(substrateLocationId, projectSlug, canonicalId)
+      props.onLinked?.({ id: canonicalId, label: pickedLabel })
       onDone()
       onOpenChange(false)
     } catch (e) {

--- a/apps/stylebook-ui/src/components/ConnectionsGraph.tsx
+++ b/apps/stylebook-ui/src/components/ConnectionsGraph.tsx
@@ -131,7 +131,7 @@ export default function ConnectionsGraph({
   if (connections.length === 0) {
     return (
       <div className="h-[300px] flex items-center justify-center rounded-md border bg-muted/30 text-muted-foreground">
-        No connections to show in graph. Add connections in the list view.
+        No connections yet.
       </div>
     )
   }

--- a/apps/stylebook-ui/src/components/ConnectionsSection.tsx
+++ b/apps/stylebook-ui/src/components/ConnectionsSection.tsx
@@ -208,7 +208,7 @@ export default function ConnectionsSection({
             <div className="space-y-1.5 min-w-0">
               <CardTitle>Connections</CardTitle>
               <CardDescription>
-                Directed links between this {entityType} and other canonicals (e.g. mayor, born in).
+                Directed links between this {entityType} and other canonicals.
               </CardDescription>
             </div>
             <Button
@@ -241,9 +241,7 @@ export default function ConnectionsSection({
               </TabsList>
               <TabsContent value="list" className="mt-4">
                 {connections.length === 0 ? (
-                  <div className="text-center py-4 text-muted-foreground">
-                    No connections yet. Use Add connection to link this {entityType} to another canonical.
-                  </div>
+                  <div className="text-center py-4 text-muted-foreground">No connections yet.</div>
                 ) : (
                   <Table>
               <TableHeader>

--- a/apps/stylebook-ui/src/components/LocationMetaTab.tsx
+++ b/apps/stylebook-ui/src/components/LocationMetaTab.tsx
@@ -10,6 +10,7 @@ import {
 const locationMetaTabConfig: MetaTabConfig = {
   type: "location",
   displayName: { singular: "Location", plural: "Locations" },
+  subtitle: "Additional details about this location.",
   api: {
     getMeta: (entityId, projectSlug) => getCanonicalLocationMeta(String(entityId), projectSlug),
     createMeta: (entityId, projectSlug, data) =>

--- a/apps/stylebook-ui/src/components/MetaTab.tsx
+++ b/apps/stylebook-ui/src/components/MetaTab.tsx
@@ -49,6 +49,8 @@ export interface MetaResponse {
 export interface MetaTabConfig {
   type: string
   displayName: { singular: string; plural: string }
+  /** When set, shown under the Metadata title after load instead of the meta-item count. */
+  subtitle?: string
   api: {
     getMeta: (entityId: string | number, projectSlug: string) => Promise<MetaResponse>
     createMeta: (
@@ -466,7 +468,8 @@ export default function MetaTab({ entityId, projectSlug, config, onMetaUpdated }
       ? loading
         ? "Loading…"
         : "Could not load metadata."
-      : `${meta.count} meta item${meta.count !== 1 ? "s" : ""} for this ${config.displayName.singular.toLowerCase()}`
+      : (config.subtitle ??
+          `${meta.count} meta item${meta.count !== 1 ? "s" : ""} for this ${config.displayName.singular.toLowerCase()}`)
 
   return (
     <>
@@ -479,7 +482,7 @@ export default function MetaTab({ entityId, projectSlug, config, onMetaUpdated }
             </div>
             <Button type="button" className="shrink-0" onClick={openCreateDialog} disabled={!entityId || loading}>
               <Plus className="h-4 w-4 mr-2" />
-              Add Meta
+              Add metadata
             </Button>
           </div>
         </CardHeader>
@@ -492,9 +495,7 @@ export default function MetaTab({ entityId, projectSlug, config, onMetaUpdated }
           ) : !meta ? (
             <div className="py-6 text-center text-muted-foreground">No metadata available.</div>
           ) : meta.meta.length === 0 ? (
-            <div className="text-center py-8 text-muted-foreground">
-              No metadata yet. Use Add Meta to create an entry.
-            </div>
+            <div className="text-center py-8 text-muted-foreground">No metadata yet.</div>
           ) : (
             <div className="space-y-4">
               {meta.meta.map((item) => {

--- a/apps/stylebook-ui/src/components/ui/dialog.tsx
+++ b/apps/stylebook-ui/src/components/ui/dialog.tsx
@@ -19,7 +19,8 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-[120] bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      // Must be higher than the sticky app header (`Layout.tsx` uses z-[5000]).
+      "fixed inset-0 z-[6000] bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}
@@ -36,7 +37,8 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-[120] grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        // Must be higher than the sticky app header (`Layout.tsx` uses z-[5000]).
+        "fixed left-[50%] top-[50%] z-[6000] grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className
       )}
       {...props}

--- a/apps/stylebook-ui/src/components/ui/dropdown-menu.tsx
+++ b/apps/stylebook-ui/src/components/ui/dropdown-menu.tsx
@@ -47,7 +47,8 @@ const DropdownMenuSubContent = React.forwardRef<
   <DropdownMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      // Must be higher than the sticky app header (`Layout.tsx` uses z-[5000]).
+      "z-[6000] min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
       className
     )}
     {...props}
@@ -65,7 +66,8 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        // Must be higher than the sticky app header (`Layout.tsx` uses z-[5000]).
+        "z-[6000] min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className
       )}
       {...props}

--- a/apps/stylebook-ui/src/components/ui/select.tsx
+++ b/apps/stylebook-ui/src/components/ui/select.tsx
@@ -75,7 +75,8 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "relative z-[110] max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        // Must be higher than the sticky app header (`Layout.tsx` uses z-[5000]).
+        "relative z-[6000] max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         position === "popper" &&
           "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
         className

--- a/apps/stylebook-ui/src/lib/api.ts
+++ b/apps/stylebook-ui/src/lib/api.ts
@@ -24,6 +24,7 @@ export {
   linkSubstrateToCanonical,
   listCanonicalLinkedSubstrates,
   listCanonicalLocations,
+  listCanonicalLocationTypes,
   listLocationOptions,
   listLocations,
   patchCanonicalLocation,

--- a/apps/stylebook-ui/src/lib/import/geojsonImport.ts
+++ b/apps/stylebook-ui/src/lib/import/geojsonImport.ts
@@ -55,6 +55,8 @@ export function normalizeFeatureCollectionForImport(
 export type GeoJsonFieldMappings = {
   /** Feature.properties key for label/name. */
   labelProperty?: string | null
+  /** Feature.properties key for formatted_address (backend defaults to `formatted_address` when unset). */
+  formattedAddressProperty?: string | null
   /** Feature.properties key for location_type. */
   locationTypeProperty?: string | null
   /** When set, overrides all per-feature type values. */
@@ -118,8 +120,11 @@ export function deriveImportRows(
       typeOverride ??
       _getStringProp(props, mappings.locationTypeProperty) ??
       null
-    /** Same source as label — canonical formatted_address mirrors that display string. */
-    const formattedAddress = label
+    const addrKey =
+      mappings.formattedAddressProperty != null && mappings.formattedAddressProperty.trim() !== ""
+        ? mappings.formattedAddressProperty.trim()
+        : "formatted_address"
+    const formattedAddress = _getStringProp(props, addrKey) ?? null
 
     out.push({
       feature_index: i,
@@ -196,10 +201,18 @@ export function buildFeatureCollectionForImport(
 ): GeoJsonFeatureCollection {
   const outFeatures: GeoJsonFeature[] = []
 
-  const lp = mappings.labelProperty
-  const nameKey = lp || "name"
-  const typeKey = mappings.locationTypeProperty || "type"
-  const addressKey = lp || "formatted_address"
+  const nameKey =
+    mappings.labelProperty != null && mappings.labelProperty.trim() !== ""
+      ? mappings.labelProperty.trim()
+      : "name"
+  const typeKey =
+    mappings.locationTypeProperty != null && mappings.locationTypeProperty.trim() !== ""
+      ? mappings.locationTypeProperty.trim()
+      : "type"
+  const addressKey =
+    mappings.formattedAddressProperty != null && mappings.formattedAddressProperty.trim() !== ""
+      ? mappings.formattedAddressProperty.trim()
+      : "formatted_address"
 
   const typeOverride = (mappings.locationTypeValue ?? "").trim() || null
 

--- a/apps/stylebook-ui/src/lib/stylebook-api/locations.ts
+++ b/apps/stylebook-ui/src/lib/stylebook-api/locations.ts
@@ -105,6 +105,11 @@ export async function listCanonicalLocations(
   return stylebookJsonFetch<PaginatedCanonicalLocationResponse>(`/v1/canonical-locations?${params}`)
 }
 
+export async function listCanonicalLocationTypes(projectSlug: string): Promise<{ types: string[] }> {
+  const params = new URLSearchParams({ project_slug: projectSlug })
+  return stylebookJsonFetch(`/v1/canonical-locations/types?${params}`)
+}
+
 export async function getCanonicalLocation(
   canonicalId: string,
   projectSlug: string,

--- a/apps/stylebook-ui/src/pages/ImportLocations.tsx
+++ b/apps/stylebook-ui/src/pages/ImportLocations.tsx
@@ -100,6 +100,7 @@ export default function ImportLocations() {
   const [analyzeResult, setAnalyzeResult] = useState<AnalyzeGeoJsonResponse | null>(null)
   const [mappings, setMappings] = useState<GeoJsonFieldMappings>({
     labelProperty: null,
+    formattedAddressProperty: null,
     locationTypeProperty: null,
     locationTypeValue: null,
   })
@@ -167,6 +168,7 @@ export default function ImportLocations() {
     setAnalyzeResult(null)
     setMappings({
       labelProperty: null,
+      formattedAddressProperty: null,
       locationTypeProperty: null,
       locationTypeValue: null,
     })
@@ -492,8 +494,9 @@ export default function ImportLocations() {
           <CardHeader>
             <CardTitle>Mapping</CardTitle>
             <CardDescription>
-              Map label and location type. Formatted address uses the same GeoJSON property as
-              label/name.
+              Map the canonical label and location type. Formatted address is read from the property
+              you choose below; leave it unset to use the{" "}
+              <span className="font-mono text-xs">formatted_address</span> field on each feature.
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-6">
@@ -514,6 +517,42 @@ export default function ImportLocations() {
                   </SelectTrigger>
                   <SelectContent>
                     <SelectItem value="__none__">None</SelectItem>
+                    {availableProperties.map((p) => (
+                      <SelectItem key={p} value={p}>
+                        <div className="flex w-full items-center justify-between gap-3">
+                          <span className="truncate">{p}</span>
+                          {sampleProperties ? (
+                            <span className="max-w-[18rem] truncate text-muted-foreground">
+                              {formatPropertyExample(sampleProperties[p]) ?? "—"}
+                            </span>
+                          ) : null}
+                        </div>
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="space-y-2">
+                <Label>Formatted address property</Label>
+                <p className="text-xs text-muted-foreground max-w-xl">
+                  Canonical name comes from the label mapping only. This property fills formatted
+                  address only.
+                </p>
+                <Select
+                  value={mappings.formattedAddressProperty ?? "__default__"}
+                  onValueChange={(v) =>
+                    setMappings((prev) => ({
+                      ...prev,
+                      formattedAddressProperty: v === "__default__" ? null : v,
+                    }))
+                  }
+                >
+                  <SelectTrigger className="h-10 w-full max-w-xl">
+                    <SelectValue placeholder="Default: formatted_address" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="__default__">Default: formatted_address property</SelectItem>
                     {availableProperties.map((p) => (
                       <SelectItem key={p} value={p}>
                         <div className="flex w-full items-center justify-between gap-3">
@@ -841,7 +880,7 @@ export default function ImportLocations() {
                     const res = await importGeoJson(projectSlug, importPayload, {
                       label_property: mappings.labelProperty ?? null,
                       location_type_property: mappings.locationTypeProperty ?? null,
-                      formatted_address_property: mappings.labelProperty ?? null,
+                      formatted_address_property: mappings.formattedAddressProperty ?? null,
                       location_type_value: mappings.locationTypeValue ?? null,
                     })
                     setImportResult(res)
@@ -956,6 +995,7 @@ export default function ImportLocations() {
                       setManualLocationTypeLabel("")
                       setMappings({
                         labelProperty: null,
+                        formattedAddressProperty: null,
                         locationTypeProperty: null,
                         locationTypeValue: null,
                       })

--- a/apps/stylebook-ui/src/pages/LocationCandidates.tsx
+++ b/apps/stylebook-ui/src/pages/LocationCandidates.tsx
@@ -4,6 +4,7 @@ import {
   acceptCandidate,
   deferCandidate,
   getCandidateContext,
+  getCanonicalLocation,
   getSuggestedCanonicals,
   linkSubstrateToCanonical,
   listCandidates,
@@ -201,6 +202,12 @@ export default function LocationCandidates() {
     canonicalId: string
     label: string
   } | null>(null)
+  const [linkedToast, setLinkedToast] = useState<{
+    canonicalId: string
+    canonicalLabel: string
+    candidateLabel: string
+  } | null>(null)
+  const [linkingSuggestedId, setLinkingSuggestedId] = useState<number | null>(null)
 
   const createModalCandidate = useMemo(
     () => (createModalId === null ? undefined : candidates.find((x) => x.id === createModalId)),
@@ -499,6 +506,34 @@ export default function LocationCandidates() {
     }
   }
 
+  async function linkCandidateToSuggestedCanonical(c: Candidate) {
+    if (!projectSlug) return
+    const cid = (c.canonical_suggestion?.stylebook_location_canonical_id ?? "").trim()
+    if (!cid) return
+    setLinkingSuggestedId(c.id)
+    setError(null)
+    try {
+      await linkSubstrateToCanonical(c.id, projectSlug, cid)
+      let canonLabel = cid
+      try {
+        const canon = await getCanonicalLocation(cid, projectSlug)
+        canonLabel = (canon.label ?? "").trim() || cid
+      } catch {
+        // ignore; fall back to id
+      }
+      setLinkedToast({
+        canonicalId: cid,
+        canonicalLabel: canonLabel,
+        candidateLabel: (c.suggested_name ?? "").trim() || `Location ${c.id}`,
+      })
+      await refreshListQuiet()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Link failed")
+    } finally {
+      setLinkingSuggestedId(null)
+    }
+  }
+
   async function handleDefer(c: Candidate) {
     if (!projectSlug) return
     setDeferringId(c.id)
@@ -609,6 +644,43 @@ export default function LocationCandidates() {
                 variant="ghost"
                 className="-mr-1 -mt-1 h-8 w-8 shrink-0"
                 onClick={() => setCreatedToast(null)}
+                aria-label="Dismiss"
+              >
+                <X className="h-4 w-4" />
+              </Button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+      {linkedToast ? (
+        <div className="fixed bottom-6 right-6 z-50 w-max max-w-[calc(100vw-3rem)]">
+          <div
+            role="status"
+            className="rounded-xl border border-primary/25 bg-card text-card-foreground shadow-xl ring-2 ring-primary/15"
+          >
+            <div className="flex items-start gap-3 p-4 pr-2">
+              <CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0 text-primary" aria-hidden />
+              <div className="flex min-w-0 max-w-[min(28rem,calc(100vw-5.5rem))] flex-col gap-1.5">
+                <div className="text-sm font-semibold leading-none">Linked to canonical</div>
+                <div className="text-sm text-muted-foreground">
+                  <span className="font-medium text-foreground break-words">
+                    {linkedToast.candidateLabel}
+                  </span>{" "}
+                  →{" "}
+                  <Link
+                    to={`/locations/canonical/${linkedToast.canonicalId}?project=${encodeURIComponent(projectSlug)}`}
+                    className="font-medium text-foreground underline-offset-4 hover:underline break-words"
+                  >
+                    {linkedToast.canonicalLabel}
+                  </Link>
+                </div>
+              </div>
+              <Button
+                type="button"
+                size="icon"
+                variant="ghost"
+                className="-mr-1 -mt-1 h-8 w-8 shrink-0"
+                onClick={() => setLinkedToast(null)}
                 aria-label="Dismiss"
               >
                 <X className="h-4 w-4" />
@@ -737,6 +809,11 @@ export default function LocationCandidates() {
                     const savedNoteText = String(contextById[c.id]?.note ?? c.note ?? "").trim()
                     const rowSug = suggestedRowAction(c)
                     const rowSugLabel = suggestedActionShortLabel(c)
+                    const suggestedCanonicalId =
+                      rowSug === "link" &&
+                      c.canonical_suggestion?.stylebook_location_canonical_id != null
+                        ? String(c.canonical_suggestion.stylebook_location_canonical_id).trim()
+                        : ""
                     return (
                     <Fragment key={c.id}>
                       <TableRow id={`candidate-row-${c.id}`}>
@@ -811,23 +888,36 @@ export default function LocationCandidates() {
                                   "ring-2 ring-primary ring-offset-2 ring-offset-background shadow-sm",
                               )}
                               title={
-                                rowSug === "link"
-                                  ? "Suggested: link to existing canonical"
+                                rowSug === "link" && suggestedCanonicalId
+                                  ? "Suggested: link now"
+                                  : rowSug === "link"
+                                    ? "Suggested: link to existing canonical"
+                                    : "Link to existing canonical"
+                              }
+                              aria-label={
+                                rowSug === "link" && suggestedCanonicalId
+                                  ? "Link to suggested canonical"
                                   : "Link to existing canonical"
                               }
-                              aria-label="Link to existing canonical"
-                              disabled={acceptingId === c.id || deferringId === c.id}
+                              disabled={
+                                acceptingId === c.id ||
+                                deferringId === c.id ||
+                                linkingSuggestedId === c.id
+                              }
                               onClick={() => {
+                                if (rowSug === "link" && suggestedCanonicalId) {
+                                  void linkCandidateToSuggestedCanonical(c)
+                                  return
+                                }
                                 setLinkModalId(c.id)
-                                const preId =
-                                  rowSug === "link" &&
-                                  c.canonical_suggestion?.stylebook_location_canonical_id != null
-                                    ? c.canonical_suggestion.stylebook_location_canonical_id
-                                    : null
-                                setLinkModalInitialCanonicalId(preId)
+                                setLinkModalInitialCanonicalId(null)
                               }}
                             >
-                              <Link2 className="h-4 w-4" aria-hidden />
+                              {linkingSuggestedId === c.id ? (
+                                <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+                              ) : (
+                                <Link2 className="h-4 w-4" aria-hidden />
+                              )}
                             </Button>
                             <Button
                               type="button"
@@ -1018,6 +1108,15 @@ export default function LocationCandidates() {
         substrateLocationId={linkModalId}
         initialCanonicalId={linkModalInitialCanonicalId}
         title="Link candidate to canonical"
+        onLinked={({ id, label }) => {
+          setLinkedToast({
+            canonicalId: id,
+            canonicalLabel: label,
+            candidateLabel:
+              (candidates.find((c) => c.id === linkModalId)?.suggested_name ?? "").trim() ||
+              (linkModalId != null ? `Location ${linkModalId}` : "Location"),
+          })
+        }}
         onDone={() => void refreshListQuiet()}
       />
 

--- a/apps/stylebook-ui/src/pages/LocationCandidates.tsx
+++ b/apps/stylebook-ui/src/pages/LocationCandidates.tsx
@@ -196,6 +196,8 @@ export default function LocationCandidates() {
   const [toastFollowupError, setToastFollowupError] = useState<string | null>(null)
   const [toastFollowupRows, setToastFollowupRows] = useState<Candidate[]>([])
   const [potentialLinksOpen, setPotentialLinksOpen] = useState(false)
+  /** Opacity transition before clearing `createdToast` after auto-dismiss timer. */
+  const [canonicalCreatedToastLeaving, setCanonicalCreatedToastLeaving] = useState(false)
   const [toastLinkBusyId, setToastLinkBusyId] = useState<number | null>(null)
   const [toastLinkError, setToastLinkError] = useState<string | null>(null)
   const [createLinkNudge, setCreateLinkNudge] = useState<{
@@ -428,6 +430,31 @@ export default function LocationCandidates() {
     void prefetchToastFollowupCandidates()
   }, [createdToast, projectSlug, prefetchToastFollowupCandidates])
 
+  useEffect(() => {
+    if (!createdToast) {
+      setCanonicalCreatedToastLeaving(false)
+      return
+    }
+    setCanonicalCreatedToastLeaving(false)
+    if (toastFollowupLoading || toastFollowupRows.length > 0) {
+      return
+    }
+
+    const timeouts = { main: 0 as number, fade: undefined as number | undefined }
+    timeouts.main = window.setTimeout(() => {
+      setCanonicalCreatedToastLeaving(true)
+      timeouts.fade = window.setTimeout(() => {
+        setCreatedToast(null)
+        setCanonicalCreatedToastLeaving(false)
+      }, 300)
+    }, 3000)
+
+    return () => {
+      window.clearTimeout(timeouts.main)
+      if (timeouts.fade !== undefined) window.clearTimeout(timeouts.fade)
+    }
+  }, [createdToast, toastFollowupLoading, toastFollowupRows.length])
+
   function defaultNewCanonicalLabel(c: Candidate): string {
     const fromName = (c.suggested_name ?? "").trim()
     if (fromName) return fromName
@@ -600,7 +627,10 @@ export default function LocationCandidates() {
         <div className="fixed bottom-6 right-6 z-50 w-max max-w-[calc(100vw-3rem)]">
           <div
             role="status"
-            className="rounded-xl border border-primary/25 bg-card text-card-foreground shadow-xl ring-2 ring-primary/15"
+            className={cn(
+              "rounded-xl border border-primary/25 bg-card text-card-foreground shadow-xl ring-2 ring-primary/15 transition-opacity duration-300",
+              canonicalCreatedToastLeaving ? "opacity-0" : "opacity-100",
+            )}
           >
             <div className="flex items-start gap-3 p-4 pr-2">
               <CheckCircle2
@@ -643,7 +673,10 @@ export default function LocationCandidates() {
                 size="icon"
                 variant="ghost"
                 className="-mr-1 -mt-1 h-8 w-8 shrink-0"
-                onClick={() => setCreatedToast(null)}
+                onClick={() => {
+                  setCanonicalCreatedToastLeaving(false)
+                  setCreatedToast(null)
+                }}
                 aria-label="Dismiss"
               >
                 <X className="h-4 w-4" />

--- a/apps/stylebook-ui/src/pages/LocationDetail.tsx
+++ b/apps/stylebook-ui/src/pages/LocationDetail.tsx
@@ -4,6 +4,7 @@ import {
   deleteCanonicalLocation,
   getCanonicalLocation,
   getCanonicalLocationMentions,
+  getLocation,
   listCanonicalLinkedSubstrates,
   patchCanonicalLocation,
   unlinkSubstrateFromCanonical,
@@ -129,6 +130,7 @@ function axisAlignedRectangleDraft(geometry: Record<string, unknown> | null): bo
 
 function geometryToFeatureCollections(
   geometry: Record<string, unknown> | null,
+  opts?: { featureId?: string; label?: string; group?: string },
 ): { points: unknown; polygons: unknown } {
   if (!geometry || typeof geometry !== "object") {
     return {
@@ -136,6 +138,10 @@ function geometryToFeatureCollections(
       polygons: { type: "FeatureCollection", features: [] },
     }
   }
+
+  const featureId = opts?.featureId ?? "canonical"
+  const label = opts?.label ?? "Canonical"
+  const group = opts?.group ?? "canonical"
 
   const g = geometry as Partial<GeoJsonGeometry>
   const type = typeof g.type === "string" ? g.type : null
@@ -148,7 +154,7 @@ function geometryToFeatureCollections(
         features: [
           {
             type: "Feature",
-            properties: { id: "canonical", label: "Canonical", group: "canonical" },
+            properties: { id: featureId, label, group },
             geometry: { type: "Point", coordinates: coords },
           },
         ],
@@ -169,7 +175,7 @@ function geometryToFeatureCollections(
         features: [
           {
             type: "Feature",
-            properties: { id: "canonical", label: "Canonical", group: "canonical" },
+            properties: { id: featureId, label, group },
             geometry: { type, coordinates: g.coordinates },
           },
         ],
@@ -213,6 +219,14 @@ export default function LocationDetail() {
   const [mentionsLoading, setMentionsLoading] = useState(false)
   const [moveSubstrateId, setMoveSubstrateId] = useState<number | null>(null)
   const [unlinkingId, setUnlinkingId] = useState<number | null>(null)
+  const [substrateGeometryOpen, setSubstrateGeometryOpen] = useState(false)
+  const [substrateGeometryLoading, setSubstrateGeometryLoading] = useState(false)
+  const [substrateGeometrySubstrate, setSubstrateGeometrySubstrate] =
+    useState<LinkedSubstrateItem | null>(null)
+  const [substrateGeometryJson, setSubstrateGeometryJson] = useState<Record<string, unknown> | null>(
+    null,
+  )
+  const [adoptingSubstrateGeometry, setAdoptingSubstrateGeometry] = useState(false)
   const prevMentionCountRef = useRef<number | null>(null)
   const prevSubstrateCountRef = useRef<number | null>(null)
   const lastCanonicalKeyRef = useRef<string>("")
@@ -437,7 +451,11 @@ export default function LocationDetail() {
   const geometrySource = geometryEditing ? geometryDraft : geometry
 
   const leafletCollections = useMemo(() => {
-    const base = geometryToFeatureCollections(geometrySource as any)
+    const base = geometryToFeatureCollections(geometrySource as any, {
+      featureId: "canonical",
+      label: "Canonical",
+      group: "canonical",
+    })
 
     const stripCanonicalPolygon = (polygons: any) => {
       const fc = polygons as any
@@ -460,6 +478,48 @@ export default function LocationDetail() {
       polygons: hideCanonicalPolygon ? stripCanonicalPolygon(base.polygons) : base.polygons,
     }
   }, [geometryAddMode, geometryDraft, geometryEditing, geometrySource, rectanglePreview])
+
+  const openSubstrateGeometry = useCallback(
+    async (sub: LinkedSubstrateItem) => {
+      if (!projectSlug) return
+      setSubstrateGeometrySubstrate(sub)
+      setSubstrateGeometryJson(null)
+      setSubstrateGeometryOpen(true)
+      setSubstrateGeometryLoading(true)
+      try {
+        const row = await getLocation(sub.id, projectSlug)
+        const g = (row.geometry_json as Record<string, unknown> | undefined) ?? null
+        setSubstrateGeometryJson(g)
+      } catch (e) {
+        showError(e instanceof Error ? e.message : "Could not load substrate geometry")
+      } finally {
+        setSubstrateGeometryLoading(false)
+      }
+    },
+    [projectSlug, showError],
+  )
+
+  const handleAdoptSubstrateGeometry = useCallback(async () => {
+    if (!canonical || !projectSlug || !substrateGeometrySubstrate) return
+    if (!substrateGeometryJson || typeof substrateGeometryJson !== "object") return
+    setAdoptingSubstrateGeometry(true)
+    try {
+      await updateCanonicalLocationGeometry(canonical.id, projectSlug, substrateGeometryJson)
+      await loadCanonical(canonical.id, projectSlug, true)
+      setSubstrateGeometryOpen(false)
+    } catch (e) {
+      showError(e instanceof Error ? e.message : "Could not adopt geometry")
+    } finally {
+      setAdoptingSubstrateGeometry(false)
+    }
+  }, [
+    canonical,
+    loadCanonical,
+    projectSlug,
+    showError,
+    substrateGeometryJson,
+    substrateGeometrySubstrate,
+  ])
 
   const leafletInitialCenter = useMemo((): [number, number] | null => {
     const g = (geometryEditing ? geometryDraft : geometry) as Record<string, unknown> | null
@@ -861,7 +921,16 @@ export default function LocationDetail() {
                     <Fragment key={`group-${s.id}`}>
                       <TableRow className="bg-muted/50 border-t">
                         <TableCell colSpan={4} className="align-top py-3">
-                          <div className="font-medium">{s.name}</div>
+                          <div className="flex items-center gap-2 min-w-0">
+                            <div className="font-medium min-w-0 break-words">{s.name}</div>
+                            <button
+                              type="button"
+                              className="text-xs text-primary hover:underline shrink-0"
+                              onClick={() => void openSubstrateGeometry(s)}
+                            >
+                              View geometry
+                            </button>
+                          </div>
                           <div className="text-xs text-muted-foreground mt-0.5 break-words">
                             {(s.location_type || "").trim()
                               ? placeExtractTypeLabel(s.location_type)
@@ -975,6 +1044,74 @@ export default function LocationDetail() {
         projectSlug={projectSlug}
         entityDisplayName={canonical.label}
       />
+
+      <Dialog open={substrateGeometryOpen} onOpenChange={setSubstrateGeometryOpen}>
+        <DialogContent className="max-w-3xl">
+          <DialogHeader>
+            <DialogTitle>Substrate geometry</DialogTitle>
+            <DialogDescription>
+              {substrateGeometrySubstrate ? substrateGeometrySubstrate.name : "—"}
+            </DialogDescription>
+          </DialogHeader>
+
+          {substrateGeometryLoading ? (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground py-4">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Loading geometry…
+            </div>
+          ) : !substrateGeometryJson ? (
+            <p className="text-sm text-muted-foreground">No geometry found on this substrate.</p>
+          ) : (
+            <div className="space-y-3">
+              <div className="h-[18rem] rounded-md border overflow-hidden">
+                <LeafletMap
+                  points={
+                    geometryToFeatureCollections(substrateGeometryJson, {
+                      featureId: "substrate",
+                      label: "Substrate",
+                      group: "substrate",
+                    }).points as any
+                  }
+                  polygons={
+                    geometryToFeatureCollections(substrateGeometryJson, {
+                      featureId: "substrate",
+                      label: "Substrate",
+                      group: "substrate",
+                    }).polygons as any
+                  }
+                  showPopups={false}
+                  fitToData
+                  initialCenter={ADD_GEOMETRY_MAP_CENTER}
+                  initialZoom={ADD_GEOMETRY_MAP_ZOOM}
+                />
+              </div>
+              <div className="rounded-md border bg-muted/30 p-3">
+                <pre className="text-xs whitespace-pre-wrap break-words">
+                  {JSON.stringify(substrateGeometryJson, null, 2)}
+                </pre>
+              </div>
+            </div>
+          )}
+
+          <DialogFooter className="gap-2">
+            <Button variant="outline" onClick={() => setSubstrateGeometryOpen(false)}>
+              Close
+            </Button>
+            <Button
+              variant="secondary"
+              disabled={
+                substrateGeometryLoading ||
+                adoptingSubstrateGeometry ||
+                !substrateGeometryJson ||
+                !canonical
+              }
+              onClick={() => void handleAdoptSubstrateGeometry()}
+            >
+              {adoptingSubstrateGeometry ? "Adopting…" : "Adopt for canonical"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
         <DialogContent>

--- a/apps/stylebook-ui/src/pages/LocationDetail.tsx
+++ b/apps/stylebook-ui/src/pages/LocationDetail.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useCallback, useEffect, useMemo, useState } from "react"
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useNavigate, useParams, useSearchParams } from "react-router-dom"
 import {
   deleteCanonicalLocation,
@@ -213,6 +213,19 @@ export default function LocationDetail() {
   const [mentionsLoading, setMentionsLoading] = useState(false)
   const [moveSubstrateId, setMoveSubstrateId] = useState<number | null>(null)
   const [unlinkingId, setUnlinkingId] = useState<number | null>(null)
+  const prevMentionCountRef = useRef<number | null>(null)
+  const prevSubstrateCountRef = useRef<number | null>(null)
+  const lastCanonicalKeyRef = useRef<string>("")
+
+  useEffect(() => {
+    const key = `${projectSlug}:${id ?? ""}`
+    if (key !== lastCanonicalKeyRef.current) {
+      lastCanonicalKeyRef.current = key
+      prevMentionCountRef.current = null
+      prevSubstrateCountRef.current = null
+    }
+  }, [id, projectSlug])
+
   useEffect(() => {
     const slug = searchParams.get("project") || ""
     setProjectSlug(slug)
@@ -282,7 +295,7 @@ export default function LocationDetail() {
       await loadSubstrates(id, projectSlug, quiet)
       await loadMentions(id, projectSlug, quiet)
     },
-    [id, projectSlug, loadMentions, loadSubstrates],
+    [id, projectSlug, loadCanonical, loadMentions, loadSubstrates],
   )
 
   const mentionsBySubstrateId = useMemo(() => {
@@ -354,7 +367,7 @@ export default function LocationDetail() {
     }
   }
 
-  const onDelete = async () => {
+  const onDelete = useCallback(async () => {
     if (!canonical || !id || !projectSlug) return
     setDeleting(true)
     try {
@@ -366,7 +379,60 @@ export default function LocationDetail() {
       setDeleting(false)
       setDeleteOpen(false)
     }
-  }
+  }, [canonical, id, navigate, projectSlug, showError])
+
+  useEffect(() => {
+    if (!id || !projectSlug) return
+    if (mentionsLoading || substratesLoading) return
+
+    const mentionCount = mentions.length
+    const substrateCount = substrates.length
+
+    const prevMentions = prevMentionCountRef.current
+    const prevSubs = prevSubstrateCountRef.current
+
+    // Establish baseline after first successful refresh for this canonical.
+    if (prevMentions === null || prevSubs === null) {
+      prevMentionCountRef.current = mentionCount
+      prevSubstrateCountRef.current = substrateCount
+      return
+    }
+
+    const mentionsCleared = prevMentions > 0 && mentionCount === 0
+    const noLinkedSubstrates = substrateCount === 0
+
+    if (mentionsCleared && noLinkedSubstrates) {
+      void (async () => {
+        const ok = await showConfirm(
+          "All mentions for this canonical have been removed. Would you like to delete it?",
+          {
+            title: "Delete canonical?",
+            confirmLabel: "Delete canonical",
+            cancelLabel: "Keep",
+            destructive: true,
+          },
+        )
+        if (ok) {
+          await onDelete()
+        }
+        prevMentionCountRef.current = mentionCount
+        prevSubstrateCountRef.current = substrateCount
+      })()
+      return
+    }
+
+    prevMentionCountRef.current = mentionCount
+    prevSubstrateCountRef.current = substrateCount
+  }, [
+    id,
+    projectSlug,
+    mentions,
+    mentionsLoading,
+    substrates,
+    substratesLoading,
+    showConfirm,
+    onDelete,
+  ])
 
   const geometrySource = geometryEditing ? geometryDraft : geometry
 

--- a/apps/stylebook-ui/src/pages/LocationDetail.tsx
+++ b/apps/stylebook-ui/src/pages/LocationDetail.tsx
@@ -449,6 +449,8 @@ export default function LocationDetail() {
   ])
 
   const geometrySource = geometryEditing ? geometryDraft : geometry
+  const geometryDraftIsMultiPolygon = geometryEditing && isMultiPolygonGeometry(geometryDraft)
+  const allowGeometryMapEditing = geometryEditing && !geometryDraftIsMultiPolygon
 
   const leafletCollections = useMemo(() => {
     const base = geometryToFeatureCollections(geometrySource as any, {
@@ -694,74 +696,27 @@ export default function LocationDetail() {
                 </Button>
               </>
             ) : (
-              <>
-                {isMultiPolygonGeometry(geometry) && geometry ? (
-                  <>
-                    <Button
-                      variant="outline"
-                      onClick={() => {
-                        // MultiPolygons are not editable in-place, but we allow replacement by
-                        // starting a fresh draft (point / rectangle).
-                        setGeometryDraft(null)
-                        setGeometryAddMode(null)
-                        setRectanglePreview(null)
-                        setGeometryEditing(true)
-                      }}
-                    >
-                      Replace geometry
-                    </Button>
-                    <Button
-                      variant="destructive"
-                      onClick={() => {
-                        void (async () => {
-                          const ok = await showConfirm("Delete this geometry?", {
-                            title: "Delete geometry",
-                            confirmLabel: "Delete",
-                            destructive: true,
-                          })
-                          if (!ok || !canonical || !projectSlug) return
-                          setGeometrySaving(true)
-                          try {
-                            await updateCanonicalLocationGeometry(canonical.id, projectSlug, null)
-                            await loadCanonical(canonical.id, projectSlug, true)
-                          } catch (e) {
-                            console.error(e)
-                            showError(
-                              e instanceof Error ? e.message : "Save geometry failed",
-                            )
-                          } finally {
-                            setGeometrySaving(false)
-                          }
-                        })()
-                      }}
-                      disabled={geometrySaving}
-                    >
-                      Delete geometry
-                    </Button>
-                  </>
-                ) : (
-                  <Button
-                    variant="outline"
-                    onClick={() => {
-                      setGeometryDraft(geometry)
-                      setGeometryAddMode(null)
-                      setRectanglePreview(null)
-                      setGeometryEditing(true)
-                    }}
-                  >
-                    Edit geography
-                  </Button>
-                )}
-              </>
+              <Button
+                variant="outline"
+                onClick={() => {
+                  setGeometryDraft(geometry)
+                  setGeometryAddMode(null)
+                  setRectanglePreview(null)
+                  setGeometryEditing(true)
+                }}
+              >
+                Edit geography
+              </Button>
             )}
           </div>
         </CardHeader>
         <CardContent className="space-y-3">
-          {!geometryEditing && isMultiPolygonGeometry(geometry) ? (
+          {geometryEditing && isMultiPolygonGeometry(geometryDraft) ? (
             <Alert>
               <Info className="h-4 w-4" />
               <AlertDescription>
-                MultiPolygon geometries can’t be edited in-place here, but you can delete or replace them.
+                Editing is disabled for MultiPolygon geometries. These complex geometries contain multiple polygons and
+                require specialized editing tools. You can delete the geometry, then add a point or rectangle replacement.
               </AlertDescription>
             </Alert>
           ) : null}
@@ -833,39 +788,41 @@ export default function LocationDetail() {
             <LeafletMap
               points={leafletCollections.points as any}
               polygons={leafletCollections.polygons as any}
-              geocoder={geometryEditing}
+              geocoder={allowGeometryMapEditing}
               showPopups={false}
               // While editing, geometry updates constantly (drag/resize). Auto fitBounds would fight manual zoom.
-              fitToData={!geometryEditing}
+              fitToData={!allowGeometryMapEditing}
               initialCenter={
-                geometryEditing &&
+                allowGeometryMapEditing &&
                 !geometryDraft &&
                 (geometryAddMode === "point" || geometryAddMode === "rectangle")
                   ? ADD_GEOMETRY_MAP_CENTER
                   : leafletInitialCenter
               }
               initialZoom={
-                geometryEditing &&
+                allowGeometryMapEditing &&
                 !geometryDraft &&
                 (geometryAddMode === "point" || geometryAddMode === "rectangle")
                   ? ADD_GEOMETRY_MAP_ZOOM
                   : null
               }
               interactiveWhenEmpty={
-                geometryEditing && geometryAddMode === "point" && !geometryDraft
+                allowGeometryMapEditing && geometryAddMode === "point" && !geometryDraft
               }
               tileUrl={
-                geometryEditing
+                allowGeometryMapEditing
                   ? "https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png"
                   : undefined
               }
               tileAttribution={
-                geometryEditing
+                allowGeometryMapEditing
                   ? '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/attributions">CARTO</a>'
                   : undefined
               }
               onMapClick={
-                geometryEditing && geometryAddMode === "point" && (!geometryDraft || isPointGeometry(geometryDraft))
+                allowGeometryMapEditing &&
+                geometryAddMode === "point" &&
+                (!geometryDraft || isPointGeometry(geometryDraft))
                   ? ({ latlng }) => {
                       setGeometryDraft({ type: "Point", coordinates: [latlng.lng, latlng.lat] })
                       setGeometryAddMode(null)
@@ -873,7 +830,9 @@ export default function LocationDetail() {
                   : undefined
               }
               editablePoint={
-                geometryEditing && isPointGeometry(geometryDraft) && geometryAddMode !== "rectangle"
+                allowGeometryMapEditing &&
+                isPointGeometry(geometryDraft) &&
+                geometryAddMode !== "rectangle"
                   ? {
                       featureId: "canonical",
                       onChange: ({ lng, lat }) =>
@@ -881,9 +840,9 @@ export default function LocationDetail() {
                     }
                   : null
               }
-              rectanglePreview={geometryEditing ? rectanglePreview : null}
+              rectanglePreview={allowGeometryMapEditing ? rectanglePreview : null}
               editableRectangle={
-                geometryEditing &&
+                allowGeometryMapEditing &&
                 axisAlignedRectangleDraft(geometryDraft) &&
                 geometryAddMode !== "rectangle" &&
                 boundsFromPolygonGeometry(geometryDraft as any)
@@ -907,7 +866,7 @@ export default function LocationDetail() {
                   : null
               }
               rectangleDraw={
-                geometryEditing && geometryAddMode === "rectangle"
+                allowGeometryMapEditing && geometryAddMode === "rectangle"
                   ? {
                       enabled: true,
                       onPreview: setRectanglePreview,
@@ -928,7 +887,7 @@ export default function LocationDetail() {
               }
             />
           </div>
-          {geometryEditing ? (
+          {geometryEditing && !geometryDraftIsMultiPolygon ? (
             <SimpleGeoJsonGeometry value={geometryDraft} onChange={setGeometryDraft} />
           ) : null}
         </CardContent>

--- a/apps/stylebook-ui/src/pages/LocationDetail.tsx
+++ b/apps/stylebook-ui/src/pages/LocationDetail.tsx
@@ -694,18 +694,65 @@ export default function LocationDetail() {
                 </Button>
               </>
             ) : (
-              <Button
-                variant="outline"
-                onClick={() => {
-                  setGeometryDraft(geometry)
-                  setGeometryAddMode(null)
-                  setRectanglePreview(null)
-                  setGeometryEditing(true)
-                }}
-                disabled={isMultiPolygonGeometry(geometry)}
-              >
-                Edit geography
-              </Button>
+              <>
+                {isMultiPolygonGeometry(geometry) && geometry ? (
+                  <>
+                    <Button
+                      variant="outline"
+                      onClick={() => {
+                        // MultiPolygons are not editable in-place, but we allow replacement by
+                        // starting a fresh draft (point / rectangle).
+                        setGeometryDraft(null)
+                        setGeometryAddMode(null)
+                        setRectanglePreview(null)
+                        setGeometryEditing(true)
+                      }}
+                    >
+                      Replace geometry
+                    </Button>
+                    <Button
+                      variant="destructive"
+                      onClick={() => {
+                        void (async () => {
+                          const ok = await showConfirm("Delete this geometry?", {
+                            title: "Delete geometry",
+                            confirmLabel: "Delete",
+                            destructive: true,
+                          })
+                          if (!ok || !canonical || !projectSlug) return
+                          setGeometrySaving(true)
+                          try {
+                            await updateCanonicalLocationGeometry(canonical.id, projectSlug, null)
+                            await loadCanonical(canonical.id, projectSlug, true)
+                          } catch (e) {
+                            console.error(e)
+                            showError(
+                              e instanceof Error ? e.message : "Save geometry failed",
+                            )
+                          } finally {
+                            setGeometrySaving(false)
+                          }
+                        })()
+                      }}
+                      disabled={geometrySaving}
+                    >
+                      Delete geometry
+                    </Button>
+                  </>
+                ) : (
+                  <Button
+                    variant="outline"
+                    onClick={() => {
+                      setGeometryDraft(geometry)
+                      setGeometryAddMode(null)
+                      setRectanglePreview(null)
+                      setGeometryEditing(true)
+                    }}
+                  >
+                    Edit geography
+                  </Button>
+                )}
+              </>
             )}
           </div>
         </CardHeader>
@@ -714,8 +761,7 @@ export default function LocationDetail() {
             <Alert>
               <Info className="h-4 w-4" />
               <AlertDescription>
-                Editing is disabled for MultiPolygon geometries. These complex geometries contain multiple polygons and
-                require specialized editing tools.
+                MultiPolygon geometries can’t be edited in-place here, but you can delete or replace them.
               </AlertDescription>
             </Alert>
           ) : null}

--- a/apps/stylebook-ui/src/pages/LocationDetail.tsx
+++ b/apps/stylebook-ui/src/pages/LocationDetail.tsx
@@ -632,7 +632,9 @@ export default function LocationDetail() {
                 placeholder="e.g. city, neighborhood"
               />
             ) : (
-              <p className="text-sm mt-1.5">{canonical.location_type || "—"}</p>
+              <p className="text-sm mt-1.5">
+                {canonical.location_type ? placeExtractTypeLabel(canonical.location_type) : "—"}
+              </p>
             )}
           </div>
           <div>
@@ -909,93 +911,94 @@ export default function LocationDetail() {
           ) : substrates.length === 0 ? (
             <p className="text-sm text-muted-foreground">No linked substrate places.</p>
           ) : (
-            <Table className="table-fixed w-full">
-              <TableHeader>
-                <TableRow>
-                  <TableHead className="w-[26%] min-w-[9rem]">Place / article</TableHead>
-                  <TableHead className="w-[6.5rem] min-w-[5.5rem]">Nature</TableHead>
-                  <TableHead className="w-[10rem]">Type / role</TableHead>
-                  <TableHead>Quoted text</TableHead>
-                  <TableHead className="w-[12rem] min-w-[12rem] text-right">Actions</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {substrates.map((s) => {
-                  const group = mentionsBySubstrateId.get(s.id) ?? []
-                  return (
-                    <Fragment key={`group-${s.id}`}>
-                      <TableRow className="bg-muted/50 border-t">
-                        <TableCell colSpan={4} className="align-top py-3">
-                          <div className="flex items-center gap-2 min-w-0">
-                            <div className="font-medium min-w-0 break-words">{s.name}</div>
-                            <button
-                              type="button"
-                              className="text-xs text-primary hover:underline shrink-0"
-                              onClick={() => void openSubstrateGeometry(s)}
-                            >
-                              View geometry
-                            </button>
-                          </div>
-                          <div className="text-xs text-muted-foreground mt-0.5 break-words">
-                            {(s.location_type || "").trim()
-                              ? placeExtractTypeLabel(s.location_type)
-                              : "—"}{" "}
-                            <span className="text-muted-foreground/70">·</span>{" "}
-                            {(s.formatted_address ?? "").trim() || "—"}
-                          </div>
-                        </TableCell>
-                        <TableCell className="text-right align-top py-3 w-[12rem] min-w-[12rem]">
-                          <div className="flex flex-wrap justify-end gap-2">
-                            <Button
-                              size="sm"
-                              variant="outline"
-                              className="shrink-0"
-                              disabled={unlinkingId === s.id}
-                              onClick={() => setMoveSubstrateId(s.id)}
-                            >
-                              Move…
-                            </Button>
-                            <Button
-                              size="sm"
-                              variant="secondary"
-                              className="shrink-0"
-                              disabled={unlinkingId === s.id}
-                              onClick={() => void handleUnlinkSubstrate(s)}
-                            >
-                              {unlinkingId === s.id ? "Unlinking…" : "Unlink"}
-                            </Button>
-                          </div>
-                        </TableCell>
-                      </TableRow>
-                      {group.length === 0 ? (
-                        <TableRow>
-                          <TableCell colSpan={5} className="pl-8 text-sm text-muted-foreground py-2">
-                            No article mentions for this place.
+            <div className="w-full overflow-x-auto">
+              <Table className="w-full min-w-[56rem]">
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="w-[26%] min-w-[9rem]">Place / article</TableHead>
+                    <TableHead className="w-[6.5rem] min-w-[5.5rem]">Nature</TableHead>
+                    <TableHead className="w-[10rem] min-w-[10rem]">Type / role</TableHead>
+                    <TableHead className="min-w-[18rem]">Quoted text</TableHead>
+                    <TableHead className="w-[12rem] min-w-[12rem] text-right">Actions</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {substrates.map((s) => {
+                    const group = mentionsBySubstrateId.get(s.id) ?? []
+                    return (
+                      <Fragment key={`group-${s.id}`}>
+                        <TableRow className="bg-muted/50 border-t">
+                          <TableCell colSpan={4} className="align-top py-3">
+                            <div className="flex items-center gap-2 min-w-0">
+                              <div className="font-medium min-w-0 break-words">{s.name}</div>
+                              <button
+                                type="button"
+                                className="text-xs text-primary hover:underline shrink-0"
+                                onClick={() => void openSubstrateGeometry(s)}
+                              >
+                                View geometry
+                              </button>
+                            </div>
+                            <div className="text-xs text-muted-foreground mt-0.5 break-words">
+                              {(s.location_type || "").trim()
+                                ? placeExtractTypeLabel(s.location_type)
+                                : "—"}{" "}
+                              <span className="text-muted-foreground/70">·</span>{" "}
+                              {(s.formatted_address ?? "").trim() || "—"}
+                            </div>
+                          </TableCell>
+                          <TableCell className="text-right align-top py-3 w-[12rem] min-w-[12rem]">
+                            <div className="flex flex-wrap justify-end gap-2">
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                className="shrink-0"
+                                disabled={unlinkingId === s.id}
+                                onClick={() => setMoveSubstrateId(s.id)}
+                              >
+                                Move…
+                              </Button>
+                              <Button
+                                size="sm"
+                                variant="secondary"
+                                className="shrink-0"
+                                disabled={unlinkingId === s.id}
+                                onClick={() => void handleUnlinkSubstrate(s)}
+                              >
+                                {unlinkingId === s.id ? "Unlinking…" : "Unlink"}
+                              </Button>
+                            </div>
                           </TableCell>
                         </TableRow>
-                      ) : (
-                        group.map((m) => {
-                          const articleHref = mentionArticleHref(m)
-                          const articleLabel = mentionArticleDisplayTitle(m)
-                          return (
-                          <TableRow key={m.mention_id} className="hover:bg-muted/30">
-                            <TableCell className="pl-8 align-top min-w-0">
-                              <div className="flex items-start gap-1 min-w-0">
-                                <span
-                                  className="text-muted-foreground select-none shrink-0 pt-0.5"
-                                  aria-hidden
-                                >
-                                  ↳
-                                </span>
-                                <div className="min-w-0">
-                                  {articleHref ? (
-                                    <a
-                                      href={articleHref}
-                                      className="font-medium text-primary hover:underline break-words"
-                                      target="_blank"
-                                      rel="noopener noreferrer"
-                                      title={articleLabel}
-                                    >
+                        {group.length === 0 ? (
+                          <TableRow>
+                            <TableCell colSpan={5} className="pl-8 text-sm text-muted-foreground py-2">
+                              No article mentions for this place.
+                            </TableCell>
+                          </TableRow>
+                        ) : (
+                          group.map((m) => {
+                            const articleHref = mentionArticleHref(m)
+                            const articleLabel = mentionArticleDisplayTitle(m)
+                            return (
+                            <TableRow key={m.mention_id} className="hover:bg-muted/30">
+                              <TableCell className="pl-8 align-top min-w-0">
+                                <div className="flex items-start gap-1 min-w-0">
+                                  <span
+                                    className="text-muted-foreground select-none shrink-0 pt-0.5"
+                                    aria-hidden
+                                  >
+                                    ↳
+                                  </span>
+                                  <div className="min-w-0">
+                                    {articleHref ? (
+                                      <a
+                                        href={articleHref}
+                                        className="font-medium text-primary hover:underline break-words"
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        title={articleLabel}
+                                      >
                                       {articleLabel}
                                     </a>
                                   ) : (
@@ -1033,6 +1036,7 @@ export default function LocationDetail() {
                 })}
               </TableBody>
             </Table>
+            </div>
           )}
         </CardContent>
       </Card>

--- a/apps/stylebook-ui/src/pages/LocationDetail.tsx
+++ b/apps/stylebook-ui/src/pages/LocationDetail.tsx
@@ -1046,7 +1046,7 @@ export default function LocationDetail() {
       />
 
       <Dialog open={substrateGeometryOpen} onOpenChange={setSubstrateGeometryOpen}>
-        <DialogContent className="max-w-3xl">
+        <DialogContent className="max-w-3xl max-h-[85vh] overflow-y-auto">
           <DialogHeader>
             <DialogTitle>Substrate geometry</DialogTitle>
             <DialogDescription>

--- a/apps/stylebook-ui/src/pages/Locations.tsx
+++ b/apps/stylebook-ui/src/pages/Locations.tsx
@@ -4,7 +4,7 @@ import { useAppMessage } from "@/components/AppMessageProvider"
 import {
   deleteCanonicalLocation,
   listCanonicalLocations,
-  listLocationCandidateTypes,
+  listCanonicalLocationTypes,
   type CanonicalLocation,
 } from "@/lib/api"
 import { placeExtractTypeLabel, sortReviewQueueTypeFilterOptions } from "@/lib/place-extract-type-label"
@@ -79,7 +79,7 @@ export default function Locations() {
     if (!projectSlug) return
     void (async () => {
       try {
-        const res = await listLocationCandidateTypes(projectSlug, "open")
+        const res = await listCanonicalLocationTypes(projectSlug)
         setTypes(res.types)
       } catch {
         setTypes([])

--- a/packages/backfield-stylebook/pyproject.toml
+++ b/packages/backfield-stylebook/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = "Stylebook domain helpers (canonical entities, workspace resolution)"
 requires-python = ">=3.11"
 dependencies = [
+    "number-parser>=0.3.2,<0.4",
     "pydantic>=2.0.0",
     "sqlmodel>=0.0.16",
     "backfield-db",

--- a/packages/backfield-stylebook/src/backfield_stylebook/canonical_link_matrix.py
+++ b/packages/backfield-stylebook/src/backfield_stylebook/canonical_link_matrix.py
@@ -75,3 +75,22 @@ def link_pair_allowed(substrate_lt: str | None, canonical_lt: str | None) -> boo
     if sg is None or cg is None:
         return False
     return sg is cg
+
+
+def types_are_comparable(substrate_lt: str | None, canonical_lt: str | None) -> bool:
+    """Return True when a substrate/canonical pair should be *compared* for matching.
+
+    This is intentionally **more permissive** than :func:`link_pair_allowed`, because:
+    - Canonical `location_type` may be user-defined (uploaded geometries), not from PlaceExtract.
+    - Substrate `location_type` may reflect a geocoder/LLM label that we do not control.
+
+    The strict safety decision (whether we may automatically link) remains with
+    :func:`link_pair_allowed`.
+    """
+    # Missing types: allow comparison; we can't infer incompatibility.
+    if not (substrate_lt or "").strip():
+        return True
+    if not (canonical_lt or "").strip():
+        return True
+    # Default posture: compare broadly; link narrowly.
+    return True

--- a/packages/backfield-stylebook/src/backfield_stylebook/canonical_match_score.py
+++ b/packages/backfield-stylebook/src/backfield_stylebook/canonical_match_score.py
@@ -11,6 +11,7 @@ from typing import Any, Literal
 # Collapse punctuation so "West Garfield Park, Chicago, IL" and "West Garfield Park — Chicago IL"
 # compare as the same place name for scoring.
 _LOOSE_TOKEN_RE = re.compile(r"[^a-z0-9]+")
+_ORDINAL_SUFFIX_RE = re.compile(r"\b(\d+)(st|nd|rd|th)\b", re.IGNORECASE)
 
 # Map common US state tokens so ``IL`` vs ``Illinois`` does not break token-coverage checks.
 _US_STATE_ABBR_FULL: dict[str, str] = {
@@ -129,7 +130,9 @@ def _ratio(a: str, b: str) -> float:
 
 def _loose_key(value: str) -> str:
     """Lowercase alnum tokens joined by single spaces (commas/dashes ignored)."""
-    t = _LOOSE_TOKEN_RE.sub(" ", value.strip().lower()).strip()
+    raw = value.strip().lower()
+    raw = _ORDINAL_SUFFIX_RE.sub(r"\1", raw)
+    t = _LOOSE_TOKEN_RE.sub(" ", raw).strip()
     return " ".join(t.split())
 
 

--- a/packages/backfield-stylebook/src/backfield_stylebook/canonical_match_score.py
+++ b/packages/backfield-stylebook/src/backfield_stylebook/canonical_match_score.py
@@ -8,67 +8,71 @@ from dataclasses import dataclass
 from difflib import SequenceMatcher
 from typing import Any, Literal
 
+from number_parser import parse_number, parse_ordinal
+
 # Collapse punctuation so "West Garfield Park, Chicago, IL" and "West Garfield Park — Chicago IL"
 # compare as the same place name for scoring.
 _LOOSE_TOKEN_RE = re.compile(r"[^a-z0-9]+")
 _ORDINAL_SUFFIX_RE = re.compile(r"\b(\d+)(st|nd|rd|th)\b", re.IGNORECASE)
 
-# Spelled ordinals that are two tokens after punctuation is collapsed to spaces
-# (``twenty-first`` → ``twenty first``). Applied before single-token mapping so
-# ``twenty second`` becomes ``22`` rather than ``twenty`` + ``2``.
-_COMPOUND_WORD_ORDINAL_RES: tuple[tuple[re.Pattern[str], str], ...] = tuple(
-    (re.compile(rf"\btwenty {w}\b"), str(n))
-    for w, n in (
-        ("first", 21),
-        ("second", 22),
-        ("third", 23),
-        ("fourth", 24),
-        ("fifth", 25),
-        ("sixth", 26),
-        ("seventh", 27),
-        ("eighth", 28),
-        ("ninth", 29),
-    )
-) + ((re.compile(r"\bthirty first\b"), "31"),)
+# ``number_parser.parse`` rewrites bare cardinals (``Six Flags`` → ``6 Flags``); we only use
+# :func:`parse_ordinal` / :func:`parse_number` on token windows with a cardinal guard.
+_NUMBER_PARSER_LANG = "en"
+# Longest English ordinals in practice (e.g. ``one hundred twenty first``).
+_MAX_WORD_ORDINAL_WINDOW = 12
+_CONCAT_COMPOUND_ORDINAL_RE = re.compile(
+    r"^(twenty|thirty)(first|second|third|fourth|fifth|sixth|seventh|eighth|ninth)$"
+)
 
-# English word ordinals → digits (v1: common district / civic numbering forms).
-# Applied before :data:`_ORDINAL_SUFFIX_RE` so ``fifth`` → ``5`` → consistent token sets
-# with ``5th`` / ``5`` spellings.
-_WORD_ORDINAL_TO_DIGIT: dict[str, str] = {
-    "zeroth": "0",
-    "first": "1",
-    "second": "2",
-    "third": "3",
-    "fourth": "4",
-    "fifth": "5",
-    "sixth": "6",
-    "seventh": "7",
-    "eighth": "8",
-    "ninth": "9",
-    "tenth": "10",
-    "eleventh": "11",
-    "twelfth": "12",
-    "thirteenth": "13",
-    "fourteenth": "14",
-    "fifteenth": "15",
-    "sixteenth": "16",
-    "seventeenth": "17",
-    "eighteenth": "18",
-    "nineteenth": "19",
-    "twentieth": "20",
-    # Concatenated forms (no separator) still tokenize as one "word".
-    "twentyfirst": "21",
-    "twentysecond": "22",
-    "twentythird": "23",
-    "twentyfourth": "24",
-    "twentyfifth": "25",
-    "twentysixth": "26",
-    "twentyseventh": "27",
-    "twentyeighth": "28",
-    "twentyninth": "29",
-    "thirtieth": "30",
-    "thirtyfirst": "31",
-}
+
+def _expand_concat_compound_ordinal_token(token: str) -> list[str]:
+    """Split rare glued forms (``twentyfirst``) so :func:`parse_ordinal` can read them."""
+    m = _CONCAT_COMPOUND_ORDINAL_RE.match(token)
+    if not m:
+        return [token]
+    return [m.group(1), m.group(2)]
+
+
+def _normalize_word_ordinal_tokens(tokens: list[str]) -> list[str]:
+    """Replace spelled ordinals with digit tokens using ``number-parser``.
+
+    Skips pure cardinal phrases (``twenty one``, ``six``) so we do not mimic
+    :func:`number_parser.parse` on full strings.
+    """
+    expanded: list[str] = []
+    for t in tokens:
+        expanded.extend(_expand_concat_compound_ordinal_token(t))
+    tpl = expanded
+    out: list[str] = []
+    i = 0
+    lang = _NUMBER_PARSER_LANG
+    while i < len(tpl):
+        max_w = min(_MAX_WORD_ORDINAL_WINDOW, len(tpl) - i)
+        replaced = False
+        for w in range(max_w, 1, -1):
+            phrase = " ".join(tpl[i : i + w])
+            ord_val = parse_ordinal(phrase, language=lang)
+            if ord_val is None:
+                continue
+            num_val = parse_number(phrase, language=lang)
+            if num_val is not None and num_val == ord_val:
+                continue
+            out.append(str(ord_val))
+            i += w
+            replaced = True
+            break
+        if replaced:
+            continue
+        t = tpl[i]
+        ord_val = parse_ordinal(t, language=lang)
+        num_val = parse_number(t, language=lang)
+        if ord_val is not None and not (num_val is not None and num_val == ord_val):
+            out.append(str(ord_val))
+        else:
+            out.append(t)
+        i += 1
+    return out
+
 
 # Map common US state tokens so ``IL`` vs ``Illinois`` does not break token-coverage checks.
 _US_STATE_ABBR_FULL: dict[str, str] = {
@@ -188,18 +192,12 @@ def _ratio(a: str, b: str) -> float:
 def _loose_key(value: str) -> str:
     """Lowercase alnum tokens joined by single spaces (commas/dashes ignored)."""
     raw = value.strip().lower()
-    # Collapse punctuation to spaces once so hyphenated ordinals (``twenty-first``)
-    # become two-token compounds (``twenty first``) for :data:`_COMPOUND_WORD_ORDINAL_RES`.
+    # Collapse punctuation to spaces so hyphenated ordinals (``twenty-first``) become
+    # separate tokens (``twenty``, ``first``) for :func:`_normalize_word_ordinal_tokens`.
     norm = " ".join(_LOOSE_TOKEN_RE.sub(" ", raw).split())
-    for pat, repl in _COMPOUND_WORD_ORDINAL_RES:
-        norm = pat.sub(repl, norm)
     if norm:
         toks = [t for t in norm.split() if t]
-        mapped: list[str] = []
-        for t in toks:
-            repl = _WORD_ORDINAL_TO_DIGIT.get(t)
-            mapped.append(repl if repl is not None else t)
-        norm = " ".join(mapped)
+        norm = " ".join(_normalize_word_ordinal_tokens(toks))
     norm = _ORDINAL_SUFFIX_RE.sub(r"\1", norm)
     t = _LOOSE_TOKEN_RE.sub(" ", norm).strip()
     return " ".join(t.split())

--- a/packages/backfield-stylebook/src/backfield_stylebook/canonical_match_score.py
+++ b/packages/backfield-stylebook/src/backfield_stylebook/canonical_match_score.py
@@ -13,6 +13,63 @@ from typing import Any, Literal
 _LOOSE_TOKEN_RE = re.compile(r"[^a-z0-9]+")
 _ORDINAL_SUFFIX_RE = re.compile(r"\b(\d+)(st|nd|rd|th)\b", re.IGNORECASE)
 
+# Spelled ordinals that are two tokens after punctuation is collapsed to spaces
+# (``twenty-first`` → ``twenty first``). Applied before single-token mapping so
+# ``twenty second`` becomes ``22`` rather than ``twenty`` + ``2``.
+_COMPOUND_WORD_ORDINAL_RES: tuple[tuple[re.Pattern[str], str], ...] = tuple(
+    (re.compile(rf"\btwenty {w}\b"), str(n))
+    for w, n in (
+        ("first", 21),
+        ("second", 22),
+        ("third", 23),
+        ("fourth", 24),
+        ("fifth", 25),
+        ("sixth", 26),
+        ("seventh", 27),
+        ("eighth", 28),
+        ("ninth", 29),
+    )
+) + ((re.compile(r"\bthirty first\b"), "31"),)
+
+# English word ordinals → digits (v1: common district / civic numbering forms).
+# Applied before :data:`_ORDINAL_SUFFIX_RE` so ``fifth`` → ``5`` → consistent token sets
+# with ``5th`` / ``5`` spellings.
+_WORD_ORDINAL_TO_DIGIT: dict[str, str] = {
+    "zeroth": "0",
+    "first": "1",
+    "second": "2",
+    "third": "3",
+    "fourth": "4",
+    "fifth": "5",
+    "sixth": "6",
+    "seventh": "7",
+    "eighth": "8",
+    "ninth": "9",
+    "tenth": "10",
+    "eleventh": "11",
+    "twelfth": "12",
+    "thirteenth": "13",
+    "fourteenth": "14",
+    "fifteenth": "15",
+    "sixteenth": "16",
+    "seventeenth": "17",
+    "eighteenth": "18",
+    "nineteenth": "19",
+    "twentieth": "20",
+    # Concatenated forms (no separator) still tokenize as one "word".
+    "twentyfirst": "21",
+    "twentysecond": "22",
+    "twentythird": "23",
+    "twentyfourth": "24",
+    "twentyfifth": "25",
+    "twentysixth": "26",
+    "twentyseventh": "27",
+    "twentyeighth": "28",
+    "twentyninth": "29",
+    "thirtieth": "30",
+    "thirtyfirst": "31",
+}
+
 # Map common US state tokens so ``IL`` vs ``Illinois`` does not break token-coverage checks.
 _US_STATE_ABBR_FULL: dict[str, str] = {
     "al": "alabama",
@@ -131,8 +188,20 @@ def _ratio(a: str, b: str) -> float:
 def _loose_key(value: str) -> str:
     """Lowercase alnum tokens joined by single spaces (commas/dashes ignored)."""
     raw = value.strip().lower()
-    raw = _ORDINAL_SUFFIX_RE.sub(r"\1", raw)
-    t = _LOOSE_TOKEN_RE.sub(" ", raw).strip()
+    # Collapse punctuation to spaces once so hyphenated ordinals (``twenty-first``)
+    # become two-token compounds (``twenty first``) for :data:`_COMPOUND_WORD_ORDINAL_RES`.
+    norm = " ".join(_LOOSE_TOKEN_RE.sub(" ", raw).split())
+    for pat, repl in _COMPOUND_WORD_ORDINAL_RES:
+        norm = pat.sub(repl, norm)
+    if norm:
+        toks = [t for t in norm.split() if t]
+        mapped: list[str] = []
+        for t in toks:
+            repl = _WORD_ORDINAL_TO_DIGIT.get(t)
+            mapped.append(repl if repl is not None else t)
+        norm = " ".join(mapped)
+    norm = _ORDINAL_SUFFIX_RE.sub(r"\1", norm)
+    t = _LOOSE_TOKEN_RE.sub(" ", norm).strip()
     return " ".join(t.split())
 
 

--- a/packages/backfield-stylebook/src/backfield_stylebook/canonical_policy.py
+++ b/packages/backfield-stylebook/src/backfield_stylebook/canonical_policy.py
@@ -9,7 +9,11 @@ from typing import Any
 from backfield_db import StylebookLocationAlias, StylebookLocationCanonical, SubstrateLocation
 from sqlmodel import Session, select
 
-from backfield_stylebook.canonical_link_matrix import link_pair_allowed, strict_type_group
+from backfield_stylebook.canonical_link_matrix import (
+    link_pair_allowed,
+    strict_type_group,
+    types_are_comparable,
+)
 from backfield_stylebook.canonical_match_score import (
     AUTOLINK_MIN_SCORE,
     RECALL_MIN_SCORE,
@@ -243,7 +247,7 @@ def rank_scored_canonical_recall_matches(
         gate_lt = _should_apply_head_anchor_gate(location.location_type)
         if gate_lt and not _head_anchor_gate_passes(str(location.name), feat):
             sc = min(sc, RECALL_MIN_SCORE - 0.001)
-        if not link_pair_allowed(location.location_type, canon.location_type):
+        if not types_are_comparable(location.location_type, canon.location_type):
             sc = min(sc, RECALL_MIN_SCORE - 0.001)
         rows.append((recall_index, str(canon_id), str(canon.label), sc))
     rows.sort(key=lambda r: (-r[3], -r[0]))
@@ -386,6 +390,12 @@ def decide_canonical_persist_plan(
         )
         if intra_ambiguous:
             tier = "ambiguous"
+        if tier == "autolink" and best_id is not None:
+            best_canon = session.get(StylebookLocationCanonical, str(best_id))
+            best_lt = best_canon.location_type if best_canon is not None else None
+            if not link_pair_allowed(location.location_type, best_lt):
+                tier = "ambiguous"
+                intra_ambiguous = True
         if tier == "autolink" and best_id is not None:
             return CanonicalPersistPlan(
                 decision=CanonicalPersistDecision.LINK_EXISTING,

--- a/packages/backfield-stylebook/src/backfield_stylebook/canonical_policy.py
+++ b/packages/backfield-stylebook/src/backfield_stylebook/canonical_policy.py
@@ -7,7 +7,7 @@ from enum import StrEnum
 from typing import Any
 
 from backfield_db import StylebookLocationAlias, StylebookLocationCanonical, SubstrateLocation
-from sqlmodel import Session, select
+from sqlmodel import Session, col, select
 
 from backfield_stylebook.canonical_link_matrix import (
     link_pair_allowed,
@@ -254,6 +254,40 @@ def rank_scored_canonical_recall_matches(
     return [(r[1], r[2], r[3], r[0]) for r in rows]
 
 
+def _best_allowed_recall_score(
+    session: Session,
+    *,
+    substrate_location_type: str | None,
+    ranked: list[tuple[str, str, float, int]],
+) -> float | None:
+    """Return best recall score among canonicals allowed to link (strict matrix).
+
+    When we "compare broadly" for retrieval, cross-type candidates can land in the
+    ambiguous band and block materializing a new canonical even when there is no
+    *linkable* candidate. This helper lets policy treat "ambiguous but disallowed"
+    as "no match" for materialization decisions.
+    """
+    if not ranked:
+        return None
+    s_lt = (substrate_location_type or "").strip().lower()
+    if not s_lt:
+        return max(sc for _cid, _lab, sc, _idx in ranked)
+    ids = [cid for cid, _lab, _sc, _idx in ranked[:24]]
+    rows = session.exec(
+        select(StylebookLocationCanonical).where(col(StylebookLocationCanonical.id).in_(ids))
+    ).all()
+    lt_by_id: dict[str, str | None] = {}
+    for c in rows:
+        if c.id is not None:
+            lt_by_id[str(c.id)] = c.location_type
+    best: float | None = None
+    for cid, _lab, sc, _idx in ranked:
+        c_lt = lt_by_id.get(str(cid))
+        if link_pair_allowed(s_lt, c_lt):
+            best = sc if best is None else max(best, sc)
+    return best
+
+
 def _should_materialize_when_no_canonical_match(location: SubstrateLocation) -> bool:
     """After exact match + fuzzy tiers: whether to create a new canonical.
 
@@ -417,6 +451,33 @@ def decide_canonical_persist_plan(
                 ),
             )
         if tier == "ambiguous" and best_id is not None:
+            # If recall is only "ambiguous" because of cross-type candidates we would never
+            # auto-link, treat it as "no match" so the substrate may materialize its own canonical.
+            if _should_materialize_when_no_canonical_match(location):
+                best_allowed = _best_allowed_recall_score(
+                    session,
+                    substrate_location_type=location.location_type,
+                    ranked=ranked,
+                )
+                if best_allowed is None or best_allowed < RECALL_MIN_SCORE:
+                    return CanonicalPersistPlan(
+                        decision=CanonicalPersistDecision.MATERIALIZE_NEW,
+                        resolution_reasons=(
+                            {
+                                "code": "materialized_new_canonical",
+                                "had_fuzzy_recall": bool(recall_canonical_ids),
+                                "match_basis": _match_basis_for_audit(location.location_type),
+                                "head_anchor_gate_applied": _should_apply_head_anchor_gate(
+                                    location.location_type
+                                ),
+                                "fuzzy_best_score_before_materialize": float(best_score),
+                                "fuzzy_recall_canonical_ids": list(recall_canonical_ids[:24]),
+                                "fuzzy_best_link_allowed_score": float(best_allowed)
+                                if best_allowed is not None
+                                else None,
+                            },
+                        ),
+                    )
             return CanonicalPersistPlan(
                 decision=CanonicalPersistDecision.DEFER,
                 resolution_reasons=(

--- a/packages/backfield-stylebook/src/backfield_stylebook/canonical_retrieval.py
+++ b/packages/backfield-stylebook/src/backfield_stylebook/canonical_retrieval.py
@@ -8,7 +8,7 @@ from backfield_db import StylebookLocationAlias, StylebookLocationCanonical
 from sqlalchemy import or_, text
 from sqlmodel import Session, col, select
 
-from backfield_stylebook.canonical_link_matrix import link_pair_allowed
+from backfield_stylebook.canonical_link_matrix import types_are_comparable
 
 # Low threshold: precision is handled in :mod:`canonical_match_score`.
 _PG_SIMILARITY_THRESHOLD: float = 0.12
@@ -125,7 +125,7 @@ def retrieve_candidate_canonical_ids(
     all query variants. On SQLite, hints are ``None`` (scorer uses :mod:`difflib`).
 
     When ``substrate_location_type`` is set, canonicals whose ``location_type`` fails
-    :func:`link_pair_allowed` with that substrate type are dropped (order preserved).
+    :func:`types_are_comparable` with that substrate type are dropped (order preserved).
     """
     variants = _distinct_query_strings(normalized_query, query_text, formatted_address)
     if not variants:
@@ -183,7 +183,7 @@ def _filter_recall_by_substrate_type(
     out: list[tuple[str, float | None]] = []
     for cid, hint in raw:
         lt = lt_by_id.get(str(cid))
-        if link_pair_allowed(substrate_location_type, lt):
+        if types_are_comparable(substrate_location_type, lt):
             out.append((cid, hint))
         if len(out) >= limit:
             break

--- a/packages/backfield-stylebook/src/backfield_stylebook/locations.py
+++ b/packages/backfield-stylebook/src/backfield_stylebook/locations.py
@@ -12,6 +12,7 @@ from backfield_stylebook.canonical_link import (
     CANONICAL_LINK_PENDING,
     CANONICAL_LINK_WAIVED,
 )
+from backfield_stylebook.canonical_match_score import _loose_key
 from backfield_stylebook.canonical_policy import CanonicalPersistDecision, CanonicalPersistPlan
 from backfield_stylebook.canonical_slug import allocate_unique_canonical_slug
 
@@ -33,6 +34,22 @@ def assert_canonical_link_invariant(location: SubstrateLocation) -> None:
 
 def _normalize_alias_text(text: str) -> str:
     return text.strip().lower()
+
+
+def _normalized_alias_variants(normalized_alias: str) -> tuple[str, ...]:
+    """Stable variants for recall/exact matching.
+
+    We keep this conservative: only add an ordinal-stripped form so that strings like
+    ``15th Ward`` and ``Ward 15`` share more overlap in recall.
+    """
+    norm = str(normalized_alias).strip().lower()
+    if not norm:
+        return ()
+    # Use the same ordinal normalization as the scorer's loose-key path.
+    stripped = _loose_key(norm)
+    if stripped and stripped != norm:
+        return (norm, stripped)
+    return (norm,)
 
 
 def upsert_alias_for_canonical_text(
@@ -74,13 +91,14 @@ def _upsert_alias_for_canonical(
     location: SubstrateLocation,
     provenance: str,
 ) -> None:
-    upsert_alias_for_canonical_text(
-        session,
-        canon_id=canon_id,
-        alias_text=str(location.name),
-        normalized_alias=str(location.normalized_name),
-        provenance=provenance,
-    )
+    for norm in _normalized_alias_variants(str(location.normalized_name)):
+        upsert_alias_for_canonical_text(
+            session,
+            canon_id=canon_id,
+            alias_text=str(location.name),
+            normalized_alias=norm,
+            provenance=provenance,
+        )
 
 
 def refresh_aliases_for_linked_location(
@@ -171,13 +189,14 @@ def create_standalone_canonical(
     session.add(canon)
     session.flush()
     cid = str(canon.id)
-    upsert_alias_for_canonical_text(
-        session,
-        canon_id=cid,
-        alias_text=clean,
-        normalized_alias=_normalize_alias_text(clean),
-        provenance=provenance,
-    )
+    for norm in _normalized_alias_variants(_normalize_alias_text(clean)):
+        upsert_alias_for_canonical_text(
+            session,
+            canon_id=cid,
+            alias_text=clean,
+            normalized_alias=norm,
+            provenance=provenance,
+        )
     session.flush()
     return canon
 

--- a/packages/backfield-stylebook/src/backfield_stylebook/substrate_canonical_link_actions.py
+++ b/packages/backfield-stylebook/src/backfield_stylebook/substrate_canonical_link_actions.py
@@ -40,10 +40,9 @@ def rank_canonical_suggestions_for_substrate(
     if exact_cid is not None:
         canon = session.get(StylebookLocationCanonical, str(exact_cid))
         if canon is not None and int(canon.stylebook_id) == int(stylebook_id):
-            if link_pair_allowed(location.location_type, canon.location_type):
-                eid = str(exact_cid)
-                out.append((eid, str(canon.label)))
-                seen.add(eid)
+            eid = str(exact_cid)
+            out.append((eid, str(canon.label)))
+            seen.add(eid)
     for cid, lab, _sc, _idx in ranked:
         if cid in seen:
             continue
@@ -136,6 +135,7 @@ def link_substrate_to_canonical_atomic(
     location: SubstrateLocation,
     target_canonical_id: str,
     provenance: str = "stylebook_ui_link",
+    enforce_type_gate: bool = False,
 ) -> bool:
     """Attach substrate to canonical B, refresh aliases on B, prune alias on old A when safe.
 
@@ -147,7 +147,7 @@ def link_substrate_to_canonical_atomic(
     canon = session.get(StylebookLocationCanonical, tid)
     if canon is None or int(canon.stylebook_id) != int(stylebook_id):
         raise ValueError("target canonical not in this stylebook")
-    if not link_pair_allowed(location.location_type, canon.location_type):
+    if enforce_type_gate and not link_pair_allowed(location.location_type, canon.location_type):
         raise ValueError(
             "substrate location_type is incompatible with the target canonical location_type "
             "for linking"

--- a/tests/stylebook/test_canonical_match_score.py
+++ b/tests/stylebook/test_canonical_match_score.py
@@ -9,6 +9,7 @@ from backfield_stylebook.canonical_match_score import (
     RECALL_MIN_SCORE,
     CanonicalMatchFeatures,
     SubstrateMatchInput,
+    _loose_key,
     classify_recall_score,
     combined_score,
     haversine_m,
@@ -81,6 +82,25 @@ def test_compound_word_ordinal_twenty_first_normalizes() -> None:
         normalized_aliases=("congressional district 21, illinois",),
     )
     assert string_score_for_candidate(sub, feat) >= AUTOLINK_MIN_SCORE
+
+
+def test_fifty_third_spelled_ordinal_matches_digit_district() -> None:
+    sub = SubstrateMatchInput(
+        name="Fifty-Third Congressional District, Illinois",
+        normalized_name="fifty-third congressional district, illinois",
+    )
+    feat = CanonicalMatchFeatures(
+        canonical_id="1",
+        label="Congressional District 53, Illinois",
+        normalized_aliases=("congressional district 53, illinois",),
+    )
+    assert string_score_for_candidate(sub, feat) >= AUTOLINK_MIN_SCORE
+
+
+def test_loose_key_does_not_apply_full_sentence_number_parsing() -> None:
+    """Guardrail: do not use ``number_parser.parse`` semantics on whole strings."""
+    assert _loose_key("Six Flags, Gurnee, IL") == "six flags gurnee il"
+    assert _loose_key("twentyfirst ward") == "21 ward"
 
 
 def test_string_score_fuzzy_close_strings() -> None:

--- a/tests/stylebook/test_canonical_match_score.py
+++ b/tests/stylebook/test_canonical_match_score.py
@@ -57,6 +57,32 @@ def test_ordinal_suffix_normalization_makes_ward_variants_match() -> None:
     assert string_score_for_candidate(sub, feat) >= AUTOLINK_MIN_SCORE
 
 
+def test_word_ordinal_normalization_matches_digit_congressional_district() -> None:
+    sub = SubstrateMatchInput(
+        name="Fifth Congressional District, Illinois",
+        normalized_name="fifth congressional district, illinois",
+    )
+    feat = CanonicalMatchFeatures(
+        canonical_id="1",
+        label="Congressional District 5, Illinois",
+        normalized_aliases=("congressional district 5, illinois",),
+    )
+    assert string_score_for_candidate(sub, feat) >= AUTOLINK_MIN_SCORE
+
+
+def test_compound_word_ordinal_twenty_first_normalizes() -> None:
+    sub = SubstrateMatchInput(
+        name="Illinois Congressional District Twenty-First",
+        normalized_name="illinois congressional district twenty-first",
+    )
+    feat = CanonicalMatchFeatures(
+        canonical_id="1",
+        label="Congressional District 21, Illinois",
+        normalized_aliases=("congressional district 21, illinois",),
+    )
+    assert string_score_for_candidate(sub, feat) >= AUTOLINK_MIN_SCORE
+
+
 def test_string_score_fuzzy_close_strings() -> None:
     sub = SubstrateMatchInput(
         name="West Garfield Park, Chicago, IL",

--- a/tests/stylebook/test_canonical_match_score.py
+++ b/tests/stylebook/test_canonical_match_score.py
@@ -44,6 +44,19 @@ def test_loose_normalization_treats_punctuation_variants_as_exact() -> None:
     assert string_score_for_candidate(sub, feat) == 1.0
 
 
+def test_ordinal_suffix_normalization_makes_ward_variants_match() -> None:
+    sub = SubstrateMatchInput(
+        name="15th Ward, Chicago, IL",
+        normalized_name="15th ward, chicago, il",
+    )
+    feat = CanonicalMatchFeatures(
+        canonical_id="1",
+        label="Ward 15, Chicago, IL",
+        normalized_aliases=("ward 15, chicago, il",),
+    )
+    assert string_score_for_candidate(sub, feat) >= AUTOLINK_MIN_SCORE
+
+
 def test_string_score_fuzzy_close_strings() -> None:
     sub = SubstrateMatchInput(
         name="West Garfield Park, Chicago, IL",

--- a/tests/stylebook/test_canonical_type_gate.py
+++ b/tests/stylebook/test_canonical_type_gate.py
@@ -154,7 +154,7 @@ def test_natural_to_city_incompatible() -> None:
 
 
 def test_link_substrate_atomic_rejects_city_to_place() -> None:
-    """Manual link API uses the same matrix as ingest."""
+    """Manual link is an editorial override and does not enforce the type matrix."""
     engine = _make_engine()
     with Session(engine) as session:
         _, sb_id = _bootstrap(session, org_slug="linkpair")
@@ -181,17 +181,14 @@ def test_link_substrate_atomic_rejects_city_to_place() -> None:
         session.add(loc)
         session.commit()
         session.refresh(loc)
-        try:
-            link_substrate_to_canonical_atomic(
-                session,
-                stylebook_id=sb_id,
-                location=loc,
-                target_canonical_id=str(canon_place.id),
-            )
-        except ValueError as e:
-            assert "incompatible" in str(e).lower()
-        else:
-            raise AssertionError("expected ValueError")
+        changed = link_substrate_to_canonical_atomic(
+            session,
+            stylebook_id=sb_id,
+            location=loc,
+            target_canonical_id=str(canon_place.id),
+        )
+        assert changed is True
+        assert loc.stylebook_location_canonical_id == str(canon_place.id)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/stylebook/test_canonical_type_gate.py
+++ b/tests/stylebook/test_canonical_type_gate.py
@@ -268,9 +268,7 @@ def test_rank_caps_incompatible_type_below_recall() -> None:
 
     assert len(ranked) == 1
     _, _label, score, _ = ranked[0]
-    assert score < RECALL_MIN_SCORE, (
-        f"Expected address→city score below RECALL_MIN_SCORE ({RECALL_MIN_SCORE}), got {score}"
-    )
+    assert score >= RECALL_MIN_SCORE
     assert score < AUTOLINK_MIN_SCORE
 
 
@@ -327,7 +325,7 @@ def test_rank_allows_same_type_city_to_city() -> None:
 
 def test_rank_caps_intersection_to_city() -> None:
     """An intersection substrate must not autolink to a city canonical."""
-    from backfield_stylebook.canonical_match_score import RECALL_MIN_SCORE
+    from backfield_stylebook.canonical_match_score import AUTOLINK_MIN_SCORE, RECALL_MIN_SCORE
 
     engine = _make_engine()
     with Session(engine) as session:
@@ -372,7 +370,8 @@ def test_rank_caps_intersection_to_city() -> None:
 
     assert len(ranked) == 1
     _, _label, score, _ = ranked[0]
-    assert score < RECALL_MIN_SCORE
+    assert score >= RECALL_MIN_SCORE
+    assert score < AUTOLINK_MIN_SCORE
 
 
 def test_rank_allows_address_to_place() -> None:
@@ -422,6 +421,50 @@ def test_rank_allows_address_to_place() -> None:
     assert len(ranked) == 1
     _, _label, score, _ = ranked[0]
     assert score >= AUTOLINK_MIN_SCORE
+
+
+def test_rank_does_not_drop_strict_to_flexible_candidates() -> None:
+    """Recall/scoring should compare across type labels, even when strict autolink disallows."""
+    engine = _make_engine()
+    with Session(engine) as session:
+        _, sb_id = _bootstrap(session, org_slug="tg-compare-1")
+        canon = StylebookLocationCanonical(
+            stylebook_id=sb_id,
+            label="Ward 15, Chicago, IL",
+            slug="ward-15-chicago-il",
+            location_type="ward",
+            status="active",
+        )
+        session.add(canon)
+        session.commit()
+        session.refresh(canon)
+        cid = str(canon.id)
+
+        alias = StylebookLocationAlias(
+            location_canonical_id=cid,
+            alias_text="Ward 15, Chicago, IL",
+            normalized_alias="ward 15, chicago, il",
+            provenance="test",
+            suppressed=False,
+        )
+        session.add(alias)
+        session.commit()
+
+        loc = SubstrateLocation(
+            project_id=1,
+            name="15th Ward, Chicago, IL",
+            normalized_name="15th ward, chicago, il",
+            location_type="region_city",
+            identity_fingerprint="fp-compare-1",
+        )
+
+        ranked = rank_scored_canonical_recall_matches(
+            session,
+            location=loc,
+            recall=[(cid, None)],
+        )
+
+    assert len(ranked) == 1
 
 
 def test_decide_canonical_persist_plan_type_gate_prevents_city_mismatch() -> None:

--- a/tests/stylebook/test_canonical_type_gate.py
+++ b/tests/stylebook/test_canonical_type_gate.py
@@ -521,3 +521,54 @@ def test_decide_canonical_persist_plan_type_gate_prevents_city_mismatch() -> Non
     assert plan.decision != CanonicalPersistDecision.LINK_EXISTING, (
         f"Intersection should not autolink to city canonical; got {plan.decision}"
     )
+
+
+def test_ambiguous_cross_type_recall_does_not_block_materialize_new() -> None:
+    """Neighborhood should materialize when only fuzzy recall is cross-type (unlinkable)."""
+    from backfield_stylebook.canonical_policy import decide_canonical_persist_plan
+
+    engine = _make_engine()
+    with Session(engine) as session:
+        _, sb_id = _bootstrap(session, org_slug="tg-materialize-ambig-x")
+
+        # Only canonical present is a ward (not linkable to neighborhood by strict matrix),
+        # but token overlap ('Chicago, IL') will still surface it in broad recall.
+        canon = StylebookLocationCanonical(
+            stylebook_id=sb_id,
+            label="Ward 15, Chicago, IL",
+            slug="ward-15-chicago-il",
+            location_type="ward",
+            status="active",
+        )
+        session.add(canon)
+        session.commit()
+        session.refresh(canon)
+        cid = str(canon.id)
+        session.add(
+            StylebookLocationAlias(
+                location_canonical_id=cid,
+                alias_text="Ward 15, Chicago, IL",
+                normalized_alias="ward 15, chicago, il",
+                provenance="test",
+                suppressed=False,
+            )
+        )
+        session.commit()
+
+        loc = SubstrateLocation(
+            project_id=1,
+            name="Avondale, Chicago, IL",
+            normalized_name="avondale, chicago, il",
+            location_type="neighborhood",
+            status="resolved",
+            identity_fingerprint="fp-mat-ambig-x",
+        )
+        plan = decide_canonical_persist_plan(
+            session,
+            stylebook_id=sb_id,
+            places_bucket="points",
+            location=loc,
+            entry=None,
+        )
+
+    assert plan.decision == CanonicalPersistDecision.MATERIALIZE_NEW

--- a/tests/stylebook_api/test_stylebook_api.py
+++ b/tests/stylebook_api/test_stylebook_api.py
@@ -385,8 +385,10 @@ def test_create_location_creates_standalone_canonical_and_alias_no_substrate(
                 StylebookLocationAlias.location_canonical_id == cid,
             )
         ).all()
-        assert len(aliases) == 1
-        assert aliases[0].normalized_alias == "west garfield park, chicago, il"
+        norms = {str(a.normalized_alias) for a in aliases}
+        # We store a conservative ordinal/punctuation-stripped variant for better recall.
+        assert "west garfield park, chicago, il" in norms
+        assert "west garfield park chicago il" in norms
 
 
 def test_create_canonical_location_post_alias_no_substrate(

--- a/tests/stylebook_api/test_stylebook_api.py
+++ b/tests/stylebook_api/test_stylebook_api.py
@@ -446,7 +446,11 @@ def test_list_canonical_locations_type_filter(client: TestClient) -> None:
         "/v1/canonical-locations?project_slug=demo-proj&type_filter=not_a_real_type",
         headers=_service_headers(),
     )
-    assert r_bad.status_code == 400
+    # Canonical types include custom values; unknown filters are treated as "no matches" rather
+    # than a hard 400.
+    assert r_bad.status_code == 200
+    data_bad = r_bad.json()
+    assert data_bad["canonicals"] == []
 
 
 def test_list_canonical_locations_orders_by_label_case_insensitive(client: TestClient) -> None:

--- a/tests/worker/test_substrate_persistence.py
+++ b/tests/worker/test_substrate_persistence.py
@@ -171,7 +171,9 @@ def test_persist_graph_outputs_writes_article_location_mention_occurrence() -> N
         assert locations[0].canonical_link_status == CANONICAL_LINK_LINKED
         assert_canonical_link_invariant(locations[0])
         alias_rows = session.exec(select(StylebookLocationAlias)).all()
-        assert len(alias_rows) == 1
+        norms = {str(a.normalized_alias) for a in alias_rows}
+        assert "chicago, il" in norms
+        assert "chicago il" in norms
         assert alias_rows[0].normalized_alias == locations[0].normalized_name
 
         mentions = session.exec(select(SubstrateLocationMention)).all()

--- a/uv.lock
+++ b/uv.lock
@@ -187,6 +187,15 @@ wheels = [
 ]
 
 [[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
 name = "backfield-auth"
 version = "0.1.0"
 source = { editable = "packages/backfield-auth" }
@@ -255,6 +264,7 @@ version = "0.1.0"
 source = { editable = "packages/backfield-stylebook" }
 dependencies = [
     { name = "backfield-db" },
+    { name = "number-parser" },
     { name = "pydantic" },
     { name = "sqlmodel" },
 ]
@@ -262,6 +272,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "backfield-db", editable = "packages/backfield-db" },
+    { name = "number-parser", specifier = ">=0.3.2,<0.4" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "sqlmodel", specifier = ">=0.0.16" },
 ]
@@ -1363,6 +1374,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "number-parser"
+version = "0.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/c1/1a3ea159327b442d2202fda38845124a51a3abe11637cbd3111479fd815f/number-parser-0.3.2.tar.gz", hash = "sha256:7650e91afd46dec2f40396f62c2babc84645679a1ca8ecdb5292bdd252685d6a", size = 42408, upload-time = "2023-03-28T16:31:37.792Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/33/85138cd4a8561d7f1722490612d30cbfab170fd6d38021b193072eecc1db/number_parser-0.3.2-py2.py3-none-any.whl", hash = "sha256:beb20ce4c66d8e8f34dde1512a21f7c2a2aa3b068c60e230c4388d548ef3e3ca", size = 51260, upload-time = "2023-03-28T16:31:36.49Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Draft PR stacking Stylebook UI/API refinement work from `feat/stylebook-agate-integration-odds-ends`.

Highlights:
- Canonical matching / queue UX (toasts, one-click link, multipolygon geography, substrate geometry viewer + adopt, canonical list type filter).
- Location detail: responsive Mentions table, human-readable location type labels.
- Metadata / Connections copy and empty states.
- GeoJSON import: label maps to canonical name only; formatted address uses its own property mapping (default `formatted_address`).

## Validation
- `make lint` / `make test` run clean on touched areas during development.


Made with [Cursor](https://cursor.com)