### PR TITLE
fix: sync Agate nodes before build:check typecheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ ui-test:
 
 agate-ui-build:
 	cd packages/backfield-ui && npm ci
-	cd apps/agate-ui && npm ci && npm run build:check
+	cd apps/agate-ui && npm ci && npm run sync-nodes && npm run build:check
 
 stylebook-ui-build:
 	cd packages/backfield-ui && npm ci

--- a/apps/agate-ui/package.json
+++ b/apps/agate-ui/package.json
@@ -9,7 +9,7 @@
     "prebuild": "npm run sync-nodes",
     "dev": "vite",
     "build": "vite build",
-    "build:check": "tsc && vite build",
+    "build:check": "npm run sync-nodes && tsc && vite build",
     "preview": "vite preview",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "test": "vitest run"


### PR DESCRIPTION
## Summary
- Run `sync-nodes` before `tsc` in Agate `build:check` and `make agate-ui-build`.
- Fixes post-#59 main CI failures where gitignored `registry.ts` was missing because `build:check` bypasses npm `prebuild`.

## Test plan
- [ ] CI `ui` job / `make ui-build` succeeds on this PR
- [ ] Locally: `cd apps/agate-ui && npm ci && npm run build:check`


Made with [Cursor](https://cursor.com)