### PR TITLE
Enforce immutable artifact objects

### DIFF
--- a/scripts/release_manifest.py
+++ b/scripts/release_manifest.py
@@ -50,6 +50,49 @@ def sha256_file(path: Path) -> str:
     return digest.hexdigest()
 
 
+def _not_found(exc: ClientError) -> bool:
+    return str(exc.response.get("Error", {}).get("Code", "")) in {
+        "404",
+        "NoSuchKey",
+        "NotFound",
+    }
+
+
+def _publish_ui_archive(
+    s3: Any,
+    *,
+    bucket: str,
+    key: str,
+    archive: Path,
+    checksum: str,
+    source_sha: str,
+) -> None:
+    try:
+        head = s3.head_object(Bucket=bucket, Key=key)
+    except ClientError as exc:
+        if not _not_found(exc):
+            raise
+        try:
+            s3.put_object(
+                Bucket=bucket,
+                Key=key,
+                Body=archive.read_bytes(),
+                ContentType="application/gzip",
+                Metadata={"sha256": checksum, "source-sha": source_sha},
+                IfNoneMatch="*",
+            )
+        except ClientError as put_exc:
+            if put_exc.response.get("Error", {}).get("Code") != "PreconditionFailed":
+                raise
+        head = s3.head_object(Bucket=bucket, Key=key)
+    if int(head["ContentLength"]) != archive.stat().st_size:
+        raise RuntimeError(f"immutable UI size conflict for s3://{bucket}/{key}")
+    if head.get("Metadata", {}).get("sha256") != checksum:
+        raise RuntimeError(f"immutable UI checksum conflict for s3://{bucket}/{key}")
+    if head.get("Metadata", {}).get("source-sha") != source_sha:
+        raise RuntimeError(f"immutable UI source conflict for s3://{bucket}/{key}")
+
+
 def package_directory(source: Path, output: Path) -> None:
     """Create a deterministic gzip-compressed tar archive."""
     if not source.is_dir():
@@ -165,20 +208,14 @@ def build_manifest(
     for name, archive in ui_archives.items():
         checksum = sha256_file(archive)
         key = f"versions/{version}/ui/{name}.tar.gz"
-        s3.upload_file(
-            str(archive),
-            artifact_bucket,
-            key,
-            ExtraArgs={
-                "ContentType": "application/gzip",
-                "Metadata": {"sha256": checksum, "source-sha": source_sha},
-            },
+        _publish_ui_archive(
+            s3,
+            bucket=artifact_bucket,
+            key=key,
+            archive=archive,
+            checksum=checksum,
+            source_sha=source_sha,
         )
-        head = s3.head_object(Bucket=artifact_bucket, Key=key)
-        if int(head["ContentLength"]) != archive.stat().st_size:
-            raise RuntimeError(f"uploaded UI size mismatch for s3://{artifact_bucket}/{key}")
-        if head.get("Metadata", {}).get("sha256") != checksum:
-            raise RuntimeError(f"uploaded UI checksum metadata mismatch for {key}")
         ui[name] = {
             "object_key": key,
             "sha256": checksum,
@@ -200,16 +237,30 @@ def build_manifest(
 def publish_manifest(s3: Any, bucket: str, manifest: dict[str, Any]) -> str:
     key = f"manifests/{manifest['version']}.json"
     body = json.dumps(manifest, indent=2, sort_keys=True).encode()
-    s3.put_object(
-        Bucket=bucket,
-        Key=key,
-        Body=body,
-        ContentType="application/json",
-        Metadata={
-            "source-sha": str(manifest["source_sha"]),
-            "schema-version": str(manifest["schema_version"]),
-        },
-    )
+    try:
+        existing = s3.get_object(Bucket=bucket, Key=key)["Body"].read()
+    except ClientError as exc:
+        if not _not_found(exc):
+            raise
+        try:
+            s3.put_object(
+                Bucket=bucket,
+                Key=key,
+                Body=body,
+                ContentType="application/json",
+                Metadata={
+                    "source-sha": str(manifest["source_sha"]),
+                    "schema-version": str(manifest["schema_version"]),
+                },
+                IfNoneMatch="*",
+            )
+            return key
+        except ClientError as put_exc:
+            if put_exc.response.get("Error", {}).get("Code") != "PreconditionFailed":
+                raise
+            existing = s3.get_object(Bucket=bucket, Key=key)["Body"].read()
+    if existing != body:
+        raise RuntimeError(f"immutable manifest conflict for s3://{bucket}/{key}")
     return key
 
 

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from botocore.exceptions import ClientError
 
 _SCRIPT = Path(__file__).parents[1] / "scripts" / "release_manifest.py"
 _SPEC = importlib.util.spec_from_file_location("release_manifest", _SCRIPT)
@@ -20,6 +21,7 @@ package_directory = release_manifest.package_directory
 sha256_file = release_manifest.sha256_file
 validate_release_version = release_manifest.validate_release_version
 scan_image_id = release_manifest._scan_image_id
+publish_manifest = release_manifest.publish_manifest
 
 
 def test_canonical_version() -> None:
@@ -81,6 +83,54 @@ def test_scan_resolves_linux_amd64_child_from_oci_index() -> None:
     assert scan_image_id(FakeIndexEcr(), "backfield-worker", "main-abc-amd64") == {
         "imageDigest": "sha256:amd64"
     }
+
+
+class FakeBody:
+    def __init__(self, value: bytes) -> None:
+        self.value = value
+
+    def read(self) -> bytes:
+        return self.value
+
+
+class FakeManifestS3:
+    def __init__(self, existing: bytes | None) -> None:
+        self.existing = existing
+        self.put_calls: list[dict[str, Any]] = []
+
+    def get_object(self, **kwargs: Any) -> dict[str, Any]:
+        if self.existing is None:
+            raise ClientError({"Error": {"Code": "NoSuchKey"}}, "GetObject")
+        return {"Body": FakeBody(self.existing)}
+
+    def put_object(self, **kwargs: Any) -> None:
+        self.put_calls.append(kwargs)
+        self.existing = kwargs["Body"]
+
+
+def _minimal_manifest() -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "version": "main-0123456789ab-amd64",
+        "source_sha": "0123456789abcdef0123456789abcdef01234567",
+    }
+
+
+def test_manifest_publish_is_idempotent_and_conditional() -> None:
+    value = _minimal_manifest()
+    encoded = json.dumps(value, indent=2, sort_keys=True).encode()
+    existing = FakeManifestS3(encoded)
+    assert publish_manifest(existing, "artifacts", value).endswith(".json")
+    assert existing.put_calls == []
+
+    missing = FakeManifestS3(None)
+    publish_manifest(missing, "artifacts", value)
+    assert missing.put_calls[0]["IfNoneMatch"] == "*"
+
+
+def test_manifest_publish_rejects_immutable_conflict() -> None:
+    with pytest.raises(RuntimeError, match="immutable manifest conflict"):
+        publish_manifest(FakeManifestS3(b"{}"), "artifacts", _minimal_manifest())
 
 
 class FakeEcr:


### PR DESCRIPTION
## Summary
- publish UI archives and manifests with conditional S3 writes
- treat byte-identical retries as success while rejecting checksum, size, source, or manifest conflicts
- cover idempotent and conflicting manifest publication behavior

## Test plan
- [x] `make lint`
- [x] `uv run pytest tests/test_release_manifest.py -q`
- [ ] merge and verify canonical main publication

Made with [Cursor](https://cursor.com)