### PR TITLE
fix: derive Stylebook/Agate sibling UI hosts at runtime

### DIFF
--- a/apps/agate-ui/DEPLOY.md
+++ b/apps/agate-ui/DEPLOY.md
@@ -33,7 +33,7 @@ make build-prd
 
 Optional: `VITE_TIMEZONE=America/Chicago` (default in app code).
 
-**Cross-app links (Agate → Stylebook on processed-item review, sidebar, etc.):** set `VITE_STYLEBOOK_UI_ORIGIN` at build time when Stylebook is not on the same browser origin as Agate. Same-origin deploys can omit it (links use `window.location.origin`). Local dev defaults live in `.env.development` and Compose — see [Frontend conventions](../../docs/development/frontend/conventions.md).
+**Cross-app links (Agate → Stylebook on processed-item review, sidebar, etc.):** Backfield Cloud split hosts (`agate.*` / `stylebook.*`) derive the sibling origin at runtime, so shared artifacts do not need per-client `VITE_*_UI_ORIGIN` bake-ins. Set `VITE_STYLEBOOK_UI_ORIGIN` only for custom host layouts. Local dev defaults live in `.env.development` and Compose — see [Frontend conventions](../../docs/development/frontend/conventions.md).
 
 ## Deploy
 

--- a/apps/agate-ui/src/lib/platformUrls.test.ts
+++ b/apps/agate-ui/src/lib/platformUrls.test.ts
@@ -1,0 +1,21 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { stylebookShellHref, stylebookUiOrigin } from './platformUrls'
+
+describe('platformUrls sibling hosts', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.unstubAllEnvs()
+  })
+
+  it('links Stylebook on the stylebook host when browsing Agate', () => {
+    vi.stubGlobal('window', {
+      location: { origin: 'https://agate.cpm.backfield.news' },
+    })
+
+    expect(stylebookUiOrigin()).toBe('https://stylebook.cpm.backfield.news')
+    expect(stylebookShellHref('cpm-stylebook', 'general')).toBe(
+      'https://stylebook.cpm.backfield.news/stylebook/cpm-stylebook?project=general',
+    )
+  })
+})

--- a/apps/agate-ui/src/lib/platformUrls.ts
+++ b/apps/agate-ui/src/lib/platformUrls.ts
@@ -1,25 +1,28 @@
 /** Cross-app navigation (Agate ↔ Stylebook SPAs). */
 
-export function agateUiOrigin(): string {
-  const raw = import.meta.env.VITE_AGATE_UI_ORIGIN
-  if (typeof raw === 'string' && raw.trim() !== '') {
-    return raw.trim().replace(/\/$/, '')
-  }
+import { resolveUiOrigin } from '@backfield/ui/siblingUiOrigin'
+
+function browserOrigin(): string {
   if (typeof window !== 'undefined') {
     return window.location.origin
   }
   return ''
 }
 
+export function agateUiOrigin(): string {
+  return resolveUiOrigin({
+    envOverride: import.meta.env.VITE_AGATE_UI_ORIGIN,
+    currentOrigin: browserOrigin(),
+    targetApp: 'agate',
+  })
+}
+
 export function stylebookUiOrigin(): string {
-  const raw = import.meta.env.VITE_STYLEBOOK_UI_ORIGIN
-  if (typeof raw === 'string' && raw.trim() !== '') {
-    return raw.trim().replace(/\/$/, '')
-  }
-  if (typeof window !== 'undefined') {
-    return window.location.origin
-  }
-  return ''
+  return resolveUiOrigin({
+    envOverride: import.meta.env.VITE_STYLEBOOK_UI_ORIGIN,
+    currentOrigin: browserOrigin(),
+    targetApp: 'stylebook',
+  })
 }
 
 /** External docs or fallback to Agate `/help`. */

--- a/apps/stylebook-ui/src/lib/platformUrls.ts
+++ b/apps/stylebook-ui/src/lib/platformUrls.ts
@@ -1,30 +1,33 @@
 /** Cross-app navigation (Agate ↔ Stylebook SPAs). */
 
-export function agateUiOrigin(): string {
-  const raw = import.meta.env.VITE_AGATE_UI_ORIGIN
-  if (typeof raw === 'string' && raw.trim() !== '') {
-    return raw.trim().replace(/\/$/, '')
-  }
-  if (typeof window !== 'undefined') {
+import { resolveUiOrigin } from "@backfield/ui/siblingUiOrigin"
+
+function browserOrigin(): string {
+  if (typeof window !== "undefined") {
     return window.location.origin
   }
-  return ''
+  return ""
+}
+
+export function agateUiOrigin(): string {
+  return resolveUiOrigin({
+    envOverride: import.meta.env.VITE_AGATE_UI_ORIGIN,
+    currentOrigin: browserOrigin(),
+    targetApp: "agate",
+  })
 }
 
 export function stylebookUiOrigin(): string {
-  const raw = import.meta.env.VITE_STYLEBOOK_UI_ORIGIN
-  if (typeof raw === 'string' && raw.trim() !== '') {
-    return raw.trim().replace(/\/$/, '')
-  }
-  if (typeof window !== 'undefined') {
-    return window.location.origin
-  }
-  return ''
+  return resolveUiOrigin({
+    envOverride: import.meta.env.VITE_STYLEBOOK_UI_ORIGIN,
+    currentOrigin: browserOrigin(),
+    targetApp: "stylebook",
+  })
 }
 
 export function helpHref(): string {
   const raw = import.meta.env.VITE_HELP_URL
-  if (typeof raw === 'string' && raw.trim() !== '') {
+  if (typeof raw === "string" && raw.trim() !== "") {
     return raw.trim()
   }
   return `${agateUiOrigin()}/help`
@@ -32,12 +35,12 @@ export function helpHref(): string {
 
 /** Agate SPA project home (flows, runs, settings). */
 export function agateProjectHref(projectSlug: string): string {
-  const base = agateUiOrigin().replace(/\/$/, '')
+  const base = agateUiOrigin().replace(/\/$/, "")
   return `${base}/project/${encodeURIComponent(projectSlug)}`
 }
 
 /** Agate SPA workspace hub. */
 export function agateWorkspaceHref(workspaceSlug: string): string {
-  const base = agateUiOrigin().replace(/\/$/, '')
+  const base = agateUiOrigin().replace(/\/$/, "")
   return `${base}/workspace/${encodeURIComponent(workspaceSlug)}`
 }

--- a/docs/development/frontend/conventions.md
+++ b/docs/development/frontend/conventions.md
@@ -59,8 +59,11 @@ Local development keeps one browser origin per UI and proxies:
 - `/api/stylebook` to Stylebook API
 
 The production bundles use the same relative paths. `VITE_AGATE_UI_ORIGIN` and
-`VITE_STYLEBOOK_UI_ORIGIN` are optional cross-app origin overrides; otherwise links
-use `window.location.origin`.
+`VITE_STYLEBOOK_UI_ORIGIN` are optional cross-app origin overrides. When unset,
+shared multi-client artifacts derive the sibling host from the current origin
+(`agate.{client}…` ↔ `stylebook.{client}…`) so one UI build works for every
+tenant. Non-split hosts (local same-origin, custom domains) keep
+`window.location.origin`.
 
 ## Shared UI package
 

--- a/docs/development/frontend/stylebook.md
+++ b/docs/development/frontend/stylebook.md
@@ -167,7 +167,8 @@ flagged item links to its canonical detail page.
 Agate builds Stylebook links through `apps/agate-ui/src/lib/platformUrls.ts` and
 passes the selected workspace Stylebook slug plus optional project context.
 Stylebook workspace and project links return to Agate through its own platform URL
-helpers. Leave origins unset for same-origin deployment or set the paired
-`VITE_*_UI_ORIGIN` values for sibling hosts.
+helpers. Leave origins unset for Backfield Cloud split hosts (sibling origins are
+derived from the current hostname) or same-origin local deploys; set the paired
+`VITE_*_UI_ORIGIN` values only for custom host layouts.
 
 Apply [`conventions.md`](conventions.md) to all Stylebook copy and UI behavior.

--- a/packages/backfield-ui/package.json
+++ b/packages/backfield-ui/package.json
@@ -11,6 +11,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./nodeOutputs": "./src/nodeOutputs.ts",
+    "./siblingUiOrigin": "./src/siblingUiOrigin.ts",
     "./LeafletMap": "./src/LeafletMap.tsx",
     "./GeometryEditLeafletMap": "./src/GeometryEditLeafletMap.tsx",
     "./axisAlignedRectangle": "./src/axisAlignedRectangle.ts"

--- a/packages/backfield-ui/src/index.ts
+++ b/packages/backfield-ui/src/index.ts
@@ -12,6 +12,11 @@ export {
 } from "./ShellSidebar"
 export { cn } from "./cn"
 export {
+  resolveUiOrigin,
+  swapUiHostname,
+  type UiApp,
+} from "./siblingUiOrigin"
+export {
   LeafletMap,
   photonExtentToLeafletLatLngBounds,
   type LeafletMapProps,

--- a/packages/backfield-ui/src/siblingUiOrigin.test.ts
+++ b/packages/backfield-ui/src/siblingUiOrigin.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest"
+
+import { resolveUiOrigin, swapUiHostname } from "./siblingUiOrigin"
+
+describe("swapUiHostname", () => {
+  it("maps production and staging Backfield hosts", () => {
+    expect(swapUiHostname("agate.cpm.backfield.news", "stylebook")).toBe(
+      "stylebook.cpm.backfield.news",
+    )
+    expect(swapUiHostname("stylebook.cpm.backfield.news", "agate")).toBe(
+      "agate.cpm.backfield.news",
+    )
+    expect(swapUiHostname("agate.canary.stg.backfield.news", "stylebook")).toBe(
+      "stylebook.canary.stg.backfield.news",
+    )
+  })
+
+  it("leaves non-split hosts unchanged", () => {
+    expect(swapUiHostname("localhost", "stylebook")).toBe("localhost")
+    expect(swapUiHostname("app.example.com", "agate")).toBe("app.example.com")
+  })
+})
+
+describe("resolveUiOrigin", () => {
+  it("prefers explicit env overrides", () => {
+    expect(
+      resolveUiOrigin({
+        envOverride: "https://stylebook.example.com/",
+        currentOrigin: "https://agate.cpm.backfield.news",
+        targetApp: "stylebook",
+      }),
+    ).toBe("https://stylebook.example.com")
+  })
+
+  it("derives sibling origins for shared multi-client artifacts", () => {
+    expect(
+      resolveUiOrigin({
+        envOverride: "",
+        currentOrigin: "https://agate.cpm.backfield.news",
+        targetApp: "stylebook",
+      }),
+    ).toBe("https://stylebook.cpm.backfield.news")
+
+    expect(
+      resolveUiOrigin({
+        currentOrigin: "https://stylebook.canary.stg.backfield.news",
+        targetApp: "agate",
+      }),
+    ).toBe("https://agate.canary.stg.backfield.news")
+  })
+
+  it("keeps same-origin fallback for local and custom hosts", () => {
+    expect(
+      resolveUiOrigin({
+        currentOrigin: "http://localhost:5173",
+        targetApp: "stylebook",
+      }),
+    ).toBe("http://localhost:5173")
+  })
+})

--- a/packages/backfield-ui/src/siblingUiOrigin.ts
+++ b/packages/backfield-ui/src/siblingUiOrigin.ts
@@ -1,0 +1,50 @@
+/** Split-host SPA origins for Backfield Cloud front doors. */
+
+export type UiApp = "agate" | "stylebook"
+
+/**
+ * Map `agate.{client}…` ↔ `stylebook.{client}…` when the first DNS label is the
+ * product host. Custom / same-origin hosts are left unchanged.
+ */
+export function swapUiHostname(hostname: string, target: UiApp): string {
+  const labels = hostname.split(".")
+  const first = labels[0]
+  if (first === "agate" || first === "stylebook") {
+    labels[0] = target
+    return labels.join(".")
+  }
+  return hostname
+}
+
+/**
+ * Resolve a cross-app origin.
+ *
+ * Prefer an explicit `VITE_*_UI_ORIGIN` override. Otherwise derive the sibling
+ * host from the current browser origin so one shared UI artifact works for every
+ * client (`agate.cpm.backfield.news` → `stylebook.cpm.backfield.news`, etc.).
+ * Falls back to the current origin when the hostname is not a split UI host
+ * (local same-origin / custom domains).
+ */
+export function resolveUiOrigin(opts: {
+  envOverride?: string | null
+  currentOrigin: string
+  targetApp: UiApp
+}): string {
+  const override = typeof opts.envOverride === "string" ? opts.envOverride.trim() : ""
+  if (override) {
+    return override.replace(/\/$/, "")
+  }
+
+  const current = opts.currentOrigin.trim().replace(/\/$/, "")
+  if (!current) {
+    return ""
+  }
+
+  try {
+    const url = new URL(current)
+    url.hostname = swapUiHostname(url.hostname, opts.targetApp)
+    return url.origin
+  } catch {
+    return current
+  }
+}


### PR DESCRIPTION
## Summary
- Shared multi-client UI artifacts left `VITE_STYLEBOOK_UI_ORIGIN` unset, so Agate nav links stayed on `agate.*` (e.g. `https://agate.cpm.backfield.news/stylebook/...`).
- Derive `agate.*` ↔ `stylebook.*` sibling origins at runtime when Vite overrides are absent, with same-origin fallback for local/custom hosts.
- Cover the helper and Agate shell href in unit tests; update frontend deploy docs.

## Test plan
- [x] `packages/backfield-ui` sibling origin unit tests
- [x] `agate-ui` `platformUrls` unit test for CPM-shaped host
- [ ] After merge/publish: deploy UI artifact to CPM and confirm sidebar Stylebook link opens `https://stylebook.cpm.backfield.news/stylebook/...`
- [ ] Confirm canary cross-app links still work after UI promote


Made with [Cursor](https://cursor.com)