### PR TITLE
Route Playground session calls through the Agate host

### DIFF
--- a/apps/api-playground/README.md
+++ b/apps/api-playground/README.md
@@ -5,9 +5,10 @@ API. It is served on tenant-specific domains such as
 `https://playground.example-newsroom.backfield.news` (production) and
 `https://playground.example-newsroom.stg.backfield.news` (staging).
 
-The app infers the organization slug and environment from its own hostname and calls the matching
-API origin (`https://api.{organization-slug}.backfield.news` or
-`https://api.{organization-slug}.stg.backfield.news`). On localhost it automatically uses
+The app infers the organization slug and environment from its own hostname. Public schema and
+API execution use `https://api.{organization-slug}.[stg.]backfield.news`. Signed-in shell
+session calls use the matching Agate host (`https://agate.{organization-slug}.[stg.]backfield.news`),
+because cloud `api.*` front doors only expose `/public/v1`. On localhost both use
 `http://localhost:8004`. There is no organization or API-origin selector.
 
 Agate and Stylebook link to the matching tenant Playground from their sidebar footer. Their

--- a/apps/api-playground/src/App.test.tsx
+++ b/apps/api-playground/src/App.test.tsx
@@ -330,3 +330,44 @@ describe("API key handling", () => {
     expect(screen.queryByDisplayValue("logout-secret-key")).not.toBeInTheDocument()
   })
 })
+
+describe("tenant session host", () => {
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it("loads the signed-in shell from the Agate host, not api.*", async () => {
+    vi.stubGlobal("location", {
+      ...window.location,
+      hostname: "playground.canary.stg.backfield.news",
+      origin: "https://playground.canary.stg.backfield.news",
+      href: "https://playground.canary.stg.backfield.news/",
+    })
+    const fetchMock = vi.fn<typeof fetch>().mockImplementation(async (input) => {
+      const response = sessionResponse(input)
+      if (response) return response
+      if (String(input).endsWith("/openapi.json")) {
+        return new Response(JSON.stringify(schema), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })
+      }
+      throw new Error(`Unexpected request: ${String(input)}`)
+    })
+    vi.stubGlobal("fetch", fetchMock)
+
+    render(<App />)
+
+    expect(
+      await screen.findByRole("navigation", { name: "Backfield products" }),
+    ).toBeInTheDocument()
+    expect(screen.getByText("https://api.canary.stg.backfield.news")).toBeInTheDocument()
+
+    const requested = fetchMock.mock.calls.map(([input]) => String(input))
+    expect(requested).toContain("https://agate.canary.stg.backfield.news/v1/auth/me")
+    expect(requested).toContain("https://api.canary.stg.backfield.news/public/v1/openapi.json")
+    expect(requested).not.toContain("https://api.canary.stg.backfield.news/v1/auth/me")
+  })
+})

--- a/apps/api-playground/src/App.tsx
+++ b/apps/api-playground/src/App.tsx
@@ -86,6 +86,9 @@ export default function App() {
     : tenant
       ? deriveProductOrigin("agate", organizationSlug, parentDomain)
       : ""
+  // Local Compose exposes Core session routes on :8004. Cloud keeps /v1 session
+  // and admin routes on the Agate UI host; api.* only serves /public/v1.
+  const sessionOrigin = localAvailable ? apiOrigin : agateOrigin
   const [apiKey, setApiKey] = useState(() => readSessionValue(API_KEY_SESSION_STORAGE))
   const [apiKeyDraft, setApiKeyDraft] = useState(apiKey)
   const [document, setDocument] = useState<OpenApiDocument>()
@@ -94,7 +97,7 @@ export default function App() {
   // Start loading when this hostname can resolve an API origin so the header
   // and sidebar reserve space instead of flashing empty chrome.
   const [sessionLoading, setSessionLoading] = useState(
-    () => Boolean(apiOrigin && stylebookApiOrigin),
+    () => Boolean(apiOrigin && stylebookApiOrigin && sessionOrigin),
   )
   const [origin, setOrigin] = useState("")
   const [selectedOperationId, setSelectedOperationId] = useState(() =>
@@ -215,13 +218,13 @@ export default function App() {
   }
 
   useEffect(() => {
-    if (!apiOrigin || !stylebookApiOrigin) {
+    if (!apiOrigin || !stylebookApiOrigin || !sessionOrigin) {
       setSessionError(
         "Open the API Playground from your organization’s tenant-specific Playground domain.",
       )
       return
     }
-    void loadSessionContext(apiOrigin, stylebookApiOrigin).catch(() => undefined)
+    void loadSessionContext(sessionOrigin, stylebookApiOrigin).catch(() => undefined)
     void loadSchema()
     // Tenant origins are intentionally inferred once from the current hostname.
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -263,8 +266,8 @@ export default function App() {
 
   async function logout() {
     clearApiKey()
-    if (apiOrigin) {
-      await logoutSession(apiOrigin)
+    if (sessionOrigin) {
+      await logoutSession(sessionOrigin)
     }
     window.location.assign(agateOrigin ? `${agateOrigin}/login` : "/")
   }

--- a/apps/api-playground/src/lib/session.test.ts
+++ b/apps/api-playground/src/lib/session.test.ts
@@ -7,14 +7,15 @@ describe("Playground session", () => {
     vi.unstubAllGlobals()
   })
 
-  it("logs out through the tenant Core API with browser credentials", async () => {
+  it("logs out through the tenant session host with browser credentials", async () => {
     const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(new Response(null))
     vi.stubGlobal("fetch", fetchMock)
 
-    await logoutSession("https://api.newsroom.backfield.news")
+    // Cloud session/admin routes live on the Agate UI host, not api.*.
+    await logoutSession("https://agate.newsroom.backfield.news")
 
     expect(fetchMock).toHaveBeenCalledWith(
-      "https://api.newsroom.backfield.news/v1/auth/logout",
+      "https://agate.newsroom.backfield.news/v1/auth/logout",
       {
         method: "POST",
         credentials: "include",
@@ -26,6 +27,6 @@ describe("Playground session", () => {
   it("still resolves when the logout request cannot be confirmed", async () => {
     vi.stubGlobal("fetch", vi.fn<typeof fetch>().mockRejectedValue(new Error("offline")))
 
-    await expect(logoutSession("https://api.newsroom.backfield.news")).resolves.toBeUndefined()
+    await expect(logoutSession("https://agate.newsroom.backfield.news")).resolves.toBeUndefined()
   })
 })


### PR DESCRIPTION
## Summary
- Use the Agate UI origin for Playground session/shell requests (`/v1/auth/me`, workspaces, logout) in cloud deployments.
- Keep public schema/execution on `api.*`; keep localhost session on Core `:8004`.
- Add a regression test that staging Playground hosts call `agate.*.stg.backfield.news`, not `api.*`.

## Why
`api.{client}.[stg.]backfield.news` only routes `/public/v1/*`. Session calls to `api.*/v1/auth/me` get an ALB 404 without CORS headers, which surfaces as "Failed to fetch" and leaves the sidebar empty.

## Test plan
- [x] `apps/api-playground` App + session unit tests
- [ ] After merge + canary redeploy: open `https://playground.canary.stg.backfield.news/` while signed into Agate canary and confirm sidebar + projects load; schema still uses `https://api.canary.stg.backfield.news`


Made with [Cursor](https://cursor.com)