### PR TITLE
Fix Playground staging host parsing and sidebar links

### DIFF
--- a/apps/agate-ui/src/lib/platformUrls.test.ts
+++ b/apps/agate-ui/src/lib/platformUrls.test.ts
@@ -44,6 +44,14 @@ describe('platformUrls sibling hosts', () => {
     expect(playgroundHref()).toBe('https://playground.cpm.backfield.news')
   })
 
+  it('preserves staging when linking to the Playground', () => {
+    vi.stubGlobal('window', {
+      location: { origin: 'https://agate.canary.stg.backfield.news' },
+    })
+
+    expect(playgroundHref()).toBe('https://playground.canary.stg.backfield.news')
+  })
+
   it('supports an organization placeholder in a custom Playground URL', () => {
     vi.stubGlobal('window', {
       location: { origin: 'https://agate.cpm.backfield.news' },

--- a/apps/agate-ui/src/lib/platformUrls.ts
+++ b/apps/agate-ui/src/lib/platformUrls.ts
@@ -1,6 +1,6 @@
 /** Cross-app navigation (Agate ↔ Stylebook SPAs). */
 
-import { resolveUiOrigin } from '@backfield/ui/siblingUiOrigin'
+import { resolveUiOrigin, swapUiHostname } from '@backfield/ui/siblingUiOrigin'
 
 function browserOrigin(): string {
   if (typeof window !== 'undefined') {
@@ -62,6 +62,18 @@ export function playgroundHref(): string {
   const override = import.meta.env.VITE_PLAYGROUND_URL
   if (typeof override === 'string' && override.trim() !== '') {
     return override.trim().replace('{organization_slug}', organizationSlug)
+  }
+  // Swap the product label only so staging (`.stg.`) is preserved.
+  if (origin) {
+    try {
+      const url = new URL(origin)
+      const swapped = swapUiHostname(url.hostname, 'playground')
+      if (swapped !== url.hostname) {
+        return `https://${swapped}`
+      }
+    } catch {
+      // Fall through to the generic playground host.
+    }
   }
   return organizationSlug
     ? `https://playground.${organizationSlug}.backfield.news`

--- a/apps/api-playground/README.md
+++ b/apps/api-playground/README.md
@@ -1,11 +1,13 @@
 # Backfield Public API Playground
 
 `apps/api-playground` is the schema-driven developer client for browsing and exercising the public
-API. It is served on tenant-specific production domains such as
-`https://playground.example-newsroom.backfield.news`.
+API. It is served on tenant-specific domains such as
+`https://playground.example-newsroom.backfield.news` (production) and
+`https://playground.example-newsroom.stg.backfield.news` (staging).
 
-The app infers the organization slug from its own hostname and calls exactly
-`https://api.{organization-slug}.backfield.news`. On localhost it automatically uses
+The app infers the organization slug and environment from its own hostname and calls the matching
+API origin (`https://api.{organization-slug}.backfield.news` or
+`https://api.{organization-slug}.stg.backfield.news`). On localhost it automatically uses
 `http://localhost:8004`. There is no organization or API-origin selector.
 
 Agate and Stylebook link to the matching tenant Playground from their sidebar footer. Their

--- a/apps/api-playground/src/App.tsx
+++ b/apps/api-playground/src/App.tsx
@@ -14,7 +14,7 @@ import {
   LOCAL_AGATE_ORIGIN,
   LOCAL_API_ORIGIN,
   LOCAL_STYLEBOOK_API_ORIGIN,
-  organizationSlugFromPlaygroundHost,
+  parsePlaygroundHost,
 } from "./lib/origin"
 import {
   fetchPlatformContext,
@@ -68,21 +68,23 @@ function groupOperations(operations: PlaygroundOperation[]): OperationGroup[] {
 
 export default function App() {
   const localAvailable = isLocalPlaygroundHost(window.location.hostname)
-  const organizationSlug = organizationSlugFromPlaygroundHost(window.location.hostname)
+  const tenant = parsePlaygroundHost(window.location.hostname)
+  const organizationSlug = tenant?.slug ?? ""
+  const parentDomain = tenant?.parentDomain ?? "backfield.news"
   const apiOrigin = localAvailable
     ? LOCAL_API_ORIGIN
-    : organizationSlug
-      ? deriveApiOrigin(organizationSlug)
+    : tenant
+      ? deriveApiOrigin(organizationSlug, parentDomain)
       : ""
   const stylebookApiOrigin = localAvailable
     ? LOCAL_STYLEBOOK_API_ORIGIN
-    : organizationSlug
-      ? deriveStylebookApiOrigin(organizationSlug)
+    : tenant
+      ? deriveStylebookApiOrigin(organizationSlug, parentDomain)
       : ""
   const agateOrigin = localAvailable
     ? LOCAL_AGATE_ORIGIN
-    : organizationSlug
-      ? deriveProductOrigin("agate", organizationSlug)
+    : tenant
+      ? deriveProductOrigin("agate", organizationSlug, parentDomain)
       : ""
   const [apiKey, setApiKey] = useState(() => readSessionValue(API_KEY_SESSION_STORAGE))
   const [apiKeyDraft, setApiKeyDraft] = useState(apiKey)
@@ -310,6 +312,7 @@ export default function App() {
           <PlatformSidebar
             context={platformContext}
             organizationSlug={organizationSlug}
+            parentDomain={parentDomain}
             local={localAvailable}
           />
         ) : sessionLoading ? (

--- a/apps/api-playground/src/components/PlatformSidebar.tsx
+++ b/apps/api-playground/src/components/PlatformSidebar.tsx
@@ -15,6 +15,7 @@ import {
   LOCAL_AGATE_ORIGIN,
   LOCAL_STYLEBOOK_ORIGIN,
   deriveProductOrigin,
+  type ParentDomain,
 } from "../lib/origin"
 import type { PlatformContext } from "../lib/session"
 
@@ -36,12 +37,14 @@ function readExpandedWorkspaceSlugs(): Set<string> {
 interface PlatformSidebarProps {
   context: PlatformContext
   organizationSlug: string
+  parentDomain: ParentDomain
   local: boolean
 }
 
 export default function PlatformSidebar({
   context,
   organizationSlug,
+  parentDomain,
   local,
 }: PlatformSidebarProps) {
   const [expandedWorkspaceSlugs, setExpandedWorkspaceSlugs] = useState<Set<string>>(
@@ -49,10 +52,10 @@ export default function PlatformSidebar({
   )
   const agateOrigin = local
     ? LOCAL_AGATE_ORIGIN
-    : deriveProductOrigin("agate", organizationSlug)
+    : deriveProductOrigin("agate", organizationSlug, parentDomain)
   const stylebookOrigin = local
     ? LOCAL_STYLEBOOK_ORIGIN
-    : deriveProductOrigin("stylebook", organizationSlug)
+    : deriveProductOrigin("stylebook", organizationSlug, parentDomain)
 
   useEffect(() => {
     try {

--- a/apps/api-playground/src/lib/origin.test.ts
+++ b/apps/api-playground/src/lib/origin.test.ts
@@ -2,14 +2,29 @@ import { describe, expect, it } from "vitest"
 
 import {
   deriveApiOrigin,
+  deriveProductOrigin,
+  deriveStylebookApiOrigin,
   normalizeOrganizationSlug,
   organizationSlugFromPlaygroundHost,
+  parsePlaygroundHost,
   validateOrganizationSlug,
 } from "./origin"
 
 describe("organization API origin", () => {
   it("derives only the organization API hostname", () => {
     expect(deriveApiOrigin(" Local-Angle ")).toBe("https://api.local-angle.backfield.news")
+    expect(deriveApiOrigin("canary", "stg.backfield.news")).toBe(
+      "https://api.canary.stg.backfield.news",
+    )
+  })
+
+  it("derives product and Stylebook API origins for staging", () => {
+    expect(deriveProductOrigin("agate", "canary", "stg.backfield.news")).toBe(
+      "https://agate.canary.stg.backfield.news",
+    )
+    expect(deriveStylebookApiOrigin("canary", "stg.backfield.news")).toBe(
+      "https://stylebook.canary.stg.backfield.news/api/stylebook",
+    )
   })
 
   it("normalizes and rejects unsafe slugs", () => {
@@ -23,7 +38,26 @@ describe("organization API origin", () => {
     expect(organizationSlugFromPlaygroundHost("playground.local-angle.backfield.news")).toBe(
       "local-angle",
     )
+    expect(organizationSlugFromPlaygroundHost("playground.canary.stg.backfield.news")).toBe(
+      "canary",
+    )
     expect(organizationSlugFromPlaygroundHost("playground.backfield.news")).toBe("")
     expect(organizationSlugFromPlaygroundHost("developer-tools.example.test")).toBe("")
+  })
+
+  it("parses production and staging Playground hosts", () => {
+    expect(parsePlaygroundHost("playground.cpm.backfield.news")).toEqual({
+      slug: "cpm",
+      parentDomain: "backfield.news",
+    })
+    expect(parsePlaygroundHost("playground.canary.stg.backfield.news")).toEqual({
+      slug: "canary",
+      parentDomain: "stg.backfield.news",
+    })
+    expect(parsePlaygroundHost("playground.canary.backfield.news")).toEqual({
+      slug: "canary",
+      parentDomain: "backfield.news",
+    })
+    expect(parsePlaygroundHost("agate.canary.stg.backfield.news")).toBeNull()
   })
 })

--- a/apps/api-playground/src/lib/origin.ts
+++ b/apps/api-playground/src/lib/origin.ts
@@ -5,6 +5,14 @@ export const LOCAL_STYLEBOOK_API_ORIGIN = "http://localhost:8003"
 export const LOCAL_AGATE_ORIGIN = "http://localhost:5173"
 export const LOCAL_STYLEBOOK_ORIGIN = "http://localhost:5175"
 
+/** Parent domain after `{app}.{slug}.` — production or staging. */
+export type ParentDomain = "backfield.news" | "stg.backfield.news"
+
+export type PlaygroundTenant = {
+  slug: string
+  parentDomain: ParentDomain
+}
+
 export function normalizeOrganizationSlug(value: string): string {
   return value.trim().toLowerCase()
 }
@@ -20,48 +28,75 @@ export function validateOrganizationSlug(value: string): string | undefined {
   return undefined
 }
 
-export function deriveApiOrigin(organizationSlug: string): string {
+function requireSlug(organizationSlug: string): string {
   const slug = normalizeOrganizationSlug(organizationSlug)
   const error = validateOrganizationSlug(slug)
   if (error) {
     throw new Error(error)
   }
-  return `https://api.${slug}.backfield.news`
+  return slug
 }
 
-export function deriveStylebookApiOrigin(organizationSlug: string): string {
-  const slug = normalizeOrganizationSlug(organizationSlug)
-  const error = validateOrganizationSlug(slug)
-  if (error) {
-    throw new Error(error)
-  }
-  return `https://stylebook.${slug}.backfield.news/api/stylebook`
+export function deriveApiOrigin(
+  organizationSlug: string,
+  parentDomain: ParentDomain = "backfield.news",
+): string {
+  return `https://api.${requireSlug(organizationSlug)}.${parentDomain}`
+}
+
+export function deriveStylebookApiOrigin(
+  organizationSlug: string,
+  parentDomain: ParentDomain = "backfield.news",
+): string {
+  return `https://stylebook.${requireSlug(organizationSlug)}.${parentDomain}/api/stylebook`
 }
 
 export function deriveProductOrigin(
   product: "agate" | "stylebook",
   organizationSlug: string,
+  parentDomain: ParentDomain = "backfield.news",
 ): string {
-  const slug = normalizeOrganizationSlug(organizationSlug)
-  const error = validateOrganizationSlug(slug)
-  if (error) {
-    throw new Error(error)
+  return `https://${product}.${requireSlug(organizationSlug)}.${parentDomain}`
+}
+
+/**
+ * Parse a tenant Playground hostname.
+ *
+ * Production: `playground.{slug}.backfield.news`
+ * Staging:    `playground.{slug}.stg.backfield.news`
+ */
+export function parsePlaygroundHost(hostname: string): PlaygroundTenant | null {
+  const labels = hostname.toLowerCase().replace(/\.$/, "").split(".")
+  let slug = ""
+  let parentDomain: ParentDomain | null = null
+
+  if (
+    labels.length === 4 &&
+    labels[0] === "playground" &&
+    labels[2] === "backfield" &&
+    labels[3] === "news"
+  ) {
+    slug = normalizeOrganizationSlug(labels[1] ?? "")
+    parentDomain = "backfield.news"
+  } else if (
+    labels.length === 5 &&
+    labels[0] === "playground" &&
+    labels[2] === "stg" &&
+    labels[3] === "backfield" &&
+    labels[4] === "news"
+  ) {
+    slug = normalizeOrganizationSlug(labels[1] ?? "")
+    parentDomain = "stg.backfield.news"
   }
-  return `https://${product}.${slug}.backfield.news`
+
+  if (!parentDomain || validateOrganizationSlug(slug)) {
+    return null
+  }
+  return { slug, parentDomain }
 }
 
 export function organizationSlugFromPlaygroundHost(hostname: string): string {
-  const labels = hostname.toLowerCase().replace(/\.$/, "").split(".")
-  if (
-    labels.length !== 4 ||
-    labels[0] !== "playground" ||
-    labels[2] !== "backfield" ||
-    labels[3] !== "news"
-  ) {
-    return ""
-  }
-  const slug = normalizeOrganizationSlug(labels[1])
-  return validateOrganizationSlug(slug) ? "" : slug
+  return parsePlaygroundHost(hostname)?.slug ?? ""
 }
 
 export function isLocalPlaygroundHost(hostname: string): boolean {

--- a/apps/stylebook-ui/src/lib/platformUrls.test.ts
+++ b/apps/stylebook-ui/src/lib/platformUrls.test.ts
@@ -16,6 +16,14 @@ describe("Playground navigation", () => {
     expect(playgroundHref()).toBe("https://playground.cpm.backfield.news")
   })
 
+  it("preserves staging when linking to the Playground", () => {
+    vi.stubGlobal("window", {
+      location: { origin: "https://stylebook.canary.stg.backfield.news" },
+    })
+
+    expect(playgroundHref()).toBe("https://playground.canary.stg.backfield.news")
+  })
+
   it("uses the local Playground while developing locally", () => {
     vi.stubGlobal("window", {
       location: { origin: "http://localhost:5175" },

--- a/apps/stylebook-ui/src/lib/platformUrls.ts
+++ b/apps/stylebook-ui/src/lib/platformUrls.ts
@@ -1,6 +1,6 @@
 /** Cross-app navigation (Agate ↔ Stylebook SPAs). */
 
-import { resolveUiOrigin } from "@backfield/ui/siblingUiOrigin"
+import { resolveUiOrigin, swapUiHostname } from "@backfield/ui/siblingUiOrigin"
 
 function browserOrigin(): string {
   if (typeof window !== "undefined") {
@@ -61,6 +61,18 @@ export function playgroundHref(): string {
   const override = import.meta.env.VITE_PLAYGROUND_URL
   if (typeof override === "string" && override.trim() !== "") {
     return override.trim().replace("{organization_slug}", organizationSlug)
+  }
+  // Swap the product label only so staging (`.stg.`) is preserved.
+  if (origin) {
+    try {
+      const url = new URL(origin)
+      const swapped = swapUiHostname(url.hostname, "playground")
+      if (swapped !== url.hostname) {
+        return `https://${swapped}`
+      }
+    } catch {
+      // Fall through to the generic playground host.
+    }
   }
   return organizationSlug
     ? `https://playground.${organizationSlug}.backfield.news`

--- a/packages/backfield-ui/src/siblingUiOrigin.test.ts
+++ b/packages/backfield-ui/src/siblingUiOrigin.test.ts
@@ -13,6 +13,12 @@ describe("swapUiHostname", () => {
     expect(swapUiHostname("agate.canary.stg.backfield.news", "stylebook")).toBe(
       "stylebook.canary.stg.backfield.news",
     )
+    expect(swapUiHostname("agate.canary.stg.backfield.news", "playground")).toBe(
+      "playground.canary.stg.backfield.news",
+    )
+    expect(swapUiHostname("stylebook.cpm.backfield.news", "playground")).toBe(
+      "playground.cpm.backfield.news",
+    )
   })
 
   it("leaves non-split hosts unchanged", () => {

--- a/packages/backfield-ui/src/siblingUiOrigin.ts
+++ b/packages/backfield-ui/src/siblingUiOrigin.ts
@@ -1,15 +1,16 @@
 /** Split-host SPA origins for Backfield Cloud front doors. */
 
-export type UiApp = "agate" | "stylebook"
+export type UiApp = "agate" | "stylebook" | "playground"
 
 /**
- * Map `agate.{client}…` ↔ `stylebook.{client}…` when the first DNS label is the
- * product host. Custom / same-origin hosts are left unchanged.
+ * Map `agate|stylebook|playground.{client}…` when the first DNS label is a
+ * product host. Preserves staging (`.stg.`) and production suffixes. Custom /
+ * same-origin hosts are left unchanged.
  */
 export function swapUiHostname(hostname: string, target: UiApp): string {
   const labels = hostname.split(".")
   const first = labels[0]
-  if (first === "agate" || first === "stylebook") {
+  if (first === "agate" || first === "stylebook" || first === "playground") {
     labels[0] = target
     return labels.join(".")
   }


### PR DESCRIPTION
## Summary
- Parse both production (`playground.{slug}.backfield.news`) and staging (`playground.{slug}.stg.backfield.news`) Playground hosts, and derive API/product origins with the matching parent domain.
- Preserve `.stg.` when Agate/Stylebook sidebar links swap to the Playground host (same pattern as Agate↔Stylebook sibling derivation).
- Document staging hostnames in the Playground README.

## Test plan
- [x] `apps/api-playground` origin + App unit tests
- [x] Agate/Stylebook `playgroundHref` tests for staging
- [x] `siblingUiOrigin` playground swap tests
- [ ] After merge + publish-artifacts: redeploy canary to `main-<sha>-amd64` and confirm `https://playground.canary.stg.backfield.news` loads the sidebar and resolves `https://api.canary.stg.backfield.news`
- [ ] From Agate canary, confirm the Playground footer link targets `playground.canary.stg.backfield.news`


Made with [Cursor](https://cursor.com)