### PR TITLE
Automate immutable artifact publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
         run: make ui-build
       - name: UI same-origin bundle checks
         run: uv run pytest tests/test_ui_same_origin_builds.py -q
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
       - name: Build production API images
         run: |
           make docker-build-prod-apis \
@@ -122,61 +123,105 @@ jobs:
         if: always()
         run: docker compose -f infra/docker-compose.yml down -v --remove-orphans
 
-  smoke-extended:
+  publish-artifacts:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
     needs:
       - lint
       - test
       - smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    concurrency:
+      group: artifact-publish-${{ github.sha }}
+      cancel-in-progress: false
+    permissions:
+      id-token: write
+      contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.11"
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
       - name: Install workspace dependencies
         run: uv sync --all-packages
-      - name: Start runtime services
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: |
+            apps/agate-ui/package-lock.json
+            apps/stylebook-ui/package-lock.json
+            packages/backfield-ui/package-lock.json
+
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
+        with:
+          role-to-assume: ${{ vars.AWS_ARTIFACT_PUBLISHER_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION || 'us-east-1' }}
+          role-session-name: backfield-publish-${{ github.run_id }}
+
+      - id: ecr
+        uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2
+
+      - name: Resolve immutable version
         run: |
           set -euo pipefail
-          : > .env
-          [ -n "${OPENAI_API_KEY:-}" ] && printf 'OPENAI_API_KEY=%s\n' "$OPENAI_API_KEY" >> .env
-          [ -n "${ANTHROPIC_API_KEY:-}" ] && printf 'ANTHROPIC_API_KEY=%s\n' "$ANTHROPIC_API_KEY" >> .env
-          docker compose -f infra/docker-compose.yml up -d --build postgres redis migrate stylebook-api core-api agate-api worker
-      - name: Wait for API health
-        run: |
-          for _ in $(seq 1 60); do
-            if curl -fsS http://localhost:8000/health >/dev/null \
-              && curl -fsS http://localhost:8003/health >/dev/null \
-              && curl -fsS http://localhost:8004/health >/dev/null; then
-              exit 0
-            fi
-            sleep 2
-          done
-          docker compose -f infra/docker-compose.yml logs
-          exit 1
-      - name: Bootstrap smoke user (fresh DB)
-        run: |
-          curl -fsS -X POST http://localhost:8004/v1/bootstrap/first-user \
-            -H "Content-Type: application/json" \
-            -d '{"email":"smoke-ci@local.test","password":"smoke-ci-pass-change-in-prod"}' \
-            || true
-      - name: Extended smoke lanes
+          VERSION=$(uv run python scripts/release_manifest.py version --sha "$GITHUB_SHA")
+          BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          {
+            echo "VERSION=$VERSION"
+            echo "BUILD_TIME=$BUILD_TIME"
+          } >> "$GITHUB_ENV"
+
+      - name: Build and push production images
         env:
-          SMOKE_EMAIL: smoke-ci@local.test
-          SMOKE_PASSWORD: smoke-ci-pass-change-in-prod
+          IMAGE_PREFIX: ${{ steps.ecr.outputs.registry }}/
         run: |
-          make smoke-worker-async
-          make smoke-stylebook-editorial
-          make smoke-stylebook-import-export
-          make smoke-s3-batch
-      - name: Dump compose logs on failure
-        if: failure()
-        run: docker compose -f infra/docker-compose.yml logs
-      - name: Tear down stack
-        if: always()
-        run: docker compose -f infra/docker-compose.yml down -v --remove-orphans
+          APP_VERSION="$VERSION" \
+          GIT_SHA="$GITHUB_SHA" \
+          IMAGE_TAG="$VERSION" \
+          docker buildx bake \
+            --push \
+            --provenance=true \
+            --sbom=true \
+            --set '*.cache-from=type=gha' \
+            --set '*.cache-to=type=gha,mode=max'
+
+      - name: Build same-origin UIs
+        run: make ui-build
+
+      - name: Package deterministic UI archives
+        run: |
+          mkdir -p dist-artifacts
+          uv run python scripts/release_manifest.py package-ui \
+            --source apps/agate-ui/dist \
+            --output dist-artifacts/agate-ui.tar.gz
+          uv run python scripts/release_manifest.py package-ui \
+            --source apps/stylebook-ui/dist \
+            --output dist-artifacts/stylebook-ui.tar.gz
+
+      - name: Verify and publish atomic artifact manifest
+        env:
+          BACKFIELD_ARTIFACT_BUCKET: ${{ vars.BACKFIELD_ARTIFACT_BUCKET }}
+        run: |
+          set -euo pipefail
+          uv run python scripts/release_manifest.py publish \
+            --version "$VERSION" \
+            --source-sha "$GITHUB_SHA" \
+            --build-time "$BUILD_TIME" \
+            --bucket "$BACKFIELD_ARTIFACT_BUCKET" \
+            --agate-ui dist-artifacts/agate-ui.tar.gz \
+            --stylebook-ui dist-artifacts/stylebook-ui.tar.gz \
+            | tee publish-summary.txt
+          {
+            echo '## Backfield artifacts published'
+            echo '```text'
+            cat publish-summary.txt
+            echo '```'
+            echo
+            echo "Deploy: \`VERSION=$VERSION\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -1,0 +1,65 @@
+name: Release Artifact Alias
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  alias:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    concurrency:
+      group: artifact-release-${{ github.ref_name }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate release tag is on main
+        run: |
+          set -euo pipefail
+          [[ "$GITHUB_REF_NAME" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] \
+            || { echo "::error::Tag must be SemVer vX.Y.Z"; exit 1; }
+          git fetch origin main
+          git merge-base --is-ancestor "$GITHUB_SHA" origin/main \
+            || { echo "::error::Release commit is not on main"; exit 1; }
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.11"
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
+      - name: Install workspace dependencies
+        run: uv sync --all-packages
+
+      - uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
+        with:
+          role-to-assume: ${{ vars.AWS_ARTIFACT_PUBLISHER_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION || 'us-east-1' }}
+          role-session-name: backfield-release-${{ github.run_id }}
+
+      - name: Alias existing immutable artifacts
+        env:
+          BACKFIELD_ARTIFACT_BUCKET: ${{ vars.BACKFIELD_ARTIFACT_BUCKET }}
+        run: |
+          set -euo pipefail
+          SOURCE_VERSION=$(uv run python scripts/release_manifest.py version --sha "$GITHUB_SHA")
+          uv run python scripts/release_manifest.py alias \
+            --source-version "$SOURCE_VERSION" \
+            --release-version "$GITHUB_REF_NAME" \
+            --source-sha "$GITHUB_SHA" \
+            --bucket "$BACKFIELD_ARTIFACT_BUCKET" \
+            | tee release-summary.txt
+          {
+            echo "## Backfield release $GITHUB_REF_NAME"
+            echo
+            echo "No images or UIs were rebuilt. This tag aliases \`$SOURCE_VERSION\`."
+            echo '```text'
+            cat release-summary.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BACKFIELD := ./scripts/backfield
 APP_VERSION ?= 0.0.0-dev
 GIT_SHA ?= unknown
 BUILD_TIME ?= unknown
-DOCKER_PROD_BUILD_ARGS := --build-arg APP_VERSION=$(APP_VERSION) --build-arg GIT_SHA=$(GIT_SHA) --build-arg BUILD_TIME=$(BUILD_TIME)
+DOCKER_BAKE_ENV := APP_VERSION=$(APP_VERSION) GIT_SHA=$(GIT_SHA) BUILD_TIME=$(BUILD_TIME)
 
 .PHONY: help up up-detached down logs migrate reset-db clear-entity-data docker-prune-build docker-prune-system docker-prune-volumes docker-trim docker-trim-full docker-build-prod-apis docker-build-prod-agate-api docker-build-prod-core-api docker-build-prod-stylebook-api docker-build-prod-worker test test-unit test-integration lint format bootstrap install-cli-shim install-user-cli uninstall-user-cli smoke smoke-auth smoke-agate-basic smoke-stylebook-basic smoke-agate-stylebook-handoff smoke-worker-async smoke-stylebook-editorial smoke-s3-batch smoke-stylebook-import-export smoke-fast smoke-runtime smoke-slower smoke-place-geocode smoke-place-geocode-stack smoke-people smoke-people-stack smoke-organizations smoke-organizations-stack smoke-article-metadata smoke-article-metadata-stack smoke-custom-extract smoke-custom-extract-stack smoke-parallel-graph smoke-parallel-graph-stack agate-ui-build stylebook-ui-build ui-build
 
@@ -134,18 +134,19 @@ docker-trim-full: docker-trim docker-prune-volumes
 	@echo "docker-trim-full done."
 
 docker-build-prod-agate-api:
-	docker build -f apps/agate-api/Dockerfile --target prod $(DOCKER_PROD_BUILD_ARGS) -t backfield-agate-api:prod .
+	$(DOCKER_BAKE_ENV) docker buildx bake agate-api --load
 
 docker-build-prod-core-api:
-	docker build -f apps/core-api/Dockerfile --target prod $(DOCKER_PROD_BUILD_ARGS) -t backfield-core-api:prod .
+	$(DOCKER_BAKE_ENV) docker buildx bake core-api --load
 
 docker-build-prod-stylebook-api:
-	docker build -f apps/stylebook-api/Dockerfile --target prod $(DOCKER_PROD_BUILD_ARGS) -t backfield-stylebook-api:prod .
+	$(DOCKER_BAKE_ENV) docker buildx bake stylebook-api --load
 
-docker-build-prod-apis: docker-build-prod-agate-api docker-build-prod-core-api docker-build-prod-stylebook-api
+docker-build-prod-apis:
+	$(DOCKER_BAKE_ENV) docker buildx bake agate-api core-api stylebook-api --load
 
 docker-build-prod-worker:
-	docker build -f apps/worker/Dockerfile --target prod $(DOCKER_PROD_BUILD_ARGS) -t backfield-worker:prod .
+	$(DOCKER_BAKE_ENV) docker buildx bake worker --load
 
 test: test-unit test-integration
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,21 @@ Run `backfield doctor` to verify repo root, uv, Docker, `.venv`, and `.env`.
 
 To manage the stack afterward, use `backfield up`, `backfield down`, `backfield logs`, or `make up` / `make down` / `make logs`.
 
+## Hosted release artifacts
+
+Every successful `main` CI run publishes one immutable Linux/AMD64 release unit:
+
+- four container images tagged `main-<12-char-sha>-amd64`
+- deterministic Agate and Stylebook UI archives
+- checksums, ECR digests, source SHA, scan results, and build metadata in one manifest
+
+Publishing does not deploy to a client. `backfield-cloud` explicitly promotes a manifest version.
+Creating a strict `vX.Y.Z` Git tag on a commit already on `main` adds ECR aliases and a release
+manifest without rebuilding any artifact. Neither `latest` nor mutable branch tags are published.
+
+Repository variables required by the workflows are `AWS_ARTIFACT_PUBLISHER_ROLE_ARN`,
+`BACKFIELD_ARTIFACT_BUCKET`, and `AWS_REGION`.
+
 ## License
 
 Copyright 2026 Local Angle

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,62 @@
+variable "APP_VERSION" {
+  default = "0.0.0-dev"
+}
+
+variable "GIT_SHA" {
+  default = "unknown"
+}
+
+variable "BUILD_TIME" {
+  default = "unknown"
+}
+
+variable "IMAGE_PREFIX" {
+  # Empty for local builds; CI sets "<account>.dkr.ecr.<region>.amazonaws.com/".
+  default = ""
+}
+
+variable "IMAGE_TAG" {
+  default = "prod"
+}
+
+group "default" {
+  targets = ["agate-api", "core-api", "stylebook-api", "worker"]
+}
+
+target "_common" {
+  context   = "."
+  platforms = ["linux/amd64"]
+  args = {
+    APP_VERSION = APP_VERSION
+    GIT_SHA      = GIT_SHA
+    BUILD_TIME   = BUILD_TIME
+  }
+}
+
+target "agate-api" {
+  inherits   = ["_common"]
+  dockerfile = "apps/agate-api/Dockerfile"
+  target     = "prod"
+  tags       = ["${IMAGE_PREFIX}backfield-agate-api:${IMAGE_TAG}"]
+}
+
+target "core-api" {
+  inherits   = ["_common"]
+  dockerfile = "apps/core-api/Dockerfile"
+  target     = "prod"
+  tags       = ["${IMAGE_PREFIX}backfield-core-api:${IMAGE_TAG}"]
+}
+
+target "stylebook-api" {
+  inherits   = ["_common"]
+  dockerfile = "apps/stylebook-api/Dockerfile"
+  target     = "prod"
+  tags       = ["${IMAGE_PREFIX}backfield-stylebook-api:${IMAGE_TAG}"]
+}
+
+target "worker" {
+  inherits   = ["_common"]
+  dockerfile = "apps/worker/Dockerfile"
+  target     = "prod"
+  tags       = ["${IMAGE_PREFIX}backfield-worker:${IMAGE_TAG}"]
+}

--- a/scripts/release_manifest.py
+++ b/scripts/release_manifest.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+"""Publish and alias complete Backfield artifact manifests.
+
+The manifest is uploaded last and is the atomic "ready to deploy" marker.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import gzip
+import hashlib
+import json
+import re
+import tarfile
+from pathlib import Path
+from typing import Any
+
+import boto3
+from botocore.exceptions import ClientError
+
+REPOSITORIES = (
+    "backfield-agate-api",
+    "backfield-core-api",
+    "backfield-stylebook-api",
+    "backfield-worker",
+)
+SEMVER_RE = re.compile(r"^v(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$")
+
+
+def canonical_version(sha: str) -> str:
+    value = sha.strip().lower()
+    if not re.fullmatch(r"[0-9a-f]{12,40}", value):
+        raise ValueError("git SHA must be 12–40 lowercase hexadecimal characters")
+    return f"main-{value[:12]}-amd64"
+
+
+def validate_release_version(version: str) -> str:
+    if not SEMVER_RE.fullmatch(version):
+        raise ValueError(f"release tag must be SemVer vX.Y.Z, got {version!r}")
+    return version
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def package_directory(source: Path, output: Path) -> None:
+    """Create a deterministic gzip-compressed tar archive."""
+    if not source.is_dir():
+        raise ValueError(f"UI build directory not found: {source}")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with output.open("wb") as raw:
+        with gzip.GzipFile(filename="", mode="wb", fileobj=raw, mtime=0) as zipped:
+            with tarfile.open(fileobj=zipped, mode="w") as archive:
+                for path in sorted(source.rglob("*")):
+                    if not path.is_file():
+                        continue
+                    relative = path.relative_to(source)
+                    info = archive.gettarinfo(str(path), arcname=relative.as_posix())
+                    info.uid = 0
+                    info.gid = 0
+                    info.uname = ""
+                    info.gname = ""
+                    info.mtime = 0
+                    with path.open("rb") as handle:
+                        archive.addfile(info, handle)
+
+
+def _image_detail(ecr: Any, repository: str, tag: str) -> dict[str, Any]:
+    response = ecr.describe_images(
+        repositoryName=repository,
+        imageIds=[{"imageTag": tag}],
+    )
+    details = response.get("imageDetails") or []
+    if not details:
+        raise RuntimeError(f"missing ECR image {repository}:{tag}")
+    return dict(details[0])
+
+
+def _wait_for_scan(ecr: Any, repository: str, tag: str) -> dict[str, int]:
+    waiter = ecr.get_waiter("image_scan_complete")
+    try:
+        waiter.wait(
+            repositoryName=repository,
+            imageId={"imageTag": tag},
+            WaiterConfig={"Delay": 10, "MaxAttempts": 60},
+        )
+    except Exception as exc:
+        raise RuntimeError(f"ECR scan did not complete for {repository}:{tag}: {exc}") from exc
+    response = ecr.describe_image_scan_findings(
+        repositoryName=repository,
+        imageId={"imageTag": tag},
+    )
+    counts = response.get("imageScanFindings", {}).get("findingSeverityCounts", {})
+    return {str(key): int(value) for key, value in counts.items()}
+
+
+def build_manifest(
+    *,
+    version: str,
+    source_sha: str,
+    build_time: str,
+    artifact_bucket: str,
+    ui_archives: dict[str, Path],
+    ecr: Any,
+    s3: Any,
+    enforce_scans: bool = True,
+) -> dict[str, Any]:
+    if version != canonical_version(source_sha):
+        raise ValueError(f"version {version!r} does not match source SHA {source_sha}")
+
+    images: dict[str, Any] = {}
+    critical: list[str] = []
+    for repository in REPOSITORIES:
+        detail = _image_detail(ecr, repository, version)
+        repo = ecr.describe_repositories(repositoryNames=[repository])["repositories"][0]
+        scans = _wait_for_scan(ecr, repository, version) if enforce_scans else {}
+        if scans.get("CRITICAL", 0):
+            critical.append(f"{repository}: {scans['CRITICAL']} CRITICAL")
+        images[repository] = {
+            "tag": version,
+            "digest": detail["imageDigest"],
+            "uri": f"{repo['repositoryUri']}:{version}",
+            "scan_findings": scans,
+        }
+    if critical:
+        raise RuntimeError("critical ECR findings block publication: " + ", ".join(critical))
+
+    ui: dict[str, Any] = {}
+    for name, archive in ui_archives.items():
+        checksum = sha256_file(archive)
+        key = f"versions/{version}/ui/{name}.tar.gz"
+        s3.upload_file(
+            str(archive),
+            artifact_bucket,
+            key,
+            ExtraArgs={
+                "ContentType": "application/gzip",
+                "Metadata": {"sha256": checksum, "source-sha": source_sha},
+            },
+        )
+        head = s3.head_object(Bucket=artifact_bucket, Key=key)
+        if int(head["ContentLength"]) != archive.stat().st_size:
+            raise RuntimeError(f"uploaded UI size mismatch for s3://{artifact_bucket}/{key}")
+        if head.get("Metadata", {}).get("sha256") != checksum:
+            raise RuntimeError(f"uploaded UI checksum metadata mismatch for {key}")
+        ui[name] = {
+            "object_key": key,
+            "sha256": checksum,
+            "size": archive.stat().st_size,
+        }
+
+    return {
+        "schema_version": 1,
+        "version": version,
+        "source_version": None,
+        "source_sha": source_sha,
+        "build_time": build_time,
+        "architecture": "linux/amd64",
+        "images": images,
+        "ui": ui,
+    }
+
+
+def publish_manifest(s3: Any, bucket: str, manifest: dict[str, Any]) -> str:
+    key = f"manifests/{manifest['version']}.json"
+    body = json.dumps(manifest, indent=2, sort_keys=True).encode()
+    s3.put_object(
+        Bucket=bucket,
+        Key=key,
+        Body=body,
+        ContentType="application/json",
+        Metadata={
+            "source-sha": str(manifest["source_sha"]),
+            "schema-version": str(manifest["schema_version"]),
+        },
+    )
+    return key
+
+
+def load_manifest(s3: Any, bucket: str, version: str) -> dict[str, Any]:
+    response = s3.get_object(Bucket=bucket, Key=f"manifests/{version}.json")
+    value = json.loads(response["Body"].read())
+    if not isinstance(value, dict):
+        raise ValueError("manifest must be a JSON object")
+    return value
+
+
+def alias_ecr_image(ecr: Any, repository: str, source_tag: str, alias_tag: str) -> str:
+    source = ecr.batch_get_image(
+        repositoryName=repository,
+        imageIds=[{"imageTag": source_tag}],
+    )
+    images = source.get("images") or []
+    if not images:
+        raise RuntimeError(f"canonical ECR image missing: {repository}:{source_tag}")
+    image = images[0]
+    source_digest = str(image["imageId"]["imageDigest"])
+
+    try:
+        existing = _image_detail(ecr, repository, alias_tag)
+    except ClientError as exc:
+        if exc.response.get("Error", {}).get("Code") != "ImageNotFoundException":
+            raise
+    except RuntimeError:
+        existing = None
+    else:
+        existing_digest = str(existing["imageDigest"])
+        if existing_digest != source_digest:
+            raise RuntimeError(
+                f"immutable alias conflict {repository}:{alias_tag}: "
+                f"{existing_digest} != {source_digest}"
+            )
+        return source_digest
+
+    put_args = {
+        "repositoryName": repository,
+        "imageManifest": image["imageManifest"],
+        "imageTag": alias_tag,
+    }
+    if image.get("imageManifestMediaType"):
+        put_args["imageManifestMediaType"] = image["imageManifestMediaType"]
+    try:
+        response = ecr.put_image(**put_args)
+    except ClientError as exc:
+        # A concurrent retry may have won; verify rather than blindly fail.
+        if exc.response.get("Error", {}).get("Code") != "ImageTagAlreadyExistsException":
+            raise
+        existing = _image_detail(ecr, repository, alias_tag)
+        if str(existing["imageDigest"]) != source_digest:
+            raise RuntimeError(f"immutable alias conflict {repository}:{alias_tag}") from exc
+        return source_digest
+    return str(response["image"]["imageId"]["imageDigest"])
+
+
+def create_release_alias(
+    *,
+    source_manifest: dict[str, Any],
+    release_version: str,
+    ecr: Any,
+) -> dict[str, Any]:
+    validate_release_version(release_version)
+    source_version = str(source_manifest["version"])
+    alias = copy.deepcopy(source_manifest)
+    alias["version"] = release_version
+    alias["source_version"] = source_version
+    for repository, image in alias["images"].items():
+        digest = alias_ecr_image(ecr, repository, source_version, release_version)
+        if digest != image["digest"]:
+            raise RuntimeError(f"digest mismatch while aliasing {repository}")
+        image["tag"] = release_version
+        image["uri"] = image["uri"].rsplit(":", 1)[0] + f":{release_version}"
+    return alias
+
+
+def _write_summary(manifest: dict[str, Any], manifest_key: str) -> None:
+    print(f"VERSION={manifest['version']}")
+    print(f"SOURCE_SHA={manifest['source_sha']}")
+    print(f"MANIFEST={manifest_key}")
+    for repository, image in manifest["images"].items():
+        scans = image.get("scan_findings") or {}
+        print(
+            f"IMAGE {repository} {image['digest']} "
+            f"HIGH={scans.get('HIGH', 0)} CRITICAL={scans.get('CRITICAL', 0)}"
+        )
+    for name, ui in manifest["ui"].items():
+        print(f"UI {name} sha256={ui['sha256']} size={ui['size']}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    version_cmd = sub.add_parser("version")
+    version_cmd.add_argument("--sha", required=True)
+
+    package_cmd = sub.add_parser("package-ui")
+    package_cmd.add_argument("--source", type=Path, required=True)
+    package_cmd.add_argument("--output", type=Path, required=True)
+
+    publish_cmd = sub.add_parser("publish")
+    publish_cmd.add_argument("--version", required=True)
+    publish_cmd.add_argument("--source-sha", required=True)
+    publish_cmd.add_argument("--build-time", required=True)
+    publish_cmd.add_argument("--bucket", required=True)
+    publish_cmd.add_argument("--agate-ui", type=Path, required=True)
+    publish_cmd.add_argument("--stylebook-ui", type=Path, required=True)
+    publish_cmd.add_argument("--skip-scan-gate", action="store_true")
+
+    alias_cmd = sub.add_parser("alias")
+    alias_cmd.add_argument("--source-version", required=True)
+    alias_cmd.add_argument("--release-version", required=True)
+    alias_cmd.add_argument("--source-sha", required=True)
+    alias_cmd.add_argument("--bucket", required=True)
+
+    args = parser.parse_args()
+    if args.command == "version":
+        print(canonical_version(args.sha))
+        return 0
+    if args.command == "package-ui":
+        package_directory(args.source, args.output)
+        print(f"{args.output} sha256={sha256_file(args.output)}")
+        return 0
+
+    ecr = boto3.client("ecr")
+    s3 = boto3.client("s3")
+    if args.command == "publish":
+        manifest = build_manifest(
+            version=args.version,
+            source_sha=args.source_sha,
+            build_time=args.build_time,
+            artifact_bucket=args.bucket,
+            ui_archives={
+                "agate-ui": args.agate_ui,
+                "stylebook-ui": args.stylebook_ui,
+            },
+            ecr=ecr,
+            s3=s3,
+            enforce_scans=not args.skip_scan_gate,
+        )
+    else:
+        validate_release_version(args.release_version)
+        expected = canonical_version(args.source_sha)
+        if args.source_version != expected:
+            raise ValueError(f"source version must be {expected}")
+        source = load_manifest(s3, args.bucket, args.source_version)
+        if source.get("source_sha") != args.source_sha:
+            raise ValueError("canonical manifest source SHA does not match release tag commit")
+        manifest = create_release_alias(
+            source_manifest=source,
+            release_version=args.release_version,
+            ecr=ecr,
+        )
+    key = publish_manifest(s3, args.bucket, manifest)
+    _write_summary(manifest, key)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_SCRIPT = Path(__file__).parents[1] / "scripts" / "release_manifest.py"
+_SPEC = importlib.util.spec_from_file_location("release_manifest", _SCRIPT)
+assert _SPEC is not None and _SPEC.loader is not None
+release_manifest = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(release_manifest)
+
+alias_ecr_image = release_manifest.alias_ecr_image
+canonical_version = release_manifest.canonical_version
+package_directory = release_manifest.package_directory
+sha256_file = release_manifest.sha256_file
+validate_release_version = release_manifest.validate_release_version
+
+
+def test_canonical_version() -> None:
+    assert canonical_version("a" * 40) == f"main-{'a' * 12}-amd64"
+    with pytest.raises(ValueError, match="git SHA"):
+        canonical_version("not-a-sha")
+
+
+def test_release_version_validation() -> None:
+    assert validate_release_version("v1.2.3") == "v1.2.3"
+    with pytest.raises(ValueError, match="SemVer"):
+        validate_release_version("release-1")
+    with pytest.raises(ValueError, match="SemVer"):
+        validate_release_version("v01.2.3")
+
+
+def test_ui_archive_is_deterministic(tmp_path: Path) -> None:
+    source = tmp_path / "dist"
+    source.mkdir()
+    (source / "index.html").write_text("<h1>hello</h1>")
+    assets = source / "assets"
+    assets.mkdir()
+    (assets / "app.abc.js").write_text("console.log('ok')")
+    first = tmp_path / "first.tar.gz"
+    second = tmp_path / "second.tar.gz"
+
+    package_directory(source, first)
+    package_directory(source, second)
+
+    assert sha256_file(first) == sha256_file(second)
+    assert hashlib.sha256(first.read_bytes()).hexdigest() == sha256_file(first)
+
+
+class FakeEcr:
+    def __init__(self, *, alias_digest: str | None = None) -> None:
+        self.alias_digest = alias_digest
+        self.put_calls: list[dict[str, Any]] = []
+
+    def batch_get_image(self, **kwargs: Any) -> dict[str, Any]:
+        return {
+            "images": [
+                {
+                    "imageId": {"imageDigest": "sha256:canonical"},
+                    "imageManifest": '{"schemaVersion":2}',
+                    "imageManifestMediaType": "application/vnd.oci.image.manifest.v1+json",
+                }
+            ]
+        }
+
+    def describe_images(self, **kwargs: Any) -> dict[str, Any]:
+        if self.alias_digest is None:
+            return {"imageDetails": []}
+        return {"imageDetails": [{"imageDigest": self.alias_digest}]}
+
+    def put_image(self, **kwargs: Any) -> dict[str, Any]:
+        self.put_calls.append(kwargs)
+        return {"image": {"imageId": {"imageDigest": "sha256:canonical"}}}
+
+
+def test_release_alias_puts_existing_manifest_without_rebuild() -> None:
+    ecr = FakeEcr()
+    digest = alias_ecr_image(ecr, "backfield-worker", "main-abc-amd64", "v1.2.3")
+    assert digest == "sha256:canonical"
+    assert ecr.put_calls[0]["imageTag"] == "v1.2.3"
+
+
+def test_release_alias_is_idempotent() -> None:
+    ecr = FakeEcr(alias_digest="sha256:canonical")
+    digest = alias_ecr_image(ecr, "backfield-worker", "main-abc-amd64", "v1.2.3")
+    assert digest == "sha256:canonical"
+    assert ecr.put_calls == []
+
+
+def test_release_alias_conflict_fails() -> None:
+    ecr = FakeEcr(alias_digest="sha256:other")
+    with pytest.raises(RuntimeError, match="immutable alias conflict"):
+        alias_ecr_image(ecr, "backfield-worker", "main-abc-amd64", "v1.2.3")


### PR DESCRIPTION
## Summary
- replace extended smoke gating with post-CI publication of four immutable images and two deterministic UI archives
- add one AMD64 Docker Bake graph plus an atomic, scan-gated release manifest
- add idempotent SemVer aliases that reuse existing ECR digests without rebuilding

## Test plan
- [x] `make lint`
- [x] `uv run pytest tests/test_release_manifest.py tests/test_ui_same_origin_builds.py -q`
- [x] `docker buildx bake --print`
- [ ] merge and verify all six artifacts plus canonical manifest
- [ ] create a test SemVer tag and verify alias manifest without builds

Made with [Cursor](https://cursor.com)