### PR TITLE
Fix cleanup AI review to resolve LLM credentials from model config.

### DIFF
--- a/apps/worker/src/worker/substrate/cleanup/ai_review.py
+++ b/apps/worker/src/worker/substrate/cleanup/ai_review.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-import os
+import logging
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextvars import copy_context
 from datetime import UTC, datetime
@@ -45,6 +45,12 @@ from worker.substrate.canonical.llm_call_policy import (
     ADJUDICATION_LLM_TIMEOUT_S,
 )
 from worker.substrate.canonical.parallel_llm import canonical_adjudication_max_concurrent
+from worker.substrate.cleanup.cleanup_llm_auth import (
+    call_llm_kwargs_from_overlay,
+    is_llm_auth_error,
+)
+
+logger = logging.getLogger(__name__)
 
 _MAX_MENTION_TEXT_LEN = 120
 
@@ -434,7 +440,15 @@ def run_cluster_partition_llm(
     prompt: str,
     model: str,
     model_config_id: str | None,
+    api_key_overlay: dict[str, str],
 ) -> dict[str, Any] | None:
+    """Call the partition LLM. Auth/config errors raise; malformed JSON returns None."""
+    key_kwargs = call_llm_kwargs_from_overlay(api_key_overlay)
+    if not key_kwargs:
+        raise ValueError(
+            "No provider credentials configured for this organization. "
+            "Add AI credentials in organization settings before running this review."
+        )
     try:
         raw = call_llm(
             prompt,
@@ -443,11 +457,12 @@ def run_cluster_partition_llm(
             temperature=0.0,
             max_retries=ADJUDICATION_LLM_MAX_RETRIES,
             timeout=ADJUDICATION_LLM_TIMEOUT_S,
-            openai_api_key=os.getenv("OPENAI_API_KEY"),
             model_config_id=model_config_id,
+            **key_kwargs,
         )
         data = json.loads(raw)
-    except Exception:
+    except json.JSONDecodeError:
+        logger.warning("cleanup AI review LLM returned non-JSON for model=%s", model)
         return None
     if not isinstance(data, dict):
         return None
@@ -460,16 +475,28 @@ def propose_for_cluster(
     members: list[CleanupClusterMember],
     model: str,
     model_config_id: str | None,
+    api_key_overlay: dict[str, str],
 ) -> list[CleanupAiProposalDraft]:
     if len(members) < 2:
         return []
     cluster_id = cluster_id_for_member_ids([member.id for member in members])
     prompt = build_cluster_partition_prompt(check_id=check_id, members=members)
-    llm_data = run_cluster_partition_llm(
-        prompt=prompt,
-        model=model,
-        model_config_id=model_config_id,
-    )
+    try:
+        llm_data = run_cluster_partition_llm(
+            prompt=prompt,
+            model=model,
+            model_config_id=model_config_id,
+            api_key_overlay=api_key_overlay,
+        )
+    except Exception as exc:
+        if is_llm_auth_error(exc):
+            raise
+        logger.exception(
+            "cleanup AI review cluster LLM failed check_id=%s cluster_id=%s",
+            check_id,
+            cluster_id,
+        )
+        return []
     valid_ids = {member.id for member in members}
     groups = parse_cluster_partition_response(llm_data, valid_member_ids=valid_ids)
     if groups is None:
@@ -576,6 +603,7 @@ def run_cleanup_review_clusters(
     members_by_cluster: list[list[CleanupClusterMember]],
     model: str,
     model_config_id: str | None,
+    api_key_overlay: dict[str, str],
 ) -> None:
     """Run cluster LLM calls in parallel and persist progress after each cluster finishes."""
     if _cleanup_ai_review_is_cancelled(engine, review_id):
@@ -596,6 +624,7 @@ def run_cleanup_review_clusters(
             members=members,
             model=model,
             model_config_id=model_config_id,
+            api_key_overlay=api_key_overlay,
         )
 
     if max_workers <= 1 or len(members_by_cluster) <= 1:

--- a/apps/worker/src/worker/substrate/cleanup/cleanup_llm_auth.py
+++ b/apps/worker/src/worker/substrate/cleanup/cleanup_llm_auth.py
@@ -1,0 +1,168 @@
+"""Shared LLM credential resolution for Stylebook cleanup worker jobs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from backfield_ai.catalog_runtime import resolve_llm_auth_for_model_config
+from backfield_ai.credentials import merge_project_and_org_llm_api_keys
+from backfield_ai.litellm_model import effective_litellm_model_row
+from backfield_db import BackfieldAiModelConfig, BackfieldProject
+from sqlmodel import Session, select
+
+
+@dataclass(frozen=True)
+class CleanupLlmAuthContext:
+    project_id: int
+    api_key_overlay: dict[str, str]
+    model: str
+    model_config_id: str | None
+
+
+def overlay_catalog_auth(
+    overlay: dict[str, str],
+    *,
+    provider: str,
+    api_key: str | None,
+    api_base: str | None,
+) -> dict[str, str]:
+    merged = dict(overlay)
+    if api_key:
+        provider_key = provider.strip().lower()
+        if provider_key == "openai":
+            merged["OPENAI_API_KEY"] = api_key
+        elif provider_key == "anthropic":
+            merged["ANTHROPIC_API_KEY"] = api_key
+        elif provider_key == "gemini":
+            merged["GEMINI_API_KEY"] = api_key
+        elif provider_key == "openrouter":
+            merged["OPENROUTER_API_KEY"] = api_key
+        elif provider_key == "azure":
+            merged["AZURE_API_KEY"] = api_key
+    if api_base:
+        merged["AZURE_API_BASE"] = api_base
+    return merged
+
+
+def resolve_organization_cleanup_project_id(session: Session, *, organization_id: int) -> int:
+    """Pick a project used to resolve org AI credentials."""
+    project_ids = session.exec(
+        select(BackfieldProject.id)
+        .where(BackfieldProject.organization_id == int(organization_id))
+        .order_by(BackfieldProject.id)
+    ).all()
+    if not project_ids:
+        raise ValueError(
+            "No projects found for this organization; cannot resolve AI credentials."
+        )
+    return int(project_ids[0])
+
+
+def resolve_cleanup_llm_auth(
+    session: Session,
+    *,
+    organization_id: int,
+    provider_model_id: str | None,
+    ai_model_config_id: str | None,
+    default_model: str,
+) -> CleanupLlmAuthContext:
+    """Resolve provider API keys from org/project secrets and optional model config."""
+    project_id = resolve_organization_cleanup_project_id(
+        session, organization_id=organization_id
+    )
+    project = session.get(BackfieldProject, project_id)
+    if project is None:
+        raise ValueError(f"Project {project_id} not found.")
+
+    model = (provider_model_id or "").strip() or default_model
+    model_config_id = (ai_model_config_id or "").strip() or None
+    overlay = merge_project_and_org_llm_api_keys(session, project_id)
+
+    if model_config_id:
+        cfg = session.get(BackfieldAiModelConfig, model_config_id)
+        if cfg is None or int(cfg.organization_id) != int(organization_id):
+            raise ValueError(
+                "Selected AI model is missing or belongs to another organization."
+            )
+        model = str(cfg.provider_model_id or model).strip() or default_model
+        _lm, catalog_key, api_base = resolve_llm_auth_for_model_config(
+            session,
+            project_id=project_id,
+            model_config_id=model_config_id,
+            fallback_litellm_model=effective_litellm_model_row(
+                litellm_model=cfg.litellm_model,
+                provider=str(cfg.provider),
+                provider_model_id=str(cfg.provider_model_id),
+            ),
+        )
+        overlay = overlay_catalog_auth(
+            overlay,
+            provider=str(cfg.provider),
+            api_key=catalog_key,
+            api_base=api_base,
+        )
+
+    llm_kwargs = call_llm_kwargs_from_overlay(overlay)
+    if not llm_kwargs:
+        raise ValueError(
+            "No provider credentials configured for this organization. "
+            "Add AI credentials in organization settings before running this review."
+        )
+
+    return CleanupLlmAuthContext(
+        project_id=project_id,
+        api_key_overlay=overlay,
+        model=model,
+        model_config_id=model_config_id,
+    )
+
+
+def call_llm_kwargs_from_overlay(overlay: dict[str, str]) -> dict[str, str]:
+    """Map env-style overlay keys to ``call_llm`` keyword arguments."""
+    kwargs: dict[str, str] = {}
+    if overlay.get("OPENAI_API_KEY"):
+        kwargs["openai_api_key"] = overlay["OPENAI_API_KEY"]
+    if overlay.get("ANTHROPIC_API_KEY"):
+        kwargs["anthropic_api_key"] = overlay["ANTHROPIC_API_KEY"]
+    if overlay.get("GEMINI_API_KEY"):
+        kwargs["gemini_api_key"] = overlay["GEMINI_API_KEY"]
+    if overlay.get("OPENROUTER_API_KEY"):
+        kwargs["openrouter_api_key"] = overlay["OPENROUTER_API_KEY"]
+    if overlay.get("AZURE_API_KEY"):
+        kwargs["azure_api_key"] = overlay["AZURE_API_KEY"]
+    if overlay.get("AZURE_API_BASE"):
+        kwargs["azure_api_base"] = overlay["AZURE_API_BASE"]
+    return kwargs
+
+
+def is_llm_auth_error(exc: BaseException) -> bool:
+    name = type(exc).__name__.lower()
+    if "auth" in name or "permission" in name:
+        return True
+    if isinstance(exc, ValueError):
+        msg = str(exc).lower()
+        return any(
+            token in msg
+            for token in (
+                "api key",
+                "api_key",
+                "credential",
+                "credentials",
+                "authentication",
+                "unauthorized",
+                "configure in project settings",
+                "organization settings",
+            )
+        )
+    msg = str(exc).lower()
+    return any(
+        token in msg
+        for token in (
+            "invalid_api_key",
+            "incorrect api key",
+            "authentication",
+            "unauthorized",
+            "401",
+            "403",
+        )
+    )

--- a/apps/worker/src/worker/substrate/cleanup/questionable_organizations_llm.py
+++ b/apps/worker/src/worker/substrate/cleanup/questionable_organizations_llm.py
@@ -19,6 +19,8 @@ from backfield_entities.quality.llm_questionable_organizations import (
 )
 from sqlmodel import Session
 
+from worker.substrate.cleanup.cleanup_llm_auth import overlay_catalog_auth
+
 
 @dataclass(frozen=True)
 class QuestionableOrganizationLlmContext:
@@ -26,31 +28,6 @@ class QuestionableOrganizationLlmContext:
     api_key_overlay: dict[str, str]
     model: str
     model_config_id: str
-
-
-def _overlay_catalog_auth(
-    overlay: dict[str, str],
-    *,
-    provider: str,
-    api_key: str | None,
-    api_base: str | None,
-) -> dict[str, str]:
-    merged = dict(overlay)
-    if api_key:
-        provider_key = provider.strip().lower()
-        if provider_key == "openai":
-            merged["OPENAI_API_KEY"] = api_key
-        elif provider_key == "anthropic":
-            merged["ANTHROPIC_API_KEY"] = api_key
-        elif provider_key == "gemini":
-            merged["GEMINI_API_KEY"] = api_key
-        elif provider_key == "openrouter":
-            merged["OPENROUTER_API_KEY"] = api_key
-        elif provider_key == "azure":
-            merged["AZURE_API_KEY"] = api_key
-    if api_base:
-        merged["AZURE_API_BASE"] = api_base
-    return merged
 
 
 def resolve_cleanup_project_id(session: Session, *, scope: CleanupRunScope) -> int:
@@ -96,7 +73,7 @@ def resolve_questionable_organization_llm_context(
             provider_model_id=str(cfg.provider_model_id),
         ),
     )
-    overlay = _overlay_catalog_auth(
+    overlay = overlay_catalog_auth(
         overlay,
         provider=str(cfg.provider),
         api_key=catalog_key,

--- a/apps/worker/src/worker/tasks.py
+++ b/apps/worker/src/worker/tasks.py
@@ -1566,6 +1566,8 @@ def _duplicate_cluster_ids_for_check(
 @celery_app.task(name="worker.tasks.execute_cleanup_ai_review")
 def execute_cleanup_ai_review(review_id: str) -> None:
     """Run LLM partition proposals for all duplicate clusters in a cleanup check."""
+    from worker.substrate.cleanup.cleanup_llm_auth import resolve_cleanup_llm_auth
+
     engine = get_engine()
     with Session(engine) as session:
         review = session.get(StylebookCleanupAiReview, review_id)
@@ -1580,8 +1582,20 @@ def execute_cleanup_ai_review(review_id: str) -> None:
         check_id = str(review.check_id)
         stylebook_id = int(review.stylebook_id)
         organization_id = int(stylebook.organization_id)
-        model = (review.provider_model_id or "").strip() or "gpt-5-nano"
-        model_config_id = review.ai_model_config_id
+        try:
+            llm_auth = resolve_cleanup_llm_auth(
+                session,
+                organization_id=organization_id,
+                provider_model_id=review.provider_model_id,
+                ai_model_config_id=review.ai_model_config_id,
+                default_model="gpt-5-nano",
+            )
+        except ValueError as exc:
+            _fail_cleanup_ai_review(engine, review_id, str(exc))
+            return
+        model = llm_auth.model
+        model_config_id = llm_auth.model_config_id
+        api_key_overlay = dict(llm_auth.api_key_overlay)
         try:
             cluster_id_lists = _duplicate_cluster_ids_for_check(
                 session,
@@ -1611,8 +1625,6 @@ def execute_cleanup_ai_review(review_id: str) -> None:
         check_id = str(review.check_id)
         stylebook_id = int(review.stylebook_id)
         organization_id = int(stylebook.organization_id)
-        model = (review.provider_model_id or "").strip() or "gpt-5-nano"
-        model_config_id = review.ai_model_config_id
         for member_ids in cluster_id_lists:
             members = load_cluster_members(
                 session,
@@ -1634,6 +1646,7 @@ def execute_cleanup_ai_review(review_id: str) -> None:
             members_by_cluster=cluster_payloads,
             model=model,
             model_config_id=model_config_id,
+            api_key_overlay=api_key_overlay,
         )
     except Exception as exc:
         logger.exception("execute_cleanup_ai_review failed")

--- a/docs/api/stylebook.md
+++ b/docs/api/stylebook.md
@@ -92,6 +92,9 @@ Bundles do not transfer project saved entities, candidate queues, caches, or act
 - merge and empty-canonical deletion actions for all current canonical domains;
 - dismissal recording;
 - optional AI review with proposal listing, acceptance, rejection, status, and cancellation.
+  AI review resolves provider credentials from the selected Agate model config and organization
+  AI settings (not only a bare worker `OPENAI_API_KEY`); missing credentials fail the review with
+  an error message instead of succeeding with zero proposals.
 
 Cleanup mutations require catalog edit access and preserve catalog tenancy.
 

--- a/tests/worker/test_cleanup_ai_review_llm_auth.py
+++ b/tests/worker/test_cleanup_ai_review_llm_auth.py
@@ -1,0 +1,239 @@
+"""Tests for Stylebook cleanup AI review LLM credential resolution."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+from backfield_ai.constants import INTEGRATION_KEY_AI_PROVIDER_OPENAI
+from backfield_db import (
+    BackfieldAiModelConfig,
+    BackfieldOrganization,
+    BackfieldOrganizationIntegrationSecret,
+    BackfieldProject,
+)
+from backfield_db.crypto import encrypt_secret
+from backfield_entities.quality.cleanup_ai_review import CleanupClusterMember
+from cryptography.fernet import Fernet
+from sqlmodel import Session, SQLModel, create_engine
+from worker.substrate.cleanup.ai_review import propose_for_cluster, run_cluster_partition_llm
+from worker.substrate.cleanup.cleanup_llm_auth import (
+    call_llm_kwargs_from_overlay,
+    is_llm_auth_error,
+    resolve_cleanup_llm_auth,
+)
+
+
+@pytest.fixture
+def session_with_org(tmp_path, monkeypatch):
+    key = Fernet.generate_key().decode()
+    monkeypatch.setenv("MASTER_ENCRYPTION_KEY", key)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    url = f"sqlite:///{tmp_path}/cleanup_llm_auth.db"
+    engine = create_engine(url, connect_args={"check_same_thread": False})
+    SQLModel.metadata.create_all(engine)
+    now = datetime.now(UTC)
+    with Session(engine) as session:
+        org = BackfieldOrganization(name="Cleanup Org", slug="cleanup-org")
+        session.add(org)
+        session.commit()
+        session.refresh(org)
+        oid = int(org.id)  # type: ignore[arg-type]
+        proj = BackfieldProject(organization_id=oid, name="P", slug="cleanup-proj")
+        session.add(proj)
+        session.commit()
+        session.refresh(proj)
+        pid = int(proj.id)  # type: ignore[arg-type]
+        yield session, oid, pid, now
+
+
+def _add_openai_secret(session: Session, *, oid: int, now: datetime, value: str) -> int:
+    secret = BackfieldOrganizationIntegrationSecret(
+        organization_id=oid,
+        integration_key=INTEGRATION_KEY_AI_PROVIDER_OPENAI,
+        value_encrypted=encrypt_secret(value),
+        created_at=now,
+        updated_at=now,
+    )
+    session.add(secret)
+    session.commit()
+    session.refresh(secret)
+    return int(secret.id)  # type: ignore[arg-type]
+
+
+def test_resolve_cleanup_llm_auth_uses_model_config_secret_without_env(
+    session_with_org, monkeypatch
+) -> None:
+    session, oid, _pid, now = session_with_org
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    secret_id = _add_openai_secret(session, oid=oid, now=now, value="sk-from-catalog")
+    cfg = BackfieldAiModelConfig(
+        organization_id=oid,
+        name="Cleanup GPT",
+        provider="openai",
+        provider_model_id="gpt-5-nano",
+        model_kind="generative",
+        status="active",
+        capabilities_json=["text", "json"],
+        litellm_model="openai/gpt-5-nano",
+        integration_secret_id=secret_id,
+    )
+    session.add(cfg)
+    session.commit()
+    session.refresh(cfg)
+
+    auth = resolve_cleanup_llm_auth(
+        session,
+        organization_id=oid,
+        provider_model_id="gpt-5-nano",
+        ai_model_config_id=str(cfg.id),
+        default_model="gpt-5-nano",
+    )
+
+    assert auth.api_key_overlay.get("OPENAI_API_KEY") == "sk-from-catalog"
+    assert call_llm_kwargs_from_overlay(auth.api_key_overlay)["openai_api_key"] == (
+        "sk-from-catalog"
+    )
+    assert auth.model == "gpt-5-nano"
+    assert auth.model_config_id == str(cfg.id)
+
+
+def test_resolve_cleanup_llm_auth_fails_without_credentials(session_with_org) -> None:
+    session, oid, _pid, _now = session_with_org
+    with pytest.raises(ValueError, match="No provider credentials"):
+        resolve_cleanup_llm_auth(
+            session,
+            organization_id=oid,
+            provider_model_id="gpt-5-nano",
+            ai_model_config_id=None,
+            default_model="gpt-5-nano",
+        )
+
+
+def test_resolve_cleanup_llm_auth_fails_for_missing_model_config(session_with_org) -> None:
+    session, oid, _pid, now = session_with_org
+    _add_openai_secret(session, oid=oid, now=now, value="sk-org")
+    with pytest.raises(ValueError, match="missing or belongs"):
+        resolve_cleanup_llm_auth(
+            session,
+            organization_id=oid,
+            provider_model_id="gpt-5-nano",
+            ai_model_config_id="does-not-exist",
+            default_model="gpt-5-nano",
+        )
+
+
+def test_run_cluster_partition_llm_passes_overlay_keys() -> None:
+    with patch(
+        "worker.substrate.cleanup.ai_review.call_llm",
+        return_value='{"groups": []}',
+    ) as mock_call:
+        data = run_cluster_partition_llm(
+            prompt="partition",
+            model="gpt-5-nano",
+            model_config_id="cfg-1",
+            api_key_overlay={"OPENAI_API_KEY": "sk-overlay"},
+        )
+    assert data == {"groups": []}
+    assert mock_call.call_args.kwargs["openai_api_key"] == "sk-overlay"
+    assert mock_call.call_args.kwargs["model_config_id"] == "cfg-1"
+
+
+def test_run_cluster_partition_llm_raises_when_overlay_empty() -> None:
+    with pytest.raises(ValueError, match="No provider credentials"):
+        run_cluster_partition_llm(
+            prompt="partition",
+            model="gpt-5-nano",
+            model_config_id=None,
+            api_key_overlay={},
+        )
+
+
+def test_propose_for_cluster_rethrows_auth_errors() -> None:
+    members = [
+        CleanupClusterMember(id="a", label="A", linked_substrate_count=1, mention_count=0),
+        CleanupClusterMember(id="b", label="B", linked_substrate_count=1, mention_count=0),
+    ]
+    with patch(
+        "worker.substrate.cleanup.ai_review.run_cluster_partition_llm",
+        side_effect=ValueError("OPENAI_API_KEY must be provided (configure in project settings)"),
+    ):
+        with pytest.raises(ValueError, match="OPENAI_API_KEY"):
+            propose_for_cluster(
+                check_id="duplicate-people",
+                members=members,
+                model="gpt-5-nano",
+                model_config_id=None,
+                api_key_overlay={"OPENAI_API_KEY": "unused"},
+            )
+
+
+def test_propose_for_cluster_soft_fails_non_auth_errors() -> None:
+    members = [
+        CleanupClusterMember(id="a", label="A", linked_substrate_count=1, mention_count=0),
+        CleanupClusterMember(id="b", label="B", linked_substrate_count=1, mention_count=0),
+    ]
+    with patch(
+        "worker.substrate.cleanup.ai_review.run_cluster_partition_llm",
+        side_effect=RuntimeError("temporary upstream blip"),
+    ):
+        drafts = propose_for_cluster(
+            check_id="duplicate-people",
+            members=members,
+            model="gpt-5-nano",
+            model_config_id=None,
+            api_key_overlay={"OPENAI_API_KEY": "sk"},
+        )
+    assert drafts == []
+
+
+def test_is_llm_auth_error_detects_missing_key() -> None:
+    assert is_llm_auth_error(ValueError("OPENAI_API_KEY must be provided"))
+    assert not is_llm_auth_error(RuntimeError("timeout after 30s"))
+
+
+def test_execute_cleanup_ai_review_fails_loudly_when_auth_missing() -> None:
+    from worker.tasks import execute_cleanup_ai_review
+
+    review = MagicMock()
+    review.status = "queued"
+    review.stylebook_id = 1
+    review.check_id = "duplicate-people"
+    review.provider_model_id = "gpt-5-nano"
+    review.ai_model_config_id = None
+
+    stylebook = MagicMock()
+    stylebook.organization_id = 9
+
+    session = MagicMock()
+    session.__enter__ = MagicMock(return_value=session)
+    session.__exit__ = MagicMock(return_value=False)
+
+    def _get(model, key):  # noqa: ANN001
+        if model.__name__ == "StylebookCleanupAiReview":
+            return review
+        if model.__name__ == "Stylebook":
+            return stylebook
+        return None
+
+    session.get.side_effect = _get
+
+    with (
+        patch("worker.tasks.get_engine", return_value=MagicMock()),
+        patch("worker.tasks.Session", return_value=session),
+        patch(
+            "worker.substrate.cleanup.cleanup_llm_auth.resolve_cleanup_llm_auth",
+            side_effect=ValueError(
+                "No provider credentials configured for this organization. "
+                "Add AI credentials in organization settings before running this review."
+            ),
+        ),
+        patch("worker.tasks._fail_cleanup_ai_review") as fail,
+        patch("worker.tasks.run_cleanup_review_clusters") as run_clusters,
+    ):
+        execute_cleanup_ai_review("review-auth-fail")
+
+    fail.assert_called_once()
+    assert "No provider credentials" in fail.call_args.args[2]
+    run_clusters.assert_not_called()


### PR DESCRIPTION
Stops silent success with zero proposals when OPENAI_API_KEY is unset on the worker by using org/project and Agate model-config keys, and failing the review when auth cannot be resolved.

## Summary

<!-- What changed and why? Link related issues when applicable. -->

## Project scope check

- [ ] This change targets local development / source inspection (production self-hosting is unsupported in this repo)
- [ ] Docs under `docs/` updated if behavior, architecture, or operations changed
- [ ] First-admin provisioning still uses `backfield init` / `backfield seed` only (no HTTP/env bootstrap paths)

## Test plan

- [ ] `make lint`
- [ ] `make test`
- [ ] `make ui-typecheck ui-test` (if UI/TypeScript changed)
- [ ] `make smoke-fast` (if live-stack behavior changed)
- [ ] `make smoke` (if golden-path / provider-dependent runtime changed; configure **Settings → AI models**)

## Notes for reviewers

<!-- Risk, rollout concerns, follow-ups, or screenshots. -->
