### PR TITLE
Keep publication gated by fast smoke only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,11 +111,6 @@ jobs:
           make smoke-auth
           make smoke-agate-basic
           make smoke-stylebook-basic
-      - name: Agate to Stylebook handoff smoke
-        env:
-          SMOKE_EMAIL: smoke-ci@local.test
-          SMOKE_PASSWORD: smoke-ci-pass-change-in-prod
-        run: make smoke
       - name: Dump compose logs on failure
         if: failure()
         run: docker compose -f infra/docker-compose.yml logs


### PR DESCRIPTION
## Summary
- remove the slower Agate-to-Stylebook golden-path lane from required CI
- retain auth, Agate basic, and Stylebook basic fast smoke as publication gates
- align CI with the documented lint + test + fast-smoke release contract

## Test plan
- [x] workflow YAML parse
- [ ] required PR CI passes
- [ ] main artifact publication succeeds

Made with [Cursor](https://cursor.com)