### PR TITLE
Fix concurrent idempotency claim session synchronization

### DIFF
--- a/apps/core-api/src/core_api/run_enqueue.py
+++ b/apps/core-api/src/core_api/run_enqueue.py
@@ -81,6 +81,10 @@ def claim_idempotency_enqueue(
             enqueue_attempt_count=column("enqueue_attempt_count") + 1,
             enqueue_last_error=None,
         )
+        # This is an atomic database claim; the caller refreshes the record
+        # afterward. Avoid Python-side predicate evaluation, which can compare
+        # SQLite's naive datetimes with the aware UTC cutoff during a race.
+        .execution_options(synchronize_session=False)
     )
     session.commit()
     return int(result.rowcount or 0) == 1


### PR DESCRIPTION
## Summary
- Disable SQLAlchemy's Python-side session synchronization for the atomic idempotency enqueue claim.
- Avoid comparing SQLite's naive in-memory timestamps with an aware UTC cutoff during concurrent requests.
- Preserve database-side atomic claim behavior; callers already refresh the record after claiming.

## Test plan
- [x] Concurrent idempotency test passed 20 consecutive runs
- [x] `uv run pytest -q tests/core_api/test_public_runs.py` (17 passed)
- [x] `uv run ruff check apps/core-api/src/core_api/run_enqueue.py`


Made with [Cursor](https://cursor.com)