### PR TITLE
Allow GeocodeAgent LLM steps to use catalog AI model configs

### DIFF
--- a/docs/NODES.md
+++ b/docs/NODES.md
@@ -177,6 +177,7 @@ Each slice should be demoable on its own.
 
 - Often sits between extract and output bookend (e.g. `PlaceExtract → GeocodeAgent → DBOutput`).
 - May read worker env (`BACKFIELD_PROJECT_ID`) and Stylebook cache bundles — see [`ARCHITECTURE.md`](ARCHITECTURE.md) geocode cache section.
+- **GeocodeAgent** — LLM steps (router, cache adjudication, display-line polish, geographic reasoning/estimation) authenticate via catalog AI model configs (`*AiModelConfigId` node params → org/project integration secrets). A raw `OPENAI_API_KEY` project or org secret remains a legacy fallback when no catalog config id is set.
 - **Article Metadata (`ArticleMetadata`)** — LLM assigns one preset-driven tag (e.g. topic category) from article text; emits consolidated `article_metadata` persisted by **DBOutput** to `substrate_article_meta`. Processed-item **Meta** tab allows editing **category** only (free text). Smoke: `make smoke-article-metadata` (in-process, mocked LLM) or `make smoke-article-metadata-stack` (live stack; create an **Article Metadata starter** graph or set `SMOKE_ARTICLE_METADATA_GRAPH_ID`).
 
 ### Embed

--- a/packages/backfield-agate/src/agate_nodes/geocode_agent/llm_auth.py
+++ b/packages/backfield-agate/src/agate_nodes/geocode_agent/llm_auth.py
@@ -1,0 +1,8 @@
+"""Shared LLM auth checks for GeocodeAgent steps."""
+
+from __future__ import annotations
+
+
+def has_llm_auth(api_key: str | None, model_config_id: str | None) -> bool:
+    """True when a raw provider key or a catalog AI model config id is available."""
+    return bool(api_key) or bool((model_config_id or "").strip())

--- a/packages/backfield-agate/src/agate_nodes/geocode_agent/models/area/natural.py
+++ b/packages/backfield-agate/src/agate_nodes/geocode_agent/models/area/natural.py
@@ -11,6 +11,7 @@ from agate_utils.geocoding.geocoding_types import (
 )
 from agate_utils.geocoding.nominatim import NominatimGeocoder
 from agate_utils.llm import call_llm
+from ...llm_auth import has_llm_auth
 from .area import Area
 
 logger = logging.getLogger(__name__)
@@ -106,7 +107,7 @@ class NaturalPlace(Area):
     ) -> Optional[Dict[str, Any]]:
         if not candidates:
             return None
-        if not openai_api_key or len(candidates) == 1:
+        if not has_llm_auth(openai_api_key, self._geographic_reasoning_model_config_id()) or len(candidates) == 1:
             return candidates[0]
 
         prompt = self._build_selection_prompt(candidates=candidates, context=context)
@@ -211,8 +212,8 @@ class NaturalPlace(Area):
         openai_api_key: Optional[str],
         context: Optional[str],
     ) -> Optional[GeocodingResult]:
-        if not openai_api_key:
-            logger.warning("NaturalPlace fallback bounding box requires an OpenAI API key.")
+        if not has_llm_auth(openai_api_key, self._geographic_estimation_model_config_id()):
+            logger.warning("NaturalPlace fallback bounding box requires LLM auth (API key or model config).")
             return None
 
         prompt_path = Path(__file__).parent.parent.parent / "prompts" / "create_natural_bbox.md"

--- a/packages/backfield-agate/src/agate_nodes/geocode_agent/models/area/region.py
+++ b/packages/backfield-agate/src/agate_nodes/geocode_agent/models/area/region.py
@@ -8,6 +8,7 @@ from agate_utils.geocoding.geocoding_types import (
     bbox_west_south_east_north_to_polygon_coordinates,
 )
 from agate_utils.llm import call_llm
+from ...llm_auth import has_llm_auth
 from .area import Area
 
 logger = logging.getLogger(__name__)
@@ -65,8 +66,8 @@ class Region(Area):
         openai_api_key: Optional[str] = None,
         **_: dict,
     ) -> Optional[GeocodingResult]:
-        if not openai_api_key:
-            logger.warning("Region geocoding requires an OpenAI API key.")
+        if not has_llm_auth(openai_api_key, self._geographic_estimation_model_config_id()):
+            logger.warning("Region geocoding requires LLM auth (API key or model config).")
             return None
 
         prompt = self._build_prompt()

--- a/packages/backfield-agate/src/agate_nodes/geocode_agent/models/point/intersection.py
+++ b/packages/backfield-agate/src/agate_nodes/geocode_agent/models/point/intersection.py
@@ -12,6 +12,7 @@ from agate_utils.geocoding.geocoding_types import GeocodingResult, GeocodingResu
 from agate_utils.geocoding.overpass import find_intersection_coordinates_from_text
 from agate_utils.llm import call_llm
 
+from ...llm_auth import has_llm_auth
 from .point import Point
 
 logger = logging.getLogger(__name__)
@@ -100,7 +101,7 @@ class Intersection(Point):
         self,
         openai_api_key: Optional[str],
     ) -> Optional[GeocodingResult]:
-        if not openai_api_key:
+        if not has_llm_auth(openai_api_key, self._geographic_reasoning_model_config_id()):
             return None
 
         try:
@@ -132,8 +133,8 @@ class Intersection(Point):
             return None
 
     def _try_llm_point_estimate(self, openai_api_key: Optional[str]) -> Optional[GeocodingResult]:
-        if not openai_api_key:
-            logger.warning("Intersection LLM estimate requires an OpenAI API key.")
+        if not has_llm_auth(openai_api_key, self._geographic_estimation_model_config_id()):
+            logger.warning("Intersection LLM estimate requires LLM auth (API key or model config).")
             return None
 
         try:

--- a/packages/backfield-agate/src/agate_nodes/geocode_agent/models/point/place.py
+++ b/packages/backfield-agate/src/agate_nodes/geocode_agent/models/point/place.py
@@ -7,6 +7,7 @@ from agate_utils.geocoding.geocoding_types import GeocodingResult
 from agate_utils.llm import call_llm
 from agate_utils.search import SearchResponse, brave_place_search, search_web_duckduckgo
 
+from ...llm_auth import has_llm_auth
 from .address import Address
 
 logger = logging.getLogger(__name__)
@@ -235,8 +236,8 @@ class Place(Address):
     ) -> Optional[GeocodingResult]:
         logger.info("Starting place geocoding: %s", self.name)
 
-        if not openai_api_key:
-            logger.warning("No OpenAI API key provided; falling back to Address geocoding")
+        if not has_llm_auth(openai_api_key, self._geographic_reasoning_model_config_id()):
+            logger.warning("No LLM auth provided; falling back to Address geocoding")
             return await super().geocode(pelias_api_key, geocodio_api_key, openai_api_key)
 
         if self._input_addressability is not None:

--- a/packages/backfield-agate/src/agate_nodes/geocode_agent/nodes/cache_adjudication.py
+++ b/packages/backfield-agate/src/agate_nodes/geocode_agent/nodes/cache_adjudication.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel, Field, ValidationError
 from agate_utils.geocoding.geocoding_types import stylebook_match_to_geocoding_result
 from agate_utils.llm import call_llm
 
+from ..llm_auth import has_llm_auth
 from ..types import AgentState, normalized_geocode_hints
 
 logger = logging.getLogger(__name__)
@@ -73,8 +74,12 @@ async def adjudicate_stylebook_cache_node(state: AgentState) -> AgentState:
 
     openai_key = state.get("openai_api_key")
     eval_model = state.get("evaluation_llm_model")
-    if not openai_key or not eval_model:
-        _adv_info(state, "[CACHE ADJUDICATION SKIP] Missing OpenAI key or evaluation model")
+    eval_model_config_id = state.get("evaluation_ai_model_config_id")
+    if not has_llm_auth(openai_key, eval_model_config_id) or not eval_model:
+        _adv_info(
+            state,
+            "[CACHE ADJUDICATION SKIP] Missing LLM auth (API key or model config) or evaluation model",
+        )
         return state
 
     location_text = state.get("location_text") or ""

--- a/packages/backfield-agate/src/agate_nodes/geocode_agent/nodes/emit_location_line.py
+++ b/packages/backfield-agate/src/agate_nodes/geocode_agent/nodes/emit_location_line.py
@@ -12,6 +12,7 @@ from typing import Any
 
 from agate_utils.llm import call_llm
 
+from ..llm_auth import has_llm_auth
 from ..types import AgentState
 
 logger = logging.getLogger(__name__)
@@ -731,7 +732,8 @@ async def compute_emit_location_line(
     """
     Produce the human-facing ``location`` string for a geocoded item.
 
-    Uses a small JSON LLM when ``openai_api_key`` is set; otherwise heuristics on ``location_text``.
+    Uses a small JSON LLM when an API key or catalog model config is available;
+    otherwise heuristics on ``location_text``.
     """
     location_type = (state.get("location_type") or "").strip()
     location_text = (state.get("location_text") or "").strip()
@@ -757,7 +759,8 @@ async def compute_emit_location_line(
         )
         return restore_preferred_place_head_casing(clamped, preferred_head)
 
-    if not openai_key:
+    emit_mc = _evaluation_ai_model_config_id_for_emit(state)
+    if not has_llm_auth(openai_key, emit_mc):
         return _finalize(_heuristic_emit_location(location_type, location_text, formatted_address))
     if not model:
         return _finalize(_heuristic_emit_location(location_type, location_text, formatted_address))
@@ -777,8 +780,6 @@ async def compute_emit_location_line(
         f"geocode_hints: {hints_snip}\n"
     )
     prompt = f"{rules}\n---\n{user_block}"
-
-    emit_mc = _evaluation_ai_model_config_id_for_emit(state)
 
     def _sync() -> str:
         return call_llm(
@@ -833,7 +834,8 @@ async def _maybe_upgrade_to_named_place(
 ) -> tuple[str, bool]:
     """Shared LLM + guard path for address or intersection → named ``place`` display upgrade."""
     openai_key = state.get("openai_api_key")
-    if not openai_key:
+    venue_mc = _evaluation_ai_model_config_id_for_emit(state)
+    if not has_llm_auth(openai_key, venue_mc):
         return baseline_location_line, False
     orig_full = (state.get("original_text") or "").strip()
     hints_full = (state.get("geocode_hints") or "").strip()

--- a/packages/backfield-agate/src/agate_nodes/geocode_agent/nodes/route_strategy.py
+++ b/packages/backfield-agate/src/agate_nodes/geocode_agent/nodes/route_strategy.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel, Field, ValidationError
 
 from agate_utils.llm import call_llm
 
+from ..llm_auth import has_llm_auth
 from ..types import AgentState
 
 logger = logging.getLogger(__name__)
@@ -94,12 +95,13 @@ async def route_strategy_node(state: AgentState) -> AgentState:
 
     openai_key = state.get("openai_api_key")
     router_model = state.get("router_llm_model")
+    router_model_config_id = state.get("router_ai_model_config_id")
 
-    if not openai_key:
+    if not has_llm_auth(openai_key, router_model_config_id):
         _apply_strategy(state, fallback)
         audit = {
             **audit_core,
-            "outcome": "fallback_no_openai_key",
+            "outcome": "fallback_no_llm_auth",
             "strategy_selected": fallback,
             "attempts": attempts,
         }

--- a/tests/agate_nodes/test_geocode_cache_adjudication.py
+++ b/tests/agate_nodes/test_geocode_cache_adjudication.py
@@ -1,8 +1,15 @@
-"""Unit tests for Stylebook cache adjudication JSON schema."""
+"""Unit tests for Stylebook cache adjudication JSON schema and auth guards."""
 
 from __future__ import annotations
 
-from agate_nodes.geocode_agent.nodes.cache_adjudication import StylebookCacheAdjudicationAnswer
+import asyncio
+import json
+from unittest.mock import patch
+
+from agate_nodes.geocode_agent.nodes.cache_adjudication import (
+    StylebookCacheAdjudicationAnswer,
+    adjudicate_stylebook_cache_node,
+)
 
 
 def test_stylebook_cache_adjudication_answer_json_roundtrip() -> None:
@@ -20,3 +27,75 @@ def test_stylebook_cache_adjudication_none_choice() -> None:
     ans = StylebookCacheAdjudicationAnswer.model_validate_json(raw)
     assert ans.chosen_canonical_id is None
     assert ans.needs_review is True
+
+
+def test_cache_adjudication_skips_without_llm_auth() -> None:
+    async def _run() -> None:
+        called = {"cand": False}
+
+        def _cand(*_a: object, **_k: object) -> list:
+            called["cand"] = True
+            return []
+
+        state: dict = {
+            "geocode_cache_bundle": {
+                "adjudication_candidates": _cand,
+                "materialize_canonical": lambda *_a, **_k: None,
+            },
+            "cache_strict_outcome": {"ambiguous_tier1": True},
+            "use_cache_llm_ambiguous_sanity": True,
+            "openai_api_key": None,
+            "evaluation_llm_model": "gpt-4o-mini",
+            "evaluation_ai_model_config_id": None,
+            "location_text": "Springfield",
+            "location_type": "city",
+            "location_components": {},
+        }
+        await adjudicate_stylebook_cache_node(state)
+        assert called["cand"] is False
+        assert state.get("geocoding_result") is None
+
+    asyncio.run(_run())
+
+
+def test_cache_adjudication_proceeds_with_catalog_model_config_without_openai_key() -> None:
+    async def _run() -> None:
+        llm_called = {"ok": False}
+
+        def _cand(*_a: object, **_k: object) -> list[dict]:
+            return [{"id": "550e8400-e29b-41d4-a716-446655440000", "display_name": "Springfield"}]
+
+        def _fake_llm(*_a: object, **kwargs: object) -> str:
+            llm_called["ok"] = True
+            assert kwargs.get("openai_api_key") is None
+            assert kwargs.get("model_config_id") == "cfg-eval-1"
+            return json.dumps(
+                {
+                    "chosen_canonical_id": None,
+                    "needs_review": True,
+                    "rationale": "catalog auth path",
+                }
+            )
+
+        state: dict = {
+            "geocode_cache_bundle": {
+                "adjudication_candidates": _cand,
+                "materialize_canonical": lambda *_a, **_k: None,
+            },
+            "cache_strict_outcome": {"ambiguous_tier1": True},
+            "use_cache_llm_ambiguous_sanity": True,
+            "openai_api_key": None,
+            "evaluation_llm_model": "gpt-4o-mini",
+            "evaluation_ai_model_config_id": "cfg-eval-1",
+            "location_text": "Springfield",
+            "location_type": "city",
+            "location_components": {},
+        }
+        with patch(
+            "agate_nodes.geocode_agent.nodes.cache_adjudication.call_llm",
+            _fake_llm,
+        ):
+            await adjudicate_stylebook_cache_node(state)
+        assert llm_called["ok"] is True
+
+    asyncio.run(_run())

--- a/tests/test_geocode_route_strategy.py
+++ b/tests/test_geocode_route_strategy.py
@@ -32,7 +32,7 @@ def test_route_strategy_skips_audit_when_cache_hit() -> None:
     asyncio.run(_run())
 
 
-def test_route_strategy_fallback_without_openai_key() -> None:
+def test_route_strategy_fallback_without_llm_auth() -> None:
     async def _run() -> None:
         state: dict = {
             "location_type": "place",
@@ -47,9 +47,36 @@ def test_route_strategy_fallback_without_openai_key() -> None:
         assert state.get("allow_web_search") is True
         audit = state.get("router_audit")
         assert isinstance(audit, dict)
-        assert audit.get("outcome") == "fallback_no_openai_key"
+        assert audit.get("outcome") == "fallback_no_llm_auth"
         assert "geocode_hints_snippet" in audit
         assert audit.get("geocode_hints_snippet") == ""
+
+    asyncio.run(_run())
+
+
+def test_route_strategy_proceeds_with_catalog_model_config_without_openai_key() -> None:
+    async def _run() -> None:
+        def _fake_llm(*_a: object, **kwargs: object) -> str:
+            assert kwargs.get("openai_api_key") is None
+            assert kwargs.get("model_config_id") == "cfg-router-1"
+            return json.dumps({"strategy": "no_web_search", "rationale": "catalog"})
+
+        state: dict = {
+            "location_type": "place",
+            "location_text": "Example",
+            "location_components": {},
+            "original_text": "",
+            "openai_api_key": None,
+            "router_llm_model": "gpt-4o-mini",
+            "router_ai_model_config_id": "cfg-router-1",
+        }
+        with patch("agate_nodes.geocode_agent.nodes.route_strategy.call_llm", _fake_llm):
+            await route_strategy_node(state)
+        assert state.get("allow_web_search") is False
+        audit = state.get("router_audit")
+        assert isinstance(audit, dict)
+        assert audit.get("outcome") == "llm_ok"
+        assert audit.get("strategy_selected") == "no_web_search"
 
     asyncio.run(_run())
 


### PR DESCRIPTION
## Summary
- GeocodeAgent pre-call auth guards previously required a raw `OPENAI_API_KEY`, which skipped router/cache adjudication on canary even when catalog AI model configs were set.
- Relax those guards so LLM steps run when either a raw key or a catalog `*AiModelConfigId` is present (matching PlaceExtract behavior).
- Add coverage for catalog-config-only and no-auth fallback paths; document GeocodeAgent catalog auth in `docs/NODES.md`.

## Test plan
- [x] `make lint`
- [x] `make test`
- [ ] Confirm canary GeocodeAgent node has `*AiModelConfigId` params set (or legacy `OPENAI_API_KEY` project secret as fallback)
- [ ] Re-run a canary place→geocode flow and verify router audit is `llm_ok` (not `fallback_no_llm_auth`) when catalog configs are present
- [ ] Spot-check cache adjudication still runs when `useCacheLlmAdjudication` is true without a raw OpenAI project secret


Made with [Cursor](https://cursor.com)