### PR TITLE
Scan deployable OCI images before publishing

### DIFF
--- a/apps/agate-api/Dockerfile
+++ b/apps/agate-api/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM python:3.11-slim AS base
+FROM python:3.11-slim-bookworm AS base
 
 WORKDIR /app
 ENV PYTHONDONTWRITEBYTECODE=1 \
@@ -31,7 +31,7 @@ RUN uv pip install --system /app/packages/backfield-db \
     && uv pip install --system --no-deps --no-sources /app/packages/backfield-cli \
     && uv pip install --system /app/apps/agate-api
 
-FROM python:3.11-slim AS prod
+FROM python:3.11-slim-bookworm AS prod
 
 WORKDIR /app
 ENV PYTHONDONTWRITEBYTECODE=1 \

--- a/apps/core-api/Dockerfile
+++ b/apps/core-api/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM python:3.11-slim AS base
+FROM python:3.11-slim-bookworm AS base
 
 WORKDIR /app
 ENV PYTHONDONTWRITEBYTECODE=1 \
@@ -25,7 +25,7 @@ RUN uv pip install --system /app/packages/backfield-db \
     && uv pip install --system /app/packages/backfield-auth \
     && uv pip install --system /app/apps/core-api
 
-FROM python:3.11-slim AS prod
+FROM python:3.11-slim-bookworm AS prod
 
 WORKDIR /app
 ENV PYTHONDONTWRITEBYTECODE=1 \

--- a/apps/stylebook-api/Dockerfile
+++ b/apps/stylebook-api/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM python:3.11-slim AS base
+FROM python:3.11-slim-bookworm AS base
 
 WORKDIR /app
 ENV PYTHONDONTWRITEBYTECODE=1 \
@@ -23,7 +23,7 @@ RUN uv pip install --system /app/packages/backfield-db \
     && uv pip install --system /app/packages/backfield-auth \
     && uv pip install --system /app/apps/stylebook-api
 
-FROM python:3.11-slim AS prod
+FROM python:3.11-slim-bookworm AS prod
 
 WORKDIR /app
 ENV PYTHONDONTWRITEBYTECODE=1 \

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM python:3.11-slim AS base
+FROM python:3.11-slim-bookworm AS base
 
 WORKDIR /app
 ENV PYTHONDONTWRITEBYTECODE=1 \
@@ -28,7 +28,7 @@ RUN uv pip install --system /app/packages/backfield-db \
     && uv pip install --system /app/packages/backfield-agate \
     && uv pip install --system /app/apps/worker
 
-FROM python:3.11-slim AS prod
+FROM python:3.11-slim-bookworm AS prod
 
 WORKDIR /app
 ENV PYTHONDONTWRITEBYTECODE=1 \

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -26,6 +26,7 @@ group "default" {
 target "_common" {
   context   = "."
   platforms = ["linux/amd64"]
+  pull      = true
   args = {
     APP_VERSION = APP_VERSION
     GIT_SHA      = GIT_SHA

--- a/scripts/release_manifest.py
+++ b/scripts/release_manifest.py
@@ -13,6 +13,7 @@ import hashlib
 import json
 import re
 import tarfile
+import time
 from pathlib import Path
 from typing import Any
 
@@ -82,22 +83,51 @@ def _image_detail(ecr: Any, repository: str, tag: str) -> dict[str, Any]:
     return dict(details[0])
 
 
-def _wait_for_scan(ecr: Any, repository: str, tag: str) -> dict[str, int]:
-    waiter = ecr.get_waiter("image_scan_complete")
-    try:
-        waiter.wait(
-            repositoryName=repository,
-            imageId={"imageTag": tag},
-            WaiterConfig={"Delay": 10, "MaxAttempts": 60},
-        )
-    except Exception as exc:
-        raise RuntimeError(f"ECR scan did not complete for {repository}:{tag}: {exc}") from exc
-    response = ecr.describe_image_scan_findings(
+def _scan_image_id(ecr: Any, repository: str, tag: str) -> dict[str, str]:
+    """Resolve an OCI index tag to its scan-enabled Linux/AMD64 child."""
+    response = ecr.batch_get_image(
         repositoryName=repository,
-        imageId={"imageTag": tag},
+        imageIds=[{"imageTag": tag}],
     )
-    counts = response.get("imageScanFindings", {}).get("findingSeverityCounts", {})
-    return {str(key): int(value) for key, value in counts.items()}
+    images = response.get("images") or []
+    if not images:
+        raise RuntimeError(f"cannot resolve image manifest for {repository}:{tag}")
+    manifest = json.loads(images[0]["imageManifest"])
+    children = manifest.get("manifests")
+    if not children:
+        return {"imageTag": tag}
+    for child in children:
+        platform = child.get("platform") or {}
+        if platform.get("os") == "linux" and platform.get("architecture") == "amd64":
+            return {"imageDigest": str(child["digest"])}
+    raise RuntimeError(f"OCI index has no Linux/AMD64 image: {repository}:{tag}")
+
+
+def _wait_for_scan(ecr: Any, repository: str, tag: str) -> dict[str, int]:
+    image_id = _scan_image_id(ecr, repository, tag)
+    for _ in range(60):
+        try:
+            response = ecr.describe_image_scan_findings(
+                repositoryName=repository,
+                imageId=image_id,
+            )
+        except ClientError as exc:
+            if exc.response.get("Error", {}).get("Code") != "ScanNotFoundException":
+                raise
+            time.sleep(10)
+            continue
+        status = response.get("imageScanStatus", {}).get("status")
+        if status == "COMPLETE":
+            counts = response.get("imageScanFindings", {}).get(
+                "findingSeverityCounts", {}
+            )
+            return {str(key): int(value) for key, value in counts.items()}
+        if status in {"FAILED", "UNSUPPORTED_IMAGE"}:
+            raise RuntimeError(
+                f"ECR scan {status} for {repository}:{tag} ({image_id})"
+            )
+        time.sleep(10)
+    raise RuntimeError(f"ECR scan timed out for {repository}:{tag} ({image_id})")
 
 
 def build_manifest(

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import importlib.util
+import json
 from pathlib import Path
 from typing import Any
 
@@ -18,6 +19,7 @@ canonical_version = release_manifest.canonical_version
 package_directory = release_manifest.package_directory
 sha256_file = release_manifest.sha256_file
 validate_release_version = release_manifest.validate_release_version
+scan_image_id = release_manifest._scan_image_id
 
 
 def test_canonical_version() -> None:
@@ -49,6 +51,36 @@ def test_ui_archive_is_deterministic(tmp_path: Path) -> None:
 
     assert sha256_file(first) == sha256_file(second)
     assert hashlib.sha256(first.read_bytes()).hexdigest() == sha256_file(first)
+
+
+class FakeIndexEcr:
+    def batch_get_image(self, **kwargs: Any) -> dict[str, Any]:
+        return {
+            "images": [
+                {
+                    "imageManifest": json.dumps(
+                        {
+                            "manifests": [
+                                {
+                                    "digest": "sha256:attestation",
+                                    "platform": {"os": "unknown", "architecture": "unknown"},
+                                },
+                                {
+                                    "digest": "sha256:amd64",
+                                    "platform": {"os": "linux", "architecture": "amd64"},
+                                },
+                            ]
+                        }
+                    )
+                }
+            ]
+        }
+
+
+def test_scan_resolves_linux_amd64_child_from_oci_index() -> None:
+    assert scan_image_id(FakeIndexEcr(), "backfield-worker", "main-abc-amd64") == {
+        "imageDigest": "sha256:amd64"
+    }
 
 
 class FakeEcr:


### PR DESCRIPTION
## Summary
- resolve provenance/SBOM OCI indexes to the Linux/AMD64 child scanned by ECR
- retry while ECR initializes scans and retain the CRITICAL publication gate
- use the patched Bookworm Python base and pull base updates on every production build

## Test plan
- [x] `make lint`
- [x] `uv run pytest tests/test_release_manifest.py -q`
- [x] live scan resolved all four AMD64 children and blocked their two current CRITICAL base findings
- [ ] main publication succeeds with patched base images

Made with [Cursor](https://cursor.com)