### PR TITLE
Minimize production runtime packages

### DIFF
--- a/apps/agate-api/Dockerfile
+++ b/apps/agate-api/Dockerfile
@@ -45,9 +45,10 @@ ENV APP_VERSION=${APP_VERSION} \
     GIT_SHA=${GIT_SHA} \
     BUILD_TIME=${BUILD_TIME}
 
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends curl \
-    && rm -rf /var/lib/apt/lists/*
+# The final Python service does not invoke Perl. Remove the unpatched Debian
+# runtime package (builders retain normal tooling); no package management runs
+# after this point.
+RUN dpkg --purge --force-depends --force-remove-essential perl-base
 
 COPY --from=builder /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
 COPY --from=builder /usr/local/bin /usr/local/bin

--- a/apps/core-api/Dockerfile
+++ b/apps/core-api/Dockerfile
@@ -38,6 +38,10 @@ ENV APP_VERSION=${APP_VERSION} \
     GIT_SHA=${GIT_SHA} \
     BUILD_TIME=${BUILD_TIME}
 
+# The final Python service does not invoke Perl. Remove the unpatched Debian
+# runtime package; no package management runs after this point.
+RUN dpkg --purge --force-depends --force-remove-essential perl-base
+
 COPY --from=builder /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
 COPY --from=builder /usr/local/bin /usr/local/bin
 

--- a/apps/stylebook-api/Dockerfile
+++ b/apps/stylebook-api/Dockerfile
@@ -36,6 +36,10 @@ ENV APP_VERSION=${APP_VERSION} \
     GIT_SHA=${GIT_SHA} \
     BUILD_TIME=${BUILD_TIME}
 
+# The final Python service does not invoke Perl. Remove the unpatched Debian
+# runtime package; no package management runs after this point.
+RUN dpkg --purge --force-depends --force-remove-essential perl-base
+
 COPY --from=builder /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
 COPY --from=builder /usr/local/bin /usr/local/bin
 

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -42,6 +42,10 @@ ENV APP_VERSION=${APP_VERSION} \
     GIT_SHA=${GIT_SHA} \
     BUILD_TIME=${BUILD_TIME}
 
+# The final Python service does not invoke Perl. Remove the unpatched Debian
+# runtime package; no package management runs after this point.
+RUN dpkg --purge --force-depends --force-remove-essential perl-base
+
 COPY --from=builder /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
 COPY --from=builder /usr/local/bin /usr/local/bin
 COPY apps/worker/scripts/entrypoint.sh /usr/local/bin/backfield-worker-entrypoint.sh


### PR DESCRIPTION
## Summary
- remove unused unpatched Perl from final Python service images without changing builders
- remove unused curl/libssh2 from the Agate runtime
- keep the CRITICAL ECR scan gate intact instead of allowing known findings

## Test plan
- [x] build all four Linux/AMD64 production images locally
- [x] run Python in each final image
- [x] verify `/usr/bin/perl` is absent in each final image
- [x] `make lint`
- [x] release-manifest unit tests
- [ ] ECR scan and canonical manifest publication

Made with [Cursor](https://cursor.com)