### PR TITLE
Fix large-run finalization, cancellation, and Playground auth redirect

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,10 @@ jobs:
           done
           docker compose -f infra/docker-compose.yml logs
           exit 1
+      - name: Verify processed-item finalization locking
+        env:
+          BACKFIELD_DATABASE_URL_DIRECT: postgresql+psycopg://postgres:postgres@127.0.0.1:5433/backfield
+        run: uv run pytest tests/worker/test_s3_finalization_postgres.py -q
       - name: Seed smoke user (fresh DB)
         env:
           BACKFIELD_DATABASE_URL_DIRECT: postgresql+psycopg://postgres:postgres@127.0.0.1:5433/backfield

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,11 @@ jobs:
       - name: Verify processed-item finalization locking
         env:
           BACKFIELD_DATABASE_URL_DIRECT: postgresql+psycopg://postgres:postgres@127.0.0.1:5433/backfield
-        run: uv run pytest tests/worker/test_s3_finalization_postgres.py -q
+        run: |
+          uv run pytest \
+            tests/worker/test_s3_finalization_postgres.py \
+            tests/worker/test_run_cancellation_postgres.py \
+            -q
       - name: Seed smoke user (fresh DB)
         env:
           BACKFIELD_DATABASE_URL_DIRECT: postgresql+psycopg://postgres:postgres@127.0.0.1:5433/backfield

--- a/README.md
+++ b/README.md
@@ -51,11 +51,11 @@ Canonical Stylebook entities can also be enriched with metadata and connected to
 
 <img src="docs/screenshots/readme3.png" alt="Stylebook" />
 
-### Public API
+### Backfield API
 
-Backfield's public API allows users to query the extracted and enriched data in a variety of ways, including by location and entity, by keyword or semantically. This API can be used to power products, services, tools and story forms based on the structured information that Backfield curates.
+Backfield API allows users to query the extracted and enriched data in a variety of ways, including by location and entity, by keyword or semantically. This API can be used to power products, services, tools and story forms based on the structured information that Backfield curates.
 
-See [docs.backfield.news](https://docs.backfield.news) for Public API documentation.
+See [docs.backfield.news](https://docs.backfield.news) for Backfield API documentation.
 
 The included **API Playground** provides an interactive tool to explore those endpoints. Entering a project API key from Agate allows users to make requests, see generated cURL commands and view sample responses.
 
@@ -89,7 +89,7 @@ Once that is done:
 
 1. Open [Agate](http://localhost:5173) and sign in with the administrator you just created.
 2. Go to **Settings → AI models** and configure credentials for the models and integrations your flows will use.
-3. Open the [API Playground](http://localhost:5176) to browse the public API schema. Apply a project API key when you want to execute requests.
+3. Open the [API Playground](http://localhost:5176) to browse the Backfield API schema. Apply a project API key when you want to execute requests.
 4. Follow [Local development setup](docs/development/local-setup.md) for stack commands, data lifecycle, and troubleshooting links.
 
 
@@ -97,8 +97,8 @@ Once that is done:
 | -------------- | ------------------------------------------------------- | ----------------------------------------------- |
 | **Agate**      | [localhost:5173](http://localhost:5173)                 | Building flows and reviewing article results    |
 | **Stylebook**  | [localhost:5175](http://localhost:5175)                 | Browsing and curating canonical records         |
-| **API Playground** | [localhost:5176](http://localhost:5176)             | Exploring the public schema and testing requests |
-| **Public API** | [localhost:8004/public/v1](http://localhost:8004/public/v1) | Querying extracted and enriched project data |
+| **API Playground** | [localhost:5176](http://localhost:5176)             | Exploring the Backfield API schema and testing requests |
+| **Backfield API** | [localhost:8004/public/v1](http://localhost:8004/public/v1) | Querying extracted and enriched project data |
 
 
 Published ports bind to `127.0.0.1` only.

--- a/apps/agate-api/src/api/routers/runs.py
+++ b/apps/agate-api/src/api/routers/runs.py
@@ -2446,7 +2446,7 @@ def sync_run_processed_item_s3_output(
 
 
 def _serialize_run(session: Session, r: AgateRun) -> RunOut:
-    """Build ``RunOut`` for ``GET /runs/{id}`` and ``POST /runs/{id}/cancel`` responses."""
+    """Build the complete ``RunOut`` response for ``GET /runs/{id}``."""
     pid = _graph_project_id(session, r.graph_id)
     result = None
     if r.result_json:
@@ -2524,15 +2524,39 @@ def _serialize_run_status(session: Session, r: AgateRun) -> RunStatusOut:
     )
 
 
-@router.post("/{run_id}/cancel", response_model=RunOut)
+def _cancel_processed_items(session: Session, run_id: str, *, now: datetime) -> int:
+    """Fail pending/running items in one bounded update without hydrating payload columns."""
+    result = session.execute(
+        update(AgateProcessedItem)
+        .where(
+            AgateProcessedItem.run_id == run_id,
+            col(AgateProcessedItem.status).in_(("pending", "running")),
+        )
+        .values(
+            status="failed",
+            error_message=case(
+                (
+                    AgateProcessedItem.status == "running",
+                    _RUN_CANCELLED_MESSAGE + " (was running)",
+                ),
+                else_=_RUN_CANCELLED_MESSAGE,
+            ),
+            updated_at=now,
+        )
+        .execution_options(synchronize_session=False)
+    )
+    return int(result.rowcount or 0)
+
+
+@router.post("/{run_id}/cancel", response_model=RunStatusOut)
 def cancel_run(
     run_id: str,
     session: Session = Depends(get_session),
     auth: dict[str, Any] = Depends(get_auth),
-):
+) -> RunStatusOut:
     """Mark a pending or running run as stopped and fail in-flight batch items.
 
-    Workers respect the updated row so graph execution can exit before writing success.
+    Repeated cancellation returns the same compact terminal status.
     """
     r = session.get(AgateRun, run_id)
     if not r:
@@ -2541,6 +2565,14 @@ def cancel_run(
     if pid:
         require_project_access(session, auth, pid)
 
+    r = session.exec(
+        select(AgateRun)
+        .where(AgateRun.id == run_id)
+        .with_for_update()
+        .execution_options(populate_existing=True)
+    ).one()
+    if r.status == "failed" and r.error_message == _RUN_CANCELLED_MESSAGE:
+        return _serialize_run_status(session, r)
     if r.status not in ("pending", "running"):
         raise HTTPException(
             400,
@@ -2550,29 +2582,15 @@ def cancel_run(
             ),
         )
 
-    items = list(
-        session.exec(select(AgateProcessedItem).where(AgateProcessedItem.run_id == run_id)).all()
-    )
     now = datetime.now(UTC)
-    for item in items:
-        if item.status == "pending":
-            item.status = "failed"
-            item.error_message = _RUN_CANCELLED_MESSAGE
-            item.updated_at = now
-            session.add(item)
-        elif item.status == "running":
-            item.status = "failed"
-            item.error_message = _RUN_CANCELLED_MESSAGE + " (was running)"
-            item.updated_at = now
-            session.add(item)
-
+    _cancel_processed_items(session, run_id, now=now)
     r.status = "failed"
     r.error_message = _RUN_CANCELLED_MESSAGE
     r.updated_at = now
     session.add(r)
     session.commit()
     session.refresh(r)
-    return _serialize_run(session, r)
+    return _serialize_run_status(session, r)
 
 
 @router.get("/{run_id}/status", response_model=RunStatusOut)

--- a/apps/agate-ui/src/lib/api.ts
+++ b/apps/agate-ui/src/lib/api.ts
@@ -1097,8 +1097,8 @@ export async function syncProcessedItemS3Output(
 export async function cancelRun(runId: string | number): Promise<Run> {
   const raw = (await fetchAPI(`/runs/${runId}/cancel`, {
     method: 'POST',
-  })) as RawRun
-  return normalizeRun(raw)
+  })) as RawRunStatus
+  return normalizeRunStatus(raw)
 }
 
 export async function checkHealth(): Promise<{ ok: boolean }> {

--- a/apps/api-playground/README.md
+++ b/apps/api-playground/README.md
@@ -57,11 +57,12 @@ operation remains in the API contract but is intentionally omitted from the Play
 
 ## Security boundary
 
-- The public schema loads immediately without authentication so every endpoint can be browsed.
-  A project API key is required only to execute requests and load project-scoped field choices.
-- When available, the existing Backfield session cookie loads the signed-in organization,
-  workspaces, and stylebooks for the shell and project selector. Schema browsing does not depend
-  on that session.
+- Opening the Playground requires a signed-in Backfield session, matching Agate and Stylebook.
+  Unauthenticated visits redirect to the tenant Agate login screen. After sign-in, the session
+  cookie loads the organization, workspaces, and stylebooks for the shell and project selector.
+- The public OpenAPI schema still loads without a project API key so every endpoint can be
+  browsed once signed in. A project API key is required only to execute requests and load
+  project-scoped field choices.
 - The project API key is held in React state and this tab's `sessionStorage`, so it survives a
   reload but is discarded when the tab closes. It is never put in local storage, cookies, URL
   state, analytics, request history, or third-party scripts. Public API requests omit browser

--- a/apps/api-playground/src/App.test.tsx
+++ b/apps/api-playground/src/App.test.tsx
@@ -120,8 +120,9 @@ describe("API key handling", () => {
       await screen.findByRole("heading", { name: "Browse the API schema" }),
     ).toBeInTheDocument()
     expect(
-      screen.getByText(/Browse every endpoint without authentication/),
+      screen.getByText(/Browse every endpoint/),
     ).toBeInTheDocument()
+    expect(screen.queryByText(/without authentication/)).not.toBeInTheDocument()
     expect(screen.getByRole("button", { name: "Execute request" })).toBeDisabled()
     expect(screen.queryByLabelText(/Organization slug/)).not.toBeInTheDocument()
     expect(screen.queryByText("Backfield developer tools")).not.toBeInTheDocument()
@@ -152,7 +153,7 @@ describe("API key handling", () => {
     vi.stubGlobal("fetch", fetchMock)
 
     render(<App />)
-    const connectionRegion = screen.getByRole("region", {
+    const connectionRegion = await screen.findByRole("region", {
       name: "API schema",
     })
     await waitFor(() => expect(connectionRegion).toHaveAttribute("aria-busy", "true"))
@@ -228,7 +229,7 @@ describe("API key handling", () => {
     vi.stubGlobal("fetch", fetchMock)
 
     const firstRender = render(<App />)
-    fireEvent.change(screen.getByLabelText(/Project API key/), {
+    fireEvent.change(await screen.findByLabelText(/Project API key/), {
       target: { value: "top-secret-key" },
     })
     fireEvent.click(screen.getByRole("button", { name: "Use API key" }))
@@ -241,8 +242,9 @@ describe("API key handling", () => {
     // A fresh mount models a reload in the same browser tab.
     firstRender.unmount()
     render(<App />)
-    expect(screen.getByLabelText(/Project API key/)).toHaveValue("top-secret-key")
-
+    expect(
+      sessionStorage.getItem("backfield-playground-project-api-key"),
+    ).toBe("top-secret-key")
     expect(await screen.findByRole("heading", { name: "List and search" })).toBeInTheDocument()
     expect(screen.getByRole("heading", { name: "API schema loaded" })).toBeInTheDocument()
     expect(screen.getByRole("button", { name: "Reload schema" })).toBeInTheDocument()
@@ -313,7 +315,7 @@ describe("API key handling", () => {
     vi.stubGlobal("fetch", fetchMock)
 
     render(<App />)
-    fireEvent.change(screen.getByLabelText(/Project API key/), {
+    fireEvent.change(await screen.findByLabelText(/Project API key/), {
       target: { value: "logout-secret-key" },
     })
     fireEvent.click(screen.getByRole("button", { name: "Use API key" }))
@@ -336,6 +338,42 @@ describe("tenant session host", () => {
     cleanup()
     vi.restoreAllMocks()
     vi.unstubAllGlobals()
+  })
+
+  it("redirects unauthenticated visits to the Agate login screen", async () => {
+    const assign = vi.fn()
+    vi.stubGlobal("location", {
+      ...window.location,
+      hostname: "playground.canary.stg.backfield.news",
+      origin: "https://playground.canary.stg.backfield.news",
+      href: "https://playground.canary.stg.backfield.news/",
+      assign,
+    })
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>().mockImplementation(async (input) => {
+        if (String(input).endsWith("/v1/auth/me")) {
+          return new Response(JSON.stringify({ detail: "Not authenticated" }), {
+            status: 401,
+            headers: { "Content-Type": "application/json" },
+          })
+        }
+        throw new Error(`Unexpected request: ${String(input)}`)
+      }),
+    )
+
+    render(<App />)
+
+    await waitFor(() =>
+      expect(assign).toHaveBeenCalledWith(
+        "https://agate.canary.stg.backfield.news/login",
+      ),
+    )
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument()
+    expect(screen.queryByRole("heading", { name: "Browse the API schema" })).not.toBeInTheDocument()
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Loading your Backfield workspace…",
+    )
   })
 
   it("loads the signed-in shell from the Agate host, not api.*", async () => {

--- a/apps/api-playground/src/App.tsx
+++ b/apps/api-playground/src/App.tsx
@@ -19,6 +19,7 @@ import {
 import {
   fetchPlatformContext,
   logoutSession,
+  SessionAuthRequiredError,
   type PlatformContext,
 } from "./lib/session"
 
@@ -194,6 +195,10 @@ export default function App() {
     })
   }
 
+  function redirectToLogin() {
+    window.location.assign(agateOrigin ? `${agateOrigin}/login` : "/")
+  }
+
   async function loadSessionContext(
     coreOrigin: string,
     stylebookApiOrigin: string,
@@ -203,29 +208,39 @@ export default function App() {
     try {
       const context = await fetchPlatformContext(coreOrigin, stylebookApiOrigin)
       setPlatformContext(context)
+      setSessionLoading(false)
       return context
     } catch (caught) {
       setPlatformContext(undefined)
+      // Match Agate/Stylebook: unauthenticated visits leave for the shared login screen.
+      if (caught instanceof SessionAuthRequiredError) {
+        redirectToLogin()
+        // Keep the loading shell visible while the browser navigates away.
+        throw caught
+      }
       const message =
         caught instanceof Error
           ? caught.message
-          : "Sign in to Backfield before opening the API Playground."
+          : "Unable to load your Backfield workspace."
       setSessionError(message)
-      throw caught
-    } finally {
       setSessionLoading(false)
+      throw caught
     }
   }
 
   useEffect(() => {
     if (!apiOrigin || !stylebookApiOrigin || !sessionOrigin) {
+      setSessionLoading(false)
       setSessionError(
         "Open the API Playground from your organization’s tenant-specific Playground domain.",
       )
       return
     }
-    void loadSessionContext(sessionOrigin, stylebookApiOrigin).catch(() => undefined)
-    void loadSchema()
+    void loadSessionContext(sessionOrigin, stylebookApiOrigin)
+      .then(() => {
+        void loadSchema()
+      })
+      .catch(() => undefined)
     // Tenant origins are intentionally inferred once from the current hostname.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
@@ -269,7 +284,7 @@ export default function App() {
     if (sessionOrigin) {
       await logoutSession(sessionOrigin)
     }
-    window.location.assign(agateOrigin ? `${agateOrigin}/login` : "/")
+    redirectToLogin()
   }
 
   function clearApiKey() {
@@ -335,6 +350,8 @@ export default function App() {
             {sessionError}
           </p>
         )}
+        {platformContext && (
+          <>
         <section
           className={`connection-card ${
             document && apiKey ? "connection-card-compact" : ""
@@ -378,10 +395,10 @@ export default function App() {
                   </h2>
                   <p>
                     {document
-                      ? "Browse every endpoint without authentication. Add a project API key to execute requests."
+                      ? "Browse every endpoint. Add a project API key to execute requests."
                       : loading
                         ? "Loading this organization’s public API schema…"
-                        : "The public API schema is available without authentication. Add a project API key to execute requests."}
+                        : "Load this organization’s public API schema. Add a project API key to execute requests."}
                   </p>
                 </div>
               </div>
@@ -524,6 +541,8 @@ export default function App() {
               onProjectSlugChange={setExplorerProjectSlug}
             />
           </div>
+        )}
+          </>
         )}
         </main>
       </div>

--- a/apps/api-playground/src/lib/session.test.ts
+++ b/apps/api-playground/src/lib/session.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 
-import { logoutSession } from "./session"
+import {
+  fetchPlatformContext,
+  logoutSession,
+  SessionAuthRequiredError,
+} from "./session"
 
 describe("Playground session", () => {
   afterEach(() => {
@@ -28,5 +32,24 @@ describe("Playground session", () => {
     vi.stubGlobal("fetch", vi.fn<typeof fetch>().mockRejectedValue(new Error("offline")))
 
     await expect(logoutSession("https://agate.newsroom.backfield.news")).resolves.toBeUndefined()
+  })
+
+  it("requires a Backfield session before loading the signed-in shell", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>().mockResolvedValue(
+        new Response(JSON.stringify({ detail: "Not authenticated" }), {
+          status: 401,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    )
+
+    await expect(
+      fetchPlatformContext(
+        "https://agate.newsroom.backfield.news",
+        "https://stylebook-api.newsroom.backfield.news",
+      ),
+    ).rejects.toBeInstanceOf(SessionAuthRequiredError)
   })
 })

--- a/apps/api-playground/src/lib/session.ts
+++ b/apps/api-playground/src/lib/session.ts
@@ -40,6 +40,14 @@ interface MeResponse {
   org_role?: string | null
 }
 
+/** Thrown when the browser has no usable Backfield session; callers redirect to Agate login. */
+export class SessionAuthRequiredError extends Error {
+  constructor() {
+    super("Sign in to Backfield before opening the API Playground.")
+    this.name = "SessionAuthRequiredError"
+  }
+}
+
 async function sessionJson<T>(origin: string, path: string): Promise<T> {
   const response = await fetch(`${origin}${path}`, {
     credentials: "include",
@@ -47,11 +55,10 @@ async function sessionJson<T>(origin: string, path: string): Promise<T> {
     referrerPolicy: "no-referrer",
   })
   if (!response.ok) {
-    throw new Error(
-      response.status === 401 || response.status === 403
-        ? "Sign in to Backfield before opening the API Playground."
-        : `Backfield session request failed with ${response.status}.`,
-    )
+    if (response.status === 401 || response.status === 403) {
+      throw new SessionAuthRequiredError()
+    }
+    throw new Error(`Backfield session request failed with ${response.status}.`)
   }
   return (await response.json()) as T
 }
@@ -74,7 +81,7 @@ export async function fetchPlatformContext(
 ): Promise<PlatformContext> {
   const me = await sessionJson<MeResponse>(coreOrigin, "/v1/auth/me")
   if (!me.authenticated || !me.email || me.organization_id == null) {
-    throw new Error("Sign in to Backfield before opening the API Playground.")
+    throw new SessionAuthRequiredError()
   }
 
   const [workspaces, stylebooks] = await Promise.all([

--- a/apps/worker/src/worker/processed_item_claims.py
+++ b/apps/worker/src/worker/processed_item_claims.py
@@ -8,6 +8,7 @@ import time
 from datetime import UTC, datetime
 
 from backfield_db import AgateProcessedItem
+from sqlalchemy import update
 from sqlmodel import Session, select
 
 logger = logging.getLogger(__name__)
@@ -18,10 +19,25 @@ _ORPHAN_RECONCILE_INTERVAL_S = float(os.getenv("BATCH_ORPHAN_RECONCILE_INTERVAL_
 _WORKER_CONCURRENCY = int(os.getenv("CELERY_WORKER_CONCURRENCY", "16"))
 
 _orphan_reconcile_last_by_run: dict[str, float] = {}
+_UNOBSERVED_STARTED_AT = object()
 
 
-def running_item_touch_ts(item: AgateProcessedItem) -> datetime:
-    return item.started_at or item.updated_at or item.created_at
+def _running_claim_is_orphan(
+    item_id: int,
+    *,
+    started_at: datetime | None,
+    updated_at: datetime,
+    created_at: datetime,
+    active_item_ids: set[int],
+    now: datetime,
+    orphan_after_s: int,
+) -> bool:
+    if item_id in active_item_ids:
+        return False
+    touch = started_at or updated_at or created_at
+    if touch.tzinfo is None:
+        touch = touch.replace(tzinfo=UTC)
+    return (now - touch).total_seconds() >= float(orphan_after_s)
 
 
 def is_orphan_running_item(
@@ -33,13 +49,16 @@ def is_orphan_running_item(
 ) -> bool:
     if item.status != "running" or item.id is None:
         return False
-    if int(item.id) in active_item_ids:
-        return False
     now = now or datetime.now(UTC)
-    touch = running_item_touch_ts(item)
-    if touch.tzinfo is None:
-        touch = touch.replace(tzinfo=UTC)
-    return (now - touch).total_seconds() >= float(orphan_after_s)
+    return _running_claim_is_orphan(
+        int(item.id),
+        started_at=item.started_at,
+        updated_at=item.updated_at,
+        created_at=item.created_at,
+        active_item_ids=active_item_ids,
+        now=now,
+        orphan_after_s=orphan_after_s,
+    )
 
 
 def should_reconcile_orphan_running_items(
@@ -58,18 +77,33 @@ def should_reconcile_orphan_running_items(
     return True
 
 
-def release_running_claim(session: Session, item_id: int, *, now: datetime | None = None) -> bool:
+def release_running_claim(
+    session: Session,
+    item_id: int,
+    *,
+    observed_started_at: datetime | None | object = _UNOBSERVED_STARTED_AT,
+    now: datetime | None = None,
+) -> bool:
     """Return a claimed item to ``pending`` so UI counts and retries stay accurate."""
-    item = session.get(AgateProcessedItem, item_id)
-    if item is None or item.status != "running":
-        return False
     now = now or datetime.now(UTC)
-    item.status = "pending"
-    item.started_at = None
-    item.error_message = None
-    item.updated_at = now
-    session.add(item)
-    return True
+    filters = [
+        AgateProcessedItem.id == item_id,
+        AgateProcessedItem.status == "running",
+    ]
+    if observed_started_at is not _UNOBSERVED_STARTED_AT:
+        filters.append(AgateProcessedItem.started_at == observed_started_at)
+    result = session.execute(
+        update(AgateProcessedItem)
+        .where(*filters)
+        .values(
+            status="pending",
+            started_at=None,
+            error_message=None,
+            updated_at=now,
+        )
+        .execution_options(synchronize_session="fetch")
+    )
+    return bool(result.rowcount)
 
 
 def release_orphan_running_items_for_run(
@@ -79,25 +113,44 @@ def release_orphan_running_items_for_run(
     active_item_ids: set[int],
     now: datetime | None = None,
 ) -> int:
+    now = now or datetime.now(UTC)
     rows = list(
         session.exec(
-            select(AgateProcessedItem).where(
+            select(
+                AgateProcessedItem.id,
+                AgateProcessedItem.started_at,
+                AgateProcessedItem.updated_at,
+                AgateProcessedItem.created_at,
+            ).where(
                 AgateProcessedItem.run_id == run_id,
                 AgateProcessedItem.status == "running",
             )
         ).all()
     )
     released = 0
-    for row in rows:
-        if not is_orphan_running_item(row, active_item_ids=active_item_ids, now=now):
+    for item_id, started_at, updated_at, created_at in rows:
+        if item_id is None:
             continue
-        if row.id is None:
+        if not _running_claim_is_orphan(
+            int(item_id),
+            started_at=started_at,
+            updated_at=updated_at,
+            created_at=created_at,
+            active_item_ids=active_item_ids,
+            now=now,
+            orphan_after_s=_ORPHAN_RUNNING_AFTER_S,
+        ):
             continue
-        if release_running_claim(session, int(row.id), now=now):
+        if release_running_claim(
+            session,
+            int(item_id),
+            observed_started_at=started_at,
+            now=now,
+        ):
             released += 1
             logger.info(
                 "Released orphan running processed_item id=%s run_id=%s back to pending",
-                row.id,
+                item_id,
                 run_id,
             )
     return released

--- a/apps/worker/src/worker/tasks.py
+++ b/apps/worker/src/worker/tasks.py
@@ -9,7 +9,7 @@ import os
 import tempfile
 from collections.abc import Callable
 from contextlib import contextmanager
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -81,8 +81,8 @@ from backfield_entities.quality.finders.duplicate_organizations import (
 from backfield_entities.quality.finders.duplicate_people import duplicate_person_cluster_ids
 from celery import Celery, chord, group
 from celery.exceptions import Reject
-from sqlalchemy import delete, update
-from sqlmodel import Session, select
+from sqlalchemy import delete, func, update
+from sqlmodel import Session, col, select
 
 from worker.flags.replace_geography import clear_replace_article_geography_flags
 from worker.nodes.db_output import run_db_output
@@ -134,50 +134,35 @@ def _is_stale_running_item(item: AgateProcessedItem, *, now: datetime | None = N
     return (now - touch).total_seconds() > _STALE_RUNNING_AFTER_S
 
 
-def _reap_stale_running_items(
-    session: Session,
-    items: list[AgateProcessedItem],
-    *,
-    now: datetime | None = None,
-) -> None:
-    """Mark zombie ``running`` rows terminal so batch runs can finalize after worker loss."""
-    now = now or datetime.now(UTC)
-    for row in items:
-        if not _is_stale_running_item(row, now=now):
-            continue
-        row.status = "failed"
-        row.error_message = _STALE_RUNNING_MESSAGE
-        row.updated_at = now
-        session.add(row)
-
-
 def _reap_stale_running_items_for_run(
     session: Session,
     run_id: str,
     *,
     now: datetime | None = None,
 ) -> int:
-    """Reap stale ``running`` rows for one parent run (batch progress helper)."""
+    """Atomically fail stale ``running`` rows for one parent run."""
     now = now or datetime.now(UTC)
-    rows = list(
-        session.exec(
-            select(AgateProcessedItem).where(
-                AgateProcessedItem.run_id == run_id,
-                AgateProcessedItem.status == "running",
-            )
-        ).all()
+    stale_before = now - timedelta(seconds=_STALE_RUNNING_AFTER_S)
+    touch_timestamp = func.coalesce(
+        AgateProcessedItem.started_at,
+        AgateProcessedItem.updated_at,
+        AgateProcessedItem.created_at,
     )
-    stale_rows = [row for row in rows if _is_stale_running_item(row, now=now)]
-    if not stale_rows:
-        return 0
-    _reap_stale_running_items(session, stale_rows, now=now)
-    return len(stale_rows)
-
-
-def _item_blocks_run_finalization(item: AgateProcessedItem) -> bool:
-    if item.status == "pending":
-        return True
-    return item.status == "running" and not _is_stale_running_item(item)
+    result = session.execute(
+        update(AgateProcessedItem)
+        .where(
+            AgateProcessedItem.run_id == run_id,
+            AgateProcessedItem.status == "running",
+            touch_timestamp < stale_before,
+        )
+        .values(
+            status="failed",
+            error_message=_STALE_RUNNING_MESSAGE,
+            updated_at=now,
+        )
+        .execution_options(synchronize_session="fetch")
+    )
+    return int(result.rowcount or 0)
 
 
 def _try_claim_processed_item(
@@ -479,40 +464,71 @@ def _first_s3_input_params(spec: GraphSpec) -> dict[str, Any]:
     raise ValueError("S3 batch setup requires an S3Input node in the graph.")
 
 
+def _parent_run_status(session: Session, run_id: str) -> str | None:
+    return session.exec(select(AgateRun.status).where(AgateRun.id == run_id)).first()
+
+
+def _run_has_unfinished_items(session: Session, run_id: str) -> bool:
+    blocker_id = session.exec(
+        select(AgateProcessedItem.id)
+        .where(
+            AgateProcessedItem.run_id == run_id,
+            col(AgateProcessedItem.status).in_(("pending", "running")),
+        )
+        .limit(1)
+    ).first()
+    return blocker_id is not None
+
+
 def _finalize_s3_parent_run(session: Session, run_id: str) -> None:
-    run = session.get(AgateRun, run_id)
-    if not run:
+    if _parent_run_status(session, run_id) != "running":
         return
-    items = list(
-        session.exec(select(AgateProcessedItem).where(AgateProcessedItem.run_id == run_id)).all()
-    )
-    _reap_stale_running_items(session, items)
-    session.commit()
-    items = list(
-        session.exec(select(AgateProcessedItem).where(AgateProcessedItem.run_id == run_id)).all()
-    )
-    if any(_item_blocks_run_finalization(row) for row in items):
+
+    reaped = _reap_stale_running_items_for_run(session, run_id)
+    if reaped:
+        # Keep stale recovery durable and release item locks before taking the parent lock.
+        session.commit()
+
+    if _run_has_unfinished_items(session, run_id):
         return
-    failed = [row for row in items if row.status == "failed"]
-    base: dict[str, Any] = {}
-    if run.result_json:
-        try:
-            base = json.loads(run.result_json)
-        except json.JSONDecodeError:
-            base = {}
-    base["items"] = [
+
+    run = session.exec(
+        select(AgateRun)
+        .where(AgateRun.id == run_id)
+        .with_for_update()
+        .execution_options(populate_existing=True)
+    ).first()
+    if run is None or run.status != "running":
+        return
+    if _run_has_unfinished_items(session, run_id):
+        return
+
+    items = list(
+        session.exec(
+            select(
+                AgateProcessedItem.id,
+                AgateProcessedItem.source_file,
+                AgateProcessedItem.status,
+                AgateProcessedItem.error_message,
+            )
+            .where(AgateProcessedItem.run_id == run_id)
+            .order_by(AgateProcessedItem.id)
+        ).all()
+    )
+    item_summary = [
         {
-            "id": row.id,
-            "source_file": row.source_file,
-            "status": row.status,
-            "error_message": row.error_message,
+            "id": item_id,
+            "source_file": source_file,
+            "status": status,
+            "error_message": error_message,
         }
-        for row in items
+        for item_id, source_file, status, error_message in items
     ]
-    run.result_json = json.dumps(base)
-    if failed:
+    failed_count = sum(1 for _, _, status, _ in items if status == "failed")
+    run.result_json = merge_run_result_payload(run.result_json, items=item_summary)
+    if failed_count:
         run.status = "failed"
-        run.error_message = f"{len(failed)} of {len(items)} file task(s) failed."
+        run.error_message = f"{failed_count} of {len(items)} file task(s) failed."
     else:
         run.status = "succeeded"
         run.error_message = None
@@ -932,16 +948,19 @@ def _execute_processed_item_impl(item_id: int) -> None:
         if not item:
             return
         reaped = _reap_stale_running_items_for_run(session, item.run_id)
-        running_rows = list(
-            session.exec(
-                select(AgateProcessedItem).where(
+        running_count = int(
+            session.scalar(
+                select(func.count())
+                .select_from(AgateProcessedItem)
+                .where(
                     AgateProcessedItem.run_id == item.run_id,
                     AgateProcessedItem.status == "running",
                 )
-            ).all()
+            )
+            or 0
         )
         released = 0
-        if should_reconcile_orphan_running_items(len(running_rows), run_id=item.run_id):
+        if should_reconcile_orphan_running_items(running_count, run_id=item.run_id):
             active_ids = active_execute_processed_item_ids(celery_app) | {int(item_id)}
             released = release_orphan_running_items_for_run(
                 session,

--- a/apps/worker/src/worker/tasks.py
+++ b/apps/worker/src/worker/tasks.py
@@ -82,6 +82,7 @@ from backfield_entities.quality.finders.duplicate_people import duplicate_person
 from celery import Celery, chord, group
 from celery.exceptions import Reject
 from sqlalchemy import delete, func, update
+from sqlalchemy.engine import Engine
 from sqlmodel import Session, col, select
 
 from worker.flags.replace_geography import clear_replace_article_geography_flags
@@ -222,7 +223,10 @@ def _try_claim_processed_item(
     return True
 
 
-def _node_wall_clock_hooks() -> tuple[
+def _node_wall_clock_hooks(
+    *,
+    before_node_check: Callable[[], None] | None = None,
+) -> tuple[
     Callable[[str, str], None],
     Callable[[str, str, float], None],
     dict[str, float],
@@ -231,12 +235,52 @@ def _node_wall_clock_hooks() -> tuple[
     timings: dict[str, float] = {}
 
     def before(node_id: str, node_type: str) -> None:
+        if before_node_check is not None:
+            before_node_check()
         set_llm_tracking_current_node(node_id, node_type)
 
     def after(node_id: str, node_type: str, elapsed_s: float) -> None:
         timings[f"{node_type}:{node_id}"] = elapsed_s
 
     return before, after, timings
+
+
+def _ensure_parent_run_running(engine: Engine, run_id: str) -> None:
+    """Stop graph work between nodes once the parent leaves ``running``."""
+    with Session(engine) as session:
+        status_and_error = session.exec(
+            select(AgateRun.status, AgateRun.error_message).where(AgateRun.id == run_id)
+        ).first()
+    if status_and_error is None:
+        raise RuntimeError("Parent run not found")
+    run_status, error_message = status_and_error
+    if run_status != "running":
+        raise RuntimeError(error_message or "Parent run is no longer active")
+
+
+def _ensure_processed_item_active(
+    engine: Engine,
+    *,
+    run_id: str,
+    item_id: int,
+    claimed_at: datetime,
+) -> None:
+    """Stop stale or cancelled item work before another graph node starts."""
+    with Session(engine) as session:
+        active_item_id = session.exec(
+            select(AgateProcessedItem.id)
+            .join(AgateRun, AgateRun.id == AgateProcessedItem.run_id)
+            .where(
+                AgateProcessedItem.id == item_id,
+                AgateProcessedItem.run_id == run_id,
+                AgateProcessedItem.status == "running",
+                AgateProcessedItem.started_at == claimed_at,
+                AgateRun.status == "running",
+            )
+            .limit(1)
+        ).first()
+    if active_item_id is None:
+        raise RuntimeError("Processed item claim is no longer active")
 
 
 def _log_node_wall_clock_summary(
@@ -480,6 +524,44 @@ def _run_has_unfinished_items(session: Session, run_id: str) -> bool:
     return blocker_id is not None
 
 
+def _update_processed_item_outcome_if_active(
+    session: Session,
+    *,
+    item_id: int,
+    run_id: str,
+    claimed_at: datetime,
+    status: str,
+    result_json: str | None,
+    substrate_article_id: int | None,
+    error_message: str | None,
+    now: datetime,
+) -> bool:
+    """Store a terminal item outcome only while both parent and item remain active."""
+    parent_status = session.exec(
+        select(AgateRun.status).where(AgateRun.id == run_id).with_for_update()
+    ).first()
+    if parent_status != "running":
+        return False
+    result = session.execute(
+        update(AgateProcessedItem)
+        .where(
+            AgateProcessedItem.id == item_id,
+            AgateProcessedItem.run_id == run_id,
+            AgateProcessedItem.status == "running",
+            AgateProcessedItem.started_at == claimed_at,
+        )
+        .values(
+            status=status,
+            result_json=result_json,
+            substrate_article_id=substrate_article_id,
+            error_message=error_message,
+            updated_at=now,
+        )
+        .execution_options(synchronize_session=False)
+    )
+    return int(result.rowcount or 0) == 1
+
+
 def _finalize_s3_parent_run(session: Session, run_id: str) -> None:
     if _parent_run_status(session, run_id) != "running":
         return
@@ -607,7 +689,9 @@ def execute_agate_run(run_id: str) -> None:
             replace_article_geography=replace_geography,
             project_system_prompt=project_system_prompt,
         ):
-            before_node, after_node, node_timings = _node_wall_clock_hooks()
+            before_node, after_node, node_timings = _node_wall_clock_hooks(
+                before_node_check=lambda: _ensure_parent_run_running(engine, run_id)
+            )
             outputs = execute_graph(
                 spec,
                 node_runners=node_runners,
@@ -709,22 +793,29 @@ def execute_s3_batch_setup(run_id: str) -> None:
             pending: list[tuple[int, int]] = []
 
             if not keys:
-                run = session.get(AgateRun, run_id)
-                if run:
-                    run.status = "failed"
-                    run.error_message = f"No JSON objects found under s3://{bucket}/{prefix or ''}"
-                    run.result_json = merge_run_result_payload(
-                        run.result_json,
-                        s3_batch={
-                            "total_json_objects": 0,
-                            "skipped_invalid": 0,
-                            "skipped_cap": 0,
-                            "valid_executed": 0,
-                        },
-                    )
-                    run.updated_at = datetime.now(UTC)
-                    session.add(run)
-                    session.commit()
+                run = session.exec(
+                    select(AgateRun)
+                    .where(AgateRun.id == run_id)
+                    .with_for_update()
+                    .execution_options(populate_existing=True)
+                ).first()
+                if run is None or run.status != "running":
+                    session.rollback()
+                    return
+                run.status = "failed"
+                run.error_message = f"No JSON objects found under s3://{bucket}/{prefix or ''}"
+                run.result_json = merge_run_result_payload(
+                    run.result_json,
+                    s3_batch={
+                        "total_json_objects": 0,
+                        "skipped_invalid": 0,
+                        "skipped_cap": 0,
+                        "valid_executed": 0,
+                    },
+                )
+                run.updated_at = datetime.now(UTC)
+                session.add(run)
+                session.commit()
                 return
 
             with _env_overlay(overlay):
@@ -788,8 +879,14 @@ def execute_s3_batch_setup(run_id: str) -> None:
                 "skipped_cap": skipped_cap,
                 "valid_executed": len(pending),
             }
-            run = session.get(AgateRun, run_id)
-            if not run:
+            run = session.exec(
+                select(AgateRun)
+                .where(AgateRun.id == run_id)
+                .with_for_update()
+                .execution_options(populate_existing=True)
+            ).first()
+            if run is None or run.status != "running":
+                session.rollback()
                 return
             run.result_json = merge_run_result_payload(
                 run.result_json,
@@ -801,16 +898,22 @@ def execute_s3_batch_setup(run_id: str) -> None:
             session.commit()
 
             if not pending:
-                run = session.get(AgateRun, run_id)
-                if run:
-                    run.status = "failed"
-                    run.error_message = (
-                        "No valid JSON files with a non-empty top-level "
-                        "'text' field under the prefix."
-                    )
-                    run.updated_at = datetime.now(UTC)
-                    session.add(run)
-                    session.commit()
+                run = session.exec(
+                    select(AgateRun)
+                    .where(AgateRun.id == run_id)
+                    .with_for_update()
+                    .execution_options(populate_existing=True)
+                ).first()
+                if run is None or run.status != "running":
+                    session.rollback()
+                    return
+                run.status = "failed"
+                run.error_message = (
+                    "No valid JSON files with a non-empty top-level 'text' field under the prefix."
+                )
+                run.updated_at = datetime.now(UTC)
+                session.add(run)
+                session.commit()
                 return
 
             # Queue all ``execute_processed_item`` tasks and return immediately. A ``chord``
@@ -834,13 +937,20 @@ def execute_s3_batch_setup(run_id: str) -> None:
         except Exception as e:
             logger.exception("S3 batch setup failed for run %s", run_id)
             with Session(engine) as session3:
-                run_fail = session3.get(AgateRun, run_id)
-                if run_fail:
-                    run_fail.status = "failed"
-                    run_fail.error_message = str(e)
-                    run_fail.updated_at = datetime.now(UTC)
-                    session3.add(run_fail)
-                    session3.commit()
+                run_fail = session3.exec(
+                    select(AgateRun)
+                    .where(AgateRun.id == run_id)
+                    .with_for_update()
+                    .execution_options(populate_existing=True)
+                ).first()
+                if run_fail is None or run_fail.status != "running":
+                    session3.rollback()
+                    return
+                run_fail.status = "failed"
+                run_fail.error_message = str(e)
+                run_fail.updated_at = datetime.now(UTC)
+                session3.add(run_fail)
+                session3.commit()
 
 
 @celery_app.task(name="worker.tasks.execute_run_replay_setup")
@@ -943,6 +1053,7 @@ def execute_processed_item(item_id: int) -> None:
 
 def _execute_processed_item_impl(item_id: int) -> None:
     engine = get_engine()
+    claimed_at: datetime
     with Session(engine) as session:
         item = session.get(AgateProcessedItem, item_id)
         if not item:
@@ -982,6 +1093,10 @@ def _execute_processed_item_impl(item_id: int) -> None:
                 # or orphan reconcile returns the row to pending.
                 raise Reject(requeue=True)
             return
+        if item.started_at is None:
+            session.rollback()
+            return
+        claimed_at = item.started_at
         session.commit()
 
     project_id: int
@@ -1009,6 +1124,8 @@ def _execute_processed_item_impl(item_id: int) -> None:
                 item.updated_at = datetime.now(UTC)
                 session.add(item)
                 session.commit()
+                return
+            if run.status != "running":
                 return
             graph = session.get(AgateGraph, run.graph_id)
             if not graph:
@@ -1099,16 +1216,24 @@ def _execute_processed_item_impl(item_id: int) -> None:
             session.commit()
     except Exception as e:
         with Session(engine) as session:
-            item = session.get(AgateProcessedItem, item_id)
-            if item:
-                item.status = "failed"
-                item.error_message = str(e)
-                item.result_json = None
-                item.substrate_article_id = None
-                item.updated_at = datetime.now(UTC)
-                session.add(item)
+            item_run_id = session.exec(
+                select(AgateProcessedItem.run_id).where(AgateProcessedItem.id == item_id)
+            ).first()
+            if item_run_id and _update_processed_item_outcome_if_active(
+                session,
+                item_id=int(item_id),
+                run_id=item_run_id,
+                claimed_at=claimed_at,
+                status="failed",
+                result_json=None,
+                substrate_article_id=None,
+                error_message=str(e),
+                now=datetime.now(UTC),
+            ):
                 session.commit()
-                _finalize_s3_parent_run(session, item.run_id)
+                _finalize_s3_parent_run(session, item_run_id)
+            else:
+                session.rollback()
         return
 
     outputs: dict[str, Any] | None = None
@@ -1131,7 +1256,14 @@ def _execute_processed_item_impl(item_id: int) -> None:
             processed_item_id=iid,
             project_system_prompt=project_system_prompt,
         ):
-            before_node, after_node, node_timings = _node_wall_clock_hooks()
+            before_node, after_node, node_timings = _node_wall_clock_hooks(
+                before_node_check=lambda: _ensure_processed_item_active(
+                    engine,
+                    run_id=run_id_str,
+                    item_id=int(item_id),
+                    claimed_at=claimed_at,
+                )
+            )
             outputs = execute_graph(
                 spec,
                 node_runners=node_runners,
@@ -1143,9 +1275,26 @@ def _execute_processed_item_impl(item_id: int) -> None:
     finally:
         reset_llm_tracking_context(track_tok)
 
+    completed_result_json = json.dumps(outputs) if item_error is None else None
+    completed_article_id = (
+        resolve_substrate_article_id_for_processed_item(outputs=outputs)
+        if item_error is None
+        else None
+    )
+    completed_status = "succeeded" if item_error is None else "failed"
     with Session(engine) as session:
-        item = session.get(AgateProcessedItem, item_id)
-        if not item:
+        if not _update_processed_item_outcome_if_active(
+            session,
+            item_id=int(item_id),
+            run_id=run_id_str,
+            claimed_at=claimed_at,
+            status=completed_status,
+            result_json=completed_result_json,
+            substrate_article_id=completed_article_id,
+            error_message=item_error,
+            now=datetime.now(UTC),
+        ):
+            session.rollback()
             return
         _log_node_wall_clock_summary(
             run_id=run_id_str,
@@ -1153,28 +1302,14 @@ def _execute_processed_item_impl(item_id: int) -> None:
             timings=node_timings,
             session=session,
         )
-        if item_error is None:
-            item.status = "succeeded"
-            item.result_json = json.dumps(outputs)
-            item.substrate_article_id = resolve_substrate_article_id_for_processed_item(
-                outputs=outputs
-            )
-            item.error_message = None
-        else:
-            item.status = "failed"
-            item.error_message = item_error
-            item.result_json = None
-            item.substrate_article_id = None
         if replace_geography and not has_db_output and run_id_str:
             clear_replace_article_geography_flags(
                 session,
                 run_id=run_id_str,
                 processed_item_id=iid,
             )
-        item.updated_at = datetime.now(UTC)
-        session.add(item)
         session.commit()
-        _finalize_s3_parent_run(session, item.run_id)
+        _finalize_s3_parent_run(session, run_id_str)
 
 
 @celery_app.task(name="worker.tasks.finalize_s3_parent_run")

--- a/docs/api/agate.md
+++ b/docs/api/agate.md
@@ -42,7 +42,9 @@ Deleting a flow removes its run-control records and detaches durable article row
 - A run pins the effective graph specification before work is queued.
 - S3 Input starts batch setup and creates one processed item per input object.
 - Inline Text Input or JSON Input creates a processed item at trigger time.
-- Run cancellation is available while pending or running. Cancellation is represented by the stored terminal failure state and fixed cancellation detail.
+- Run cancellation is available while pending or running. Cancellation atomically fails active
+  items, preserves completed items, and returns the same compact status shape used for polling.
+  Repeating cancellation returns that terminal status without changing the run again.
 - Replay creates a new run from an existing run contract; item rerun requeues an existing processed item and clears its review state.
 
 For active runs, poll `GET /runs/{run_id}/status` and page summaries through `GET /runs/{run_id}/items`. Full `GET /runs/{run_id}` remains supported for callers that need the complete run response.

--- a/docs/api/public.md
+++ b/docs/api/public.md
@@ -26,9 +26,10 @@ Public routes are therefore under `http://127.0.0.1:8004/public/v1/...`.
 ## API Playground
 
 The local stack serves the interactive API Playground at
-[localhost:5176](http://localhost:5176). It loads the public OpenAPI contract immediately, so the
-endpoint catalog and request fields can be browsed without authentication. Apply a project API key
-in the Playground to execute requests and load project-scoped choices. Generated curl commands use
+[localhost:5176](http://localhost:5176). Opening it requires a signed-in Backfield session
+(unauthenticated visits redirect to Agate login). Once signed in, it loads the public OpenAPI
+contract so the endpoint catalog and request fields can be browsed. Apply a project API key in the
+Playground to execute requests and load project-scoped choices. Generated curl commands use
 `$BACKFIELD_PROJECT_API_KEY` instead of embedding the key.
 
 See the [`apps/api-playground` guide](../../apps/api-playground/README.md) for interaction,

--- a/docs/architecture/database.md
+++ b/docs/architecture/database.md
@@ -127,7 +127,8 @@ specialized indexes include:
 - unique identity fingerprints within a project and canonical slugs within a Stylebook;
 - unique public idempotency keys within project and operation, plus expiry, run,
   and enqueue-state indexes for retention cleanup, run linkage, and publish recovery;
-- run, processed-item, node-type, activity-feed, cleanup-run, and AI-call aggregation indexes.
+- processed-item run/status indexes for batch progress and finalization, plus run, node-type,
+  activity-feed, cleanup-run, and AI-call aggregation indexes.
 
 Postgres uses PostGIS, `pg_trgm`, pgvector, and H3. Migrations create required extensions and fail
 when the database role cannot install them.

--- a/docs/development/local-setup.md
+++ b/docs/development/local-setup.md
@@ -163,8 +163,8 @@ All published ports bind to `127.0.0.1`:
 
 - Agate UI: <http://localhost:5173>
 - Stylebook UI: <http://localhost:5175>
-- API Playground: <http://localhost:5176> (schema browsing is unauthenticated; requests require a
-  project API key)
+- API Playground: <http://localhost:5176> (requires a signed-in Backfield session; requests also
+  need a project API key)
 - Agate API: <http://localhost:8000>
 - Stylebook API: <http://localhost:8003>
 - Core API: <http://localhost:8004>

--- a/packages/backfield-db/alembic/versions/066_agate_pi_run_status.py
+++ b/packages/backfield-db/alembic/versions/066_agate_pi_run_status.py
@@ -1,0 +1,49 @@
+"""Replace the processed-item run index with a run/status index."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "066_agate_pi_run_status"
+down_revision: str | None = "065_public_idempotency_enqueue"
+branch_labels: Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "agate_processed_item"
+_RUN_INDEX = "ix_agate_processed_item_run_id"
+_RUN_STATUS_INDEX = "ix_agate_processed_item_run_status"
+
+
+def upgrade() -> None:
+    # Concurrent DDL keeps active batch-item writes available during release migration.
+    with op.get_context().autocommit_block():
+        op.create_index(
+            _RUN_STATUS_INDEX,
+            _TABLE,
+            ["run_id", "status"],
+            unique=False,
+            postgresql_concurrently=True,
+        )
+        op.drop_index(
+            _RUN_INDEX,
+            table_name=_TABLE,
+            postgresql_concurrently=True,
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.create_index(
+            _RUN_INDEX,
+            _TABLE,
+            ["run_id"],
+            unique=False,
+            postgresql_concurrently=True,
+        )
+        op.drop_index(
+            _RUN_STATUS_INDEX,
+            table_name=_TABLE,
+            postgresql_concurrently=True,
+        )

--- a/packages/backfield-db/src/backfield_db/models.py
+++ b/packages/backfield-db/src/backfield_db/models.py
@@ -2094,9 +2094,12 @@ class AgateProcessedItem(SQLModel, table=True):
     """Per-S3-object execution unit for S3Input batch runs (parent ``agate_run``)."""
 
     __tablename__ = "agate_processed_item"
+    __table_args__ = (
+        Index("ix_agate_processed_item_run_status", "run_id", "status"),
+    )
 
     id: int | None = Field(default=None, primary_key=True)
-    run_id: str = Field(foreign_key="agate_run.id", index=True)
+    run_id: str = Field(foreign_key="agate_run.id")
     source_file: str | None = Field(default=None, sa_column=Column(Text, nullable=True))
     input_json: str | None = Field(default=None, sa_column=Column(Text, nullable=True))
     status: str = Field(

--- a/packages/backfield-db/tests/test_processed_item_model.py
+++ b/packages/backfield-db/tests/test_processed_item_model.py
@@ -1,0 +1,28 @@
+"""Structural contracts for Agate processed-item persistence."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from backfield_db import AgateProcessedItem
+
+
+def test_processed_item_model_has_run_status_index() -> None:
+    table = AgateProcessedItem.__table__
+    indexes = {
+        index.name: tuple(column.name for column in index.columns)
+        for index in table.indexes
+    }
+
+    assert indexes["ix_agate_processed_item_run_status"] == ("run_id", "status")
+    assert "ix_agate_processed_item_run_id" not in indexes
+
+
+def test_processed_item_index_migration_follows_current_head() -> None:
+    versions = Path(__file__).resolve().parents[1] / "alembic" / "versions"
+    migration = (versions / "066_agate_pi_run_status.py").read_text(encoding="utf-8")
+
+    assert 'revision: str = "066_agate_pi_run_status"' in migration
+    assert 'down_revision: str | None = "065_public_idempotency_enqueue"' in migration
+    assert '"ix_agate_processed_item_run_status"' in migration
+    assert "postgresql_concurrently=True" in migration

--- a/tests/agate_api/test_run_cancellation.py
+++ b/tests/agate_api/test_run_cancellation.py
@@ -1,0 +1,239 @@
+"""Large-run cancellation contracts."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Generator
+from typing import Any
+
+import pytest
+from api.deps import get_session
+from api.main import app
+from backfield_db import (
+    AgateGraph,
+    AgateProcessedItem,
+    AgateRun,
+    BackfieldOrganization,
+    BackfieldProject,
+)
+from fastapi.testclient import TestClient
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+from sqlmodel import Session, SQLModel, create_engine, select
+
+from tests.integration_helpers import patch_test_engine
+
+_CANCELLED = "Run cancelled by user"
+
+
+@pytest.fixture
+def cancel_client(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Generator[tuple[TestClient, Engine, str], None, None]:
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'run-cancellation.db'}",
+        connect_args={"check_same_thread": False},
+    )
+    SQLModel.metadata.create_all(engine)
+    patch_test_engine(monkeypatch, engine)
+
+    with Session(engine) as session:
+        organization = BackfieldOrganization(name="Cancellation", slug="cancellation")
+        session.add(organization)
+        session.commit()
+        session.refresh(organization)
+        project = BackfieldProject(
+            organization_id=int(organization.id),
+            name="Cancellation",
+            slug="cancellation",
+        )
+        session.add(project)
+        session.commit()
+        session.refresh(project)
+        graph = AgateGraph(
+            project_id=int(project.id),
+            name="Cancellation",
+            spec_json=json.dumps({"name": "cancel", "nodes": [], "edges": []}),
+        )
+        session.add(graph)
+        session.commit()
+        session.refresh(graph)
+        graph_id = str(graph.id)
+
+    def get_test_session() -> Generator[Session, None, None]:
+        with Session(engine) as session:
+            yield session
+
+    app.dependency_overrides[get_session] = get_test_session
+    try:
+        yield (
+            TestClient(app, headers={"Authorization": "Bearer backfield-dev"}),
+            engine,
+            graph_id,
+        )
+    finally:
+        app.dependency_overrides.clear()
+        engine.dispose()
+
+
+def _insert_run(engine: Engine, graph_id: str, statuses: list[str]) -> str:
+    large_payload = json.dumps({"payload": "x" * 10_000})
+    with Session(engine) as session:
+        run = AgateRun(graph_id=graph_id, status="running")
+        session.add(run)
+        session.commit()
+        session.refresh(run)
+        run_id = str(run.id)
+        for index, status in enumerate(statuses):
+            session.add(
+                AgateProcessedItem(
+                    run_id=run_id,
+                    source_file=f"batch/{index}.json",
+                    input_json=large_payload,
+                    result_json=large_payload,
+                    overlay_json=large_payload,
+                    reviewed_output_json=large_payload,
+                    status=status,
+                    error_message="existing" if status == "failed" else None,
+                )
+            )
+        session.commit()
+        return run_id
+
+
+def _capture_request_sql(
+    client: TestClient,
+    engine: Engine,
+    run_id: str,
+) -> tuple[Any, list[str]]:
+    statements: list[str] = []
+
+    def capture(_conn, _cursor, statement, _parameters, _context, _many) -> None:
+        statements.append(str(statement).lower())
+
+    event.listen(engine, "before_cursor_execute", capture)
+    try:
+        response = client.post(f"/runs/{run_id}/cancel")
+    finally:
+        event.remove(engine, "before_cursor_execute", capture)
+    return response, statements
+
+
+def test_cancel_bulk_updates_active_items_and_returns_compact_status(cancel_client) -> None:
+    client, engine, graph_id = cancel_client
+    run_id = _insert_run(engine, graph_id, ["pending", "running", "succeeded", "skipped"])
+
+    response, statements = _capture_request_sql(client, engine, run_id)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "failed"
+    assert body["error_message"] == _CANCELLED
+    assert body["total_items"] == 4
+    assert body["pending_items"] == 0
+    assert body["running_items"] == 0
+    assert body["succeeded_items"] == 1
+    assert body["failed_items"] == 2
+    assert "processed_items" not in body
+    assert "result" not in body
+    assert len(response.content) < 2_000
+
+    with Session(engine) as session:
+        items = list(
+            session.exec(
+                select(AgateProcessedItem)
+                .where(AgateProcessedItem.run_id == run_id)
+                .order_by(AgateProcessedItem.id)
+            ).all()
+        )
+        assert [(item.status, item.error_message) for item in items] == [
+            ("failed", _CANCELLED),
+            ("failed", _CANCELLED + " (was running)"),
+            ("succeeded", None),
+            ("skipped", None),
+        ]
+
+    item_updates = [
+        statement
+        for statement in statements
+        if statement.lstrip().startswith("update agate_processed_item")
+    ]
+    assert len(item_updates) == 1
+    for forbidden in (
+        "input_json",
+        "result_json",
+        "overlay_json",
+        "reviewed_output_json",
+    ):
+        assert all(
+            forbidden not in statement
+            for statement in statements
+            if statement.lstrip().startswith("select")
+            and "from agate_processed_item" in statement
+        )
+
+
+def test_repeated_cancellation_is_idempotent(cancel_client) -> None:
+    client, engine, graph_id = cancel_client
+    run_id = _insert_run(engine, graph_id, ["pending", "running"])
+
+    first = client.post(f"/runs/{run_id}/cancel")
+    second = client.post(f"/runs/{run_id}/cancel")
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert second.json() == first.json()
+
+
+def test_cancel_openapi_uses_compact_status_contract(cancel_client) -> None:
+    client, _engine, _graph_id = cancel_client
+
+    schema = client.get("/openapi.json").json()
+    response_schema = schema["paths"]["/runs/{run_id}/cancel"]["post"]["responses"]["200"][
+        "content"
+    ]["application/json"]["schema"]
+
+    assert response_schema["$ref"].endswith("/RunStatusOut")
+
+
+def test_cancellation_parent_and_items_roll_back_together(
+    cancel_client,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, engine, graph_id = cancel_client
+    run_id = _insert_run(engine, graph_id, ["pending", "running"])
+
+    def fail_commit(_session: Session) -> None:
+        raise RuntimeError("forced commit failure")
+
+    monkeypatch.setattr(Session, "commit", fail_commit)
+    with pytest.raises(RuntimeError, match="forced commit failure"):
+        client.post(f"/runs/{run_id}/cancel")
+
+    with Session(engine) as session:
+        run = session.get(AgateRun, run_id)
+        assert run is not None
+        assert run.status == "running"
+        assert run.error_message is None
+        statuses = session.exec(
+            select(AgateProcessedItem.status)
+            .where(AgateProcessedItem.run_id == run_id)
+            .order_by(AgateProcessedItem.id)
+        ).all()
+        assert list(statuses) == ["pending", "running"]
+
+
+def test_cancellation_query_and_response_size_are_bounded(cancel_client) -> None:
+    client, engine, graph_id = cancel_client
+    small_run_id = _insert_run(engine, graph_id, ["pending"] * 10)
+    large_run_id = _insert_run(engine, graph_id, ["pending"] * 1195)
+
+    small_response, small_statements = _capture_request_sql(client, engine, small_run_id)
+    large_response, large_statements = _capture_request_sql(client, engine, large_run_id)
+
+    assert small_response.status_code == 200
+    assert large_response.status_code == 200
+    assert len(large_statements) == len(small_statements)
+    assert len(large_response.content) - len(small_response.content) < 100
+    assert len(large_response.content) < 2_000

--- a/tests/worker/test_processed_item_claims.py
+++ b/tests/worker/test_processed_item_claims.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from datetime import UTC, datetime, timedelta
 
 from backfield_db import AgateProcessedItem
+from sqlalchemy import event, update
+from sqlmodel import Session, SQLModel, create_engine
 from worker import processed_item_claims as claims
 
 
@@ -31,6 +33,8 @@ def test_is_not_orphan_when_item_is_actively_executing() -> None:
 
 
 def test_release_orphan_running_items_for_run() -> None:
+    engine = create_engine("sqlite://", echo=False)
+    SQLModel.metadata.create_all(engine)
     now = datetime(2026, 7, 1, 12, 0, 0, tzinfo=UTC)
     orphan = AgateProcessedItem(
         id=1,
@@ -45,35 +49,108 @@ def test_release_orphan_running_items_for_run() -> None:
         started_at=now - timedelta(seconds=claims._ORPHAN_RUNNING_AFTER_S + 5),
     )
 
-    class _ExecResult:
-        def __init__(self, rows: list[AgateProcessedItem]) -> None:
-            self._rows = rows
+    with Session(engine) as session:
+        session.add(orphan)
+        session.add(active)
+        session.commit()
 
-        def all(self) -> list[AgateProcessedItem]:
-            return self._rows
+        released = claims.release_orphan_running_items_for_run(
+            session,
+            "run-1",
+            active_item_ids={2},
+            now=now,
+        )
+        session.commit()
+        session.refresh(orphan)
+        session.refresh(active)
 
-    class _Session:
-        def __init__(self) -> None:
-            self.rows = {1: orphan, 2: active}
+        assert released == 1
+        assert orphan.status == "pending"
+        assert orphan.started_at is None
+        assert active.status == "running"
 
-        def exec(self, _stmt: object) -> _ExecResult:
-            return _ExecResult([orphan, active])
 
-        def get(self, _model: object, item_id: int) -> AgateProcessedItem | None:
-            return self.rows.get(item_id)
+def test_release_running_claim_preserves_a_newer_claim() -> None:
+    engine = create_engine("sqlite://", echo=False)
+    SQLModel.metadata.create_all(engine)
+    observed_started_at = datetime(2026, 7, 1, 12, 0, 0, tzinfo=UTC)
+    newer_started_at = observed_started_at + timedelta(minutes=5)
 
-        def add(self, row: AgateProcessedItem) -> None:
-            if row.id is not None:
-                self.rows[int(row.id)] = row
+    with Session(engine) as session:
+        item = AgateProcessedItem(
+            id=1,
+            run_id="run-1",
+            status="running",
+            started_at=observed_started_at,
+        )
+        session.add(item)
+        session.commit()
+        session.execute(
+            update(AgateProcessedItem)
+            .where(AgateProcessedItem.id == 1)
+            .values(started_at=newer_started_at)
+        )
+        session.commit()
 
-    session = _Session()
-    released = claims.release_orphan_running_items_for_run(
-        session,
-        "run-1",
-        active_item_ids={2},
-        now=now,
-    )
-    assert released == 1
-    assert orphan.status == "pending"
-    assert orphan.started_at is None
-    assert active.status == "running"
+        released = claims.release_running_claim(
+            session,
+            1,
+            observed_started_at=observed_started_at,
+        )
+        session.refresh(item)
+
+        assert not released
+        assert item.status == "running"
+        assert item.started_at == newer_started_at.replace(tzinfo=None)
+
+
+def test_orphan_reconciliation_selects_only_claim_columns() -> None:
+    engine = create_engine("sqlite://", echo=False)
+    SQLModel.metadata.create_all(engine)
+    statements: list[str] = []
+
+    def capture_sql(_conn, _cursor, statement, _parameters, _context, _many) -> None:
+        statements.append(str(statement).lower())
+
+    with Session(engine) as session:
+        session.add(
+            AgateProcessedItem(
+                id=1,
+                run_id="run-1",
+                status="running",
+                started_at=datetime.now(UTC),
+                input_json='{"large":"input"}',
+                result_json='{"large":"result"}',
+                overlay_json='{"large":"overlay"}',
+                reviewed_output_json='{"large":"reviewed"}',
+            )
+        )
+        session.commit()
+
+    event.listen(engine, "before_cursor_execute", capture_sql)
+    try:
+        with Session(engine) as session:
+            claims.release_orphan_running_items_for_run(
+                session,
+                "run-1",
+                active_item_ids={1},
+            )
+    finally:
+        event.remove(engine, "before_cursor_execute", capture_sql)
+
+    item_selects = [
+        statement
+        for statement in statements
+        if statement.lstrip().startswith("select")
+        and "from agate_processed_item" in statement
+    ]
+    assert len(item_selects) == 1
+    for expected in ("id", "started_at", "updated_at", "created_at"):
+        assert expected in item_selects[0]
+    for forbidden in (
+        "input_json",
+        "result_json",
+        "overlay_json",
+        "reviewed_output_json",
+    ):
+        assert forbidden not in item_selects[0]

--- a/tests/worker/test_run_cancellation_postgres.py
+++ b/tests/worker/test_run_cancellation_postgres.py
@@ -1,0 +1,170 @@
+"""PostgreSQL coverage for cancellation racing with worker completion."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from concurrent.futures import ThreadPoolExecutor
+from datetime import UTC, datetime
+from threading import Event
+from uuid import uuid4
+
+import pytest
+from api.routers import runs as run_routes
+from backfield_db import (
+    AgateGraph,
+    AgateProcessedItem,
+    AgateRun,
+    BackfieldOrganization,
+    BackfieldProject,
+)
+from sqlalchemy import delete
+from sqlmodel import Session, create_engine, select
+from worker import tasks as worker_tasks
+
+_DATABASE_URL = os.getenv("BACKFIELD_DATABASE_URL_DIRECT", "")
+
+
+@pytest.mark.skipif(
+    not _DATABASE_URL.startswith("postgresql"),
+    reason="requires BACKFIELD_DATABASE_URL_DIRECT for PostgreSQL",
+)
+def test_cancel_wins_before_worker_stores_completion() -> None:
+    engine = create_engine(_DATABASE_URL, pool_pre_ping=True)
+    suffix = uuid4().hex[:12]
+    cancellation_applied = Event()
+    allow_cancellation_commit = Event()
+
+    organization_id: int | None = None
+    project_id: int | None = None
+    graph_id: str | None = None
+    run_id: str | None = None
+    item_id: int | None = None
+    claimed_at: datetime | None = None
+    try:
+        with Session(engine) as session:
+            organization = BackfieldOrganization(
+                name=f"Cancellation race {suffix}",
+                slug=f"cancellation-race-{suffix}",
+            )
+            session.add(organization)
+            session.commit()
+            session.refresh(organization)
+            organization_id = int(organization.id)
+            project = BackfieldProject(
+                organization_id=organization_id,
+                name=f"Cancellation race {suffix}",
+                slug=f"cancellation-race-{suffix}",
+            )
+            session.add(project)
+            session.commit()
+            session.refresh(project)
+            project_id = int(project.id)
+            graph = AgateGraph(
+                project_id=project_id,
+                name="Cancellation race",
+                spec_json=json.dumps({"name": "race", "nodes": [], "edges": []}),
+            )
+            session.add(graph)
+            session.commit()
+            session.refresh(graph)
+            graph_id = str(graph.id)
+            run = AgateRun(graph_id=graph_id, status="running")
+            session.add(run)
+            session.commit()
+            session.refresh(run)
+            run_id = str(run.id)
+            item = AgateProcessedItem(
+                run_id=run_id,
+                source_file="batch/1.json",
+                status="running",
+                started_at=datetime.now(UTC),
+            )
+            session.add(item)
+            session.commit()
+            session.refresh(item)
+            item_id = int(item.id)
+            claimed_at = item.started_at
+
+        def cancel() -> None:
+            assert run_id is not None
+            with Session(engine) as session:
+                run = session.exec(
+                    select(AgateRun).where(AgateRun.id == run_id).with_for_update()
+                ).one()
+                now = datetime.now(UTC)
+                run.status = "failed"
+                run.error_message = run_routes._RUN_CANCELLED_MESSAGE
+                run.updated_at = now
+                session.add(run)
+                run_routes._cancel_processed_items(session, run_id, now=now)
+                session.flush()
+                cancellation_applied.set()
+                assert allow_cancellation_commit.wait(timeout=10)
+                session.commit()
+
+        def store_worker_completion() -> bool:
+            assert run_id is not None
+            assert item_id is not None
+            assert claimed_at is not None
+            with Session(engine) as session:
+                stored = worker_tasks._update_processed_item_outcome_if_active(
+                    session,
+                    item_id=item_id,
+                    run_id=run_id,
+                    claimed_at=claimed_at,
+                    status="succeeded",
+                    result_json='{"result":"late"}',
+                    substrate_article_id=None,
+                    error_message=None,
+                    now=datetime.now(UTC),
+                )
+                if stored:
+                    session.commit()
+                else:
+                    session.rollback()
+                return stored
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            cancel_future = executor.submit(cancel)
+            assert cancellation_applied.wait(timeout=10)
+            worker_future = executor.submit(store_worker_completion)
+            time.sleep(0.2)
+            assert not worker_future.done()
+            allow_cancellation_commit.set()
+            cancel_future.result(timeout=10)
+            assert worker_future.result(timeout=10) is False
+
+        with Session(engine) as session:
+            run = session.get(AgateRun, run_id)
+            item = session.get(AgateProcessedItem, item_id)
+            assert run is not None
+            assert item is not None
+            assert run.status == "failed"
+            assert run.error_message == run_routes._RUN_CANCELLED_MESSAGE
+            assert item.status == "failed"
+            assert item.error_message == run_routes._RUN_CANCELLED_MESSAGE + " (was running)"
+            assert item.result_json is None
+    finally:
+        allow_cancellation_commit.set()
+        with Session(engine) as session:
+            if run_id is not None:
+                session.execute(
+                    delete(AgateProcessedItem).where(AgateProcessedItem.run_id == run_id)
+                )
+                session.execute(delete(AgateRun).where(AgateRun.id == run_id))
+            if graph_id is not None:
+                session.execute(delete(AgateGraph).where(AgateGraph.id == graph_id))
+            if project_id is not None:
+                session.execute(
+                    delete(BackfieldProject).where(BackfieldProject.id == project_id)
+                )
+            if organization_id is not None:
+                session.execute(
+                    delete(BackfieldOrganization).where(
+                        BackfieldOrganization.id == organization_id
+                    )
+                )
+            session.commit()
+        engine.dispose()

--- a/tests/worker/test_s3_batch_worker.py
+++ b/tests/worker/test_s3_batch_worker.py
@@ -364,6 +364,57 @@ def test_execute_s3_batch_setup_fanout_and_finalize(batch_engine, monkeypatch):
         assert summary.get("graph_spec_json") == graph.spec_json
 
 
+def test_s3_setup_rolls_back_items_if_run_is_cancelled_during_listing(
+    batch_engine,
+    monkeypatch,
+):
+    engine, graph_id = batch_engine
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "ak")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "sk")
+
+    with Session(engine) as session:
+        run = AgateRun(graph_id=graph_id, status="pending")
+        session.add(run)
+        session.commit()
+        session.refresh(run)
+        run_id = str(run.id)
+
+    class _CancellingS3(_FakeS3):
+        cancelled = False
+
+        def get_object(self, **kwargs: Any) -> dict[str, Any]:
+            if not self.cancelled:
+                self.cancelled = True
+                with Session(engine) as cancel_session:
+                    run = cancel_session.get(AgateRun, run_id)
+                    assert run is not None
+                    run.status = "failed"
+                    run.error_message = worker_tasks._RUN_CANCELLED_MESSAGE
+                    run.updated_at = datetime.now(UTC)
+                    cancel_session.add(run)
+                    cancel_session.commit()
+            return super().get_object(**kwargs)
+
+    monkeypatch.setattr(worker_tasks, "_s3_client_from_env", _CancellingS3)
+    monkeypatch.setattr(
+        worker_tasks,
+        "chord",
+        lambda *_args, **_kwargs: pytest.fail("cancelled setup must not queue item work"),
+    )
+
+    worker_tasks.execute_s3_batch_setup(run_id)
+
+    with Session(engine) as session:
+        run = session.get(AgateRun, run_id)
+        assert run is not None
+        assert run.status == "failed"
+        assert run.error_message == worker_tasks._RUN_CANCELLED_MESSAGE
+        items = session.exec(
+            select(AgateProcessedItem).where(AgateProcessedItem.run_id == run_id)
+        ).all()
+        assert list(items) == []
+
+
 def test_execute_run_replay_setup_clones_items(batch_engine, monkeypatch):
     engine, graph_id = batch_engine
 

--- a/tests/worker/test_s3_batch_worker.py
+++ b/tests/worker/test_s3_batch_worker.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import io
 import json
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import pytest
@@ -19,6 +20,7 @@ from backfield_db import (
     BackfieldProject,
 )
 from backfield_entities.catalog.bootstrap import ensure_default_stylebook_for_organization
+from sqlalchemy import event, update
 from sqlmodel import Session, SQLModel, create_engine, select
 from worker import tasks as worker_tasks
 
@@ -107,6 +109,215 @@ def batch_engine(tmp_path, monkeypatch):
     worker_tasks.celery_app.conf.task_always_eager = False
     worker_tasks.celery_app.conf.task_eager_propagates = False
     db_session._engine = None
+
+
+def _create_batch_run(
+    engine,
+    graph_id: str,
+    statuses: list[str],
+    *,
+    result_json: str | None = None,
+    started_at: datetime | None = None,
+) -> str:
+    with Session(engine) as session:
+        run = AgateRun(
+            graph_id=graph_id,
+            status="running",
+            result_json=result_json,
+        )
+        session.add(run)
+        session.commit()
+        session.refresh(run)
+        run_id = str(run.id)
+        for index, status in enumerate(statuses):
+            session.add(
+                AgateProcessedItem(
+                    run_id=run_id,
+                    source_file=f"batch/{index}.json",
+                    input_json=json.dumps({"large": "x" * 100}),
+                    result_json=json.dumps({"large": "y" * 100}),
+                    overlay_json=json.dumps({"note": "z" * 100}),
+                    reviewed_output_json=json.dumps({"reviewed": True}),
+                    status=status,
+                    error_message="item failed" if status == "failed" else None,
+                    started_at=started_at if status == "running" else None,
+                )
+            )
+        session.commit()
+        return run_id
+
+
+@pytest.mark.parametrize("blocking_status", ["pending", "running"])
+def test_finalization_returns_while_items_are_unfinished(batch_engine, blocking_status):
+    engine, graph_id = batch_engine
+    run_id = _create_batch_run(
+        engine,
+        graph_id,
+        ["succeeded", blocking_status],
+        started_at=datetime.now(UTC),
+    )
+
+    with Session(engine) as session:
+        worker_tasks._finalize_s3_parent_run(session, run_id)
+
+    with Session(engine) as session:
+        run = session.get(AgateRun, run_id)
+        assert run is not None
+        assert run.status == "running"
+        assert run.result_json is None
+
+
+def test_finalization_preserves_metadata_and_is_idempotent(batch_engine):
+    engine, graph_id = batch_engine
+    run_id = _create_batch_run(
+        engine,
+        graph_id,
+        ["succeeded", "skipped"],
+        result_json=json.dumps(
+            {
+                "s3_batch": {"valid_executed": 1},
+                "graph_spec_json": "{\"name\":\"snapshot\"}",
+            }
+        ),
+    )
+
+    with Session(engine) as session:
+        worker_tasks._finalize_s3_parent_run(session, run_id)
+
+    with Session(engine) as session:
+        run = session.get(AgateRun, run_id)
+        assert run is not None
+        first_result = run.result_json
+        first_updated_at = run.updated_at
+        payload = json.loads(first_result or "{}")
+        assert run.status == "succeeded"
+        assert run.error_message is None
+        assert payload["s3_batch"] == {"valid_executed": 1}
+        assert payload["graph_spec_json"] == '{"name":"snapshot"}'
+        assert [item["id"] for item in payload["items"]] == sorted(
+            item["id"] for item in payload["items"]
+        )
+
+        worker_tasks._finalize_s3_parent_run(session, run_id)
+        session.refresh(run)
+        assert run.result_json == first_result
+        assert run.updated_at == first_updated_at
+
+
+def test_failed_and_stale_items_fail_parent(batch_engine):
+    engine, graph_id = batch_engine
+    failed_run_id = _create_batch_run(engine, graph_id, ["succeeded", "failed"])
+    stale_run_id = _create_batch_run(
+        engine,
+        graph_id,
+        ["running"],
+        started_at=datetime.now(UTC)
+        - timedelta(seconds=worker_tasks._STALE_RUNNING_AFTER_S + 5),
+    )
+
+    with Session(engine) as session:
+        worker_tasks._finalize_s3_parent_run(session, failed_run_id)
+        worker_tasks._finalize_s3_parent_run(session, stale_run_id)
+
+    with Session(engine) as session:
+        failed_run = session.get(AgateRun, failed_run_id)
+        stale_run = session.get(AgateRun, stale_run_id)
+        assert failed_run is not None
+        assert stale_run is not None
+        assert failed_run.status == "failed"
+        assert failed_run.error_message == "1 of 2 file task(s) failed."
+        assert stale_run.status == "failed"
+        assert stale_run.error_message == "1 of 1 file task(s) failed."
+        stale_item = session.exec(
+            select(AgateProcessedItem).where(AgateProcessedItem.run_id == stale_run_id)
+        ).one()
+        assert stale_item.error_message == worker_tasks._STALE_RUNNING_MESSAGE
+
+
+def test_finalization_does_not_overwrite_cancelled_parent(batch_engine):
+    engine, graph_id = batch_engine
+    run_id = _create_batch_run(
+        engine,
+        graph_id,
+        ["failed"],
+        result_json=json.dumps({"s3_batch": {"total_json_objects": 1}}),
+    )
+    cancelled_at = datetime.now(UTC) - timedelta(seconds=30)
+    with Session(engine) as session:
+        run = session.get(AgateRun, run_id)
+        assert run is not None
+        run.status = "failed"
+        run.error_message = worker_tasks._RUN_CANCELLED_MESSAGE
+        run.updated_at = cancelled_at
+        session.add(run)
+        session.commit()
+
+        worker_tasks._finalize_s3_parent_run(session, run_id)
+        session.refresh(run)
+        assert run.status == "failed"
+        assert run.error_message == worker_tasks._RUN_CANCELLED_MESSAGE
+        assert run.result_json == json.dumps({"s3_batch": {"total_json_objects": 1}})
+        assert run.updated_at == cancelled_at.replace(tzinfo=None)
+
+
+def test_repeated_active_finalization_uses_bounded_narrow_queries(batch_engine):
+    engine, graph_id = batch_engine
+    item_count = 1000
+    run_id = _create_batch_run(engine, graph_id, ["pending"] * item_count)
+    statements: list[str] = []
+
+    def capture_sql(_conn, _cursor, statement, _parameters, _context, _executemany):
+        statements.append(str(statement).lower())
+
+    event.listen(engine, "before_cursor_execute", capture_sql)
+    try:
+        with Session(engine) as session:
+            for _ in range(25):
+                worker_tasks._finalize_s3_parent_run(session, run_id)
+
+            preterminal_item_selects = [
+                statement
+                for statement in statements
+                if statement.lstrip().startswith("select")
+                and "from agate_processed_item" in statement
+            ]
+            assert len(preterminal_item_selects) == 25
+            assert all("limit" in statement for statement in preterminal_item_selects)
+            assert all("source_file" not in statement for statement in preterminal_item_selects)
+            for forbidden in (
+                "input_json",
+                "result_json",
+                "overlay_json",
+                "reviewed_output_json",
+            ):
+                assert all(forbidden not in statement for statement in preterminal_item_selects)
+
+            session.execute(
+                update(AgateProcessedItem)
+                .where(AgateProcessedItem.run_id == run_id)
+                .values(status="succeeded")
+            )
+            session.commit()
+            worker_tasks._finalize_s3_parent_run(session, run_id)
+            worker_tasks._finalize_s3_parent_run(session, run_id)
+    finally:
+        event.remove(engine, "before_cursor_execute", capture_sql)
+
+    summary_selects = [
+        statement
+        for statement in statements
+        if statement.lstrip().startswith("select")
+        and "from agate_processed_item" in statement
+        and "source_file" in statement
+    ]
+    assert len(summary_selects) == 1
+    for forbidden in (
+        "input_json",
+        "result_json",
+        "overlay_json",
+        "reviewed_output_json",
+    ):
+        assert forbidden not in summary_selects[0]
 
 
 def test_execute_s3_batch_setup_fanout_and_finalize(batch_engine, monkeypatch):

--- a/tests/worker/test_s3_finalization_postgres.py
+++ b/tests/worker/test_s3_finalization_postgres.py
@@ -1,0 +1,151 @@
+"""PostgreSQL locking coverage for competing parent-run finalizers."""
+
+from __future__ import annotations
+
+import json
+import os
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier, Lock
+from uuid import uuid4
+
+import pytest
+from backfield_db import (
+    AgateGraph,
+    AgateProcessedItem,
+    AgateRun,
+    BackfieldOrganization,
+    BackfieldProject,
+)
+from sqlalchemy import delete, event
+from sqlmodel import Session, create_engine
+from worker import tasks as worker_tasks
+
+_DATABASE_URL = os.getenv("BACKFIELD_DATABASE_URL_DIRECT", "")
+
+
+@pytest.mark.skipif(
+    not _DATABASE_URL.startswith("postgresql"),
+    reason="requires BACKFIELD_DATABASE_URL_DIRECT for PostgreSQL",
+)
+def test_competing_finalizers_mutate_parent_once(monkeypatch) -> None:
+    engine = create_engine(_DATABASE_URL, pool_pre_ping=True)
+    suffix = uuid4().hex[:12]
+    barrier = Barrier(2)
+    mutation_lock = Lock()
+    parent_updates: list[str] = []
+    original_parent_status = worker_tasks._parent_run_status
+
+    def synchronized_parent_status(session: Session, run_id: str) -> str | None:
+        status = original_parent_status(session, run_id)
+        barrier.wait(timeout=10)
+        return status
+
+    def capture_parent_updates(_conn, _cursor, statement, _parameters, _context, _many) -> None:
+        normalized = str(statement).lower().strip()
+        if normalized.startswith("update agate_run "):
+            with mutation_lock:
+                parent_updates.append(normalized)
+
+    monkeypatch.setattr(worker_tasks, "_parent_run_status", synchronized_parent_status)
+    event.listen(engine, "before_cursor_execute", capture_parent_updates)
+
+    organization_id: int | None = None
+    project_id: int | None = None
+    graph_id: str | None = None
+    run_id: str | None = None
+    try:
+        with Session(engine) as session:
+            organization = BackfieldOrganization(
+                name=f"Finalizer race {suffix}",
+                slug=f"finalizer-race-{suffix}",
+            )
+            session.add(organization)
+            session.commit()
+            session.refresh(organization)
+            organization_id = int(organization.id)
+
+            project = BackfieldProject(
+                organization_id=organization_id,
+                name=f"Finalizer race {suffix}",
+                slug=f"finalizer-race-{suffix}",
+            )
+            session.add(project)
+            session.commit()
+            session.refresh(project)
+            project_id = int(project.id)
+
+            graph = AgateGraph(
+                project_id=project_id,
+                name="Finalizer race",
+                spec_json=json.dumps({"name": "race", "nodes": [], "edges": []}),
+            )
+            session.add(graph)
+            session.commit()
+            session.refresh(graph)
+            graph_id = str(graph.id)
+
+            run = AgateRun(
+                graph_id=graph_id,
+                status="running",
+                result_json=json.dumps({"s3_batch": {"valid_executed": 2}}),
+            )
+            session.add(run)
+            session.commit()
+            session.refresh(run)
+            run_id = str(run.id)
+            session.add(
+                AgateProcessedItem(
+                    run_id=run_id,
+                    source_file="batch/1.json",
+                    status="succeeded",
+                )
+            )
+            session.add(
+                AgateProcessedItem(
+                    run_id=run_id,
+                    source_file="batch/2.json",
+                    status="skipped",
+                )
+            )
+            session.commit()
+
+        def finalize() -> None:
+            assert run_id is not None
+            with Session(engine) as session:
+                worker_tasks._finalize_s3_parent_run(session, run_id)
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            futures = [executor.submit(finalize) for _ in range(2)]
+            for future in futures:
+                future.result(timeout=20)
+
+        with Session(engine) as session:
+            run = session.get(AgateRun, run_id)
+            assert run is not None
+            assert run.status == "succeeded"
+            payload = json.loads(run.result_json or "{}")
+            assert payload["s3_batch"] == {"valid_executed": 2}
+            assert len(payload["items"]) == 2
+        assert len(parent_updates) == 1
+    finally:
+        event.remove(engine, "before_cursor_execute", capture_parent_updates)
+        with Session(engine) as session:
+            if run_id is not None:
+                session.execute(
+                    delete(AgateProcessedItem).where(AgateProcessedItem.run_id == run_id)
+                )
+                session.execute(delete(AgateRun).where(AgateRun.id == run_id))
+            if graph_id is not None:
+                session.execute(delete(AgateGraph).where(AgateGraph.id == graph_id))
+            if project_id is not None:
+                session.execute(
+                    delete(BackfieldProject).where(BackfieldProject.id == project_id)
+                )
+            if organization_id is not None:
+                session.execute(
+                    delete(BackfieldOrganization).where(
+                        BackfieldOrganization.id == organization_id
+                    )
+                )
+            session.commit()
+        engine.dispose()

--- a/tests/worker/test_single_item_worker.py
+++ b/tests/worker/test_single_item_worker.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from datetime import UTC, datetime
 
 import pytest
 from backfield_db import (
@@ -107,3 +108,101 @@ def test_execute_processed_item_text_input_shim(single_engine, monkeypatch):
         wrap = json.loads(run.result_json or "{}")
         assert "items" in wrap
         assert len(wrap["items"]) == 1
+
+
+def test_worker_cannot_store_output_after_cancellation(single_engine):
+    engine, item_id, run_id = single_engine
+    claimed_at = datetime.now(UTC)
+    with Session(engine) as session:
+        run = session.get(AgateRun, run_id)
+        item = session.get(AgateProcessedItem, item_id)
+        assert run is not None
+        assert item is not None
+        run.status = "failed"
+        run.error_message = worker_tasks._RUN_CANCELLED_MESSAGE
+        item.status = "failed"
+        item.started_at = claimed_at
+        item.error_message = worker_tasks._RUN_CANCELLED_MESSAGE + " (was running)"
+        session.add(run)
+        session.add(item)
+        session.commit()
+
+        stored = worker_tasks._update_processed_item_outcome_if_active(
+            session,
+            item_id=item_id,
+            run_id=run_id,
+            claimed_at=claimed_at,
+            status="succeeded",
+            result_json='{"result":"late"}',
+            substrate_article_id=None,
+            error_message=None,
+            now=datetime.now(UTC),
+        )
+        session.rollback()
+        session.refresh(item)
+
+        assert not stored
+        assert item.status == "failed"
+        assert item.error_message == worker_tasks._RUN_CANCELLED_MESSAGE + " (was running)"
+        assert item.result_json is None
+
+
+def test_stale_worker_cannot_complete_a_newer_claim(single_engine):
+    engine, item_id, run_id = single_engine
+    stale_claimed_at = datetime(2026, 7, 20, 12, 0, tzinfo=UTC)
+    newer_claimed_at = datetime(2026, 7, 20, 12, 5, tzinfo=UTC)
+    with Session(engine) as session:
+        run = session.get(AgateRun, run_id)
+        item = session.get(AgateProcessedItem, item_id)
+        assert run is not None
+        assert item is not None
+        run.status = "running"
+        item.status = "running"
+        item.started_at = newer_claimed_at
+        session.add(run)
+        session.add(item)
+        session.commit()
+
+        stored = worker_tasks._update_processed_item_outcome_if_active(
+            session,
+            item_id=item_id,
+            run_id=run_id,
+            claimed_at=stale_claimed_at,
+            status="succeeded",
+            result_json='{"result":"stale"}',
+            substrate_article_id=None,
+            error_message=None,
+            now=datetime.now(UTC),
+        )
+        session.rollback()
+        session.refresh(item)
+
+        assert not stored
+        assert item.status == "running"
+        assert item.started_at == newer_claimed_at.replace(tzinfo=None)
+        assert item.result_json is None
+
+    with pytest.raises(RuntimeError, match="claim is no longer active"):
+        worker_tasks._ensure_processed_item_active(
+            engine,
+            run_id=run_id,
+            item_id=item_id,
+            claimed_at=stale_claimed_at,
+        )
+
+
+def test_between_node_check_stops_cancelled_run(single_engine):
+    engine, _item_id, run_id = single_engine
+    with Session(engine) as session:
+        run = session.get(AgateRun, run_id)
+        assert run is not None
+        run.status = "failed"
+        run.error_message = worker_tasks._RUN_CANCELLED_MESSAGE
+        session.add(run)
+        session.commit()
+
+    before_node, _after_node, _timings = worker_tasks._node_wall_clock_hooks(
+        before_node_check=lambda: worker_tasks._ensure_parent_run_running(engine, run_id)
+    )
+    with pytest.raises(RuntimeError, match=worker_tasks._RUN_CANCELLED_MESSAGE):
+        before_node("node-2", "Output")

--- a/tests/worker/test_stale_running_items.py
+++ b/tests/worker/test_stale_running_items.py
@@ -6,6 +6,7 @@ from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 
 from backfield_db import AgateProcessedItem
+from sqlmodel import Session, SQLModel, create_engine
 from worker import tasks as worker_tasks
 
 
@@ -29,24 +30,6 @@ def test_is_not_stale_while_within_hard_limit() -> None:
         started_at=now - timedelta(seconds=60),
     )
     assert not worker_tasks._is_stale_running_item(item, now=now)
-
-
-def test_item_blocks_finalization_only_for_active_running() -> None:
-    now = datetime.now(UTC)
-    active = AgateProcessedItem(
-        id=1,
-        run_id="run-1",
-        status="running",
-        started_at=now - timedelta(seconds=30),
-    )
-    stale = AgateProcessedItem(
-        id=2,
-        run_id="run-1",
-        status="running",
-        started_at=now - timedelta(seconds=worker_tasks._STALE_RUNNING_AFTER_S + 5),
-    )
-    assert worker_tasks._item_blocks_run_finalization(active)
-    assert not worker_tasks._item_blocks_run_finalization(stale)
 
 
 def test_try_claim_pending_uses_conditional_update() -> None:
@@ -124,6 +107,8 @@ def test_try_claim_keeps_active_running_without_stale_lease() -> None:
 
 
 def test_reap_stale_running_items_for_run_only_affects_stale_rows() -> None:
+    engine = create_engine("sqlite://", echo=False)
+    SQLModel.metadata.create_all(engine)
     now = datetime(2026, 6, 17, 12, 0, 0, tzinfo=UTC)
     stale = AgateProcessedItem(
         id=1,
@@ -144,25 +129,20 @@ def test_reap_stale_running_items_for_run_only_affects_stale_rows() -> None:
         started_at=now - timedelta(seconds=worker_tasks._STALE_RUNNING_AFTER_S + 5),
     )
 
-    class _ExecResult:
-        def __init__(self, rows: list[AgateProcessedItem]) -> None:
-            self._rows = rows
+    with Session(engine) as session:
+        session.add(stale)
+        session.add(active)
+        session.add(other_run)
+        session.commit()
 
-        def all(self) -> list[AgateProcessedItem]:
-            return self._rows
+        reaped = worker_tasks._reap_stale_running_items_for_run(session, "run-1", now=now)
+        session.commit()
+        session.refresh(stale)
+        session.refresh(active)
+        session.refresh(other_run)
 
-    added: list[AgateProcessedItem] = []
-
-    class _Session:
-        def exec(self, _stmt: object) -> _ExecResult:
-            return _ExecResult([stale, active])
-
-        def add(self, row: AgateProcessedItem) -> None:
-            added.append(row)
-
-    reaped = worker_tasks._reap_stale_running_items_for_run(_Session(), "run-1", now=now)
-    assert reaped == 1
-    assert stale.status == "failed"
-    assert stale.error_message == worker_tasks._STALE_RUNNING_MESSAGE
-    assert active.status == "running"
-    assert other_run.status == "running"
+        assert reaped == 1
+        assert stale.status == "failed"
+        assert stale.error_message == worker_tasks._STALE_RUNNING_MESSAGE
+        assert active.status == "running"
+        assert other_run.status == "running"


### PR DESCRIPTION
## Summary
- Make S3 batch parent finalization scale with run size: indexed `(run_id, status)` lookup, narrow blocker probes, parent row lock, and idempotent summary writes (avoids O(N²) full-row hydration under large active runs).
- Make large-run cancellation bounded and race-safe: bulk item updates, compact `RunStatusOut` response, claim-timestamp-gated worker completion, between-node cancellation checks, and S3 setup rollback when cancel wins mid-listing.
- Redirect unauthenticated API Playground visits to Agate login (match Agate/Stylebook), and rename README “Public API” to “Backfield API”.

## Project scope check
- [x] This change targets local development / source inspection (production self-hosting is unsupported in this repo)
- [x] Docs under `docs/` updated if behavior, architecture, or operations changed
- [x] First-admin provisioning still uses `backfield init` / `backfield seed` only (no HTTP/env bootstrap paths)

## Test plan
- [x] `make lint`
- [x] `make test`
- [x] `make ui-typecheck` / `make agate-ui-build` (Playground + cancel response client)
- [x] `make smoke-fast`
- [ ] Deploy to canary/staging and confirm:
  - Cancelling a large S3 batch run returns quickly (no 504) and leaves parent `failed` with `Run cancelled by user`
  - Active workers stop storing success after cancel; finalization does not overwrite the cancel marker
  - In-flight batch finalization no longer saturates RDS with full-row `agate_processed_item` selects
  - Unauthenticated Playground visits redirect to Agate login
- [ ] Run migration `066_agate_pi_run_status` (concurrent index create/drop) before relying on the finalization fast path in production

## Notes for reviewers
- Migration uses `CREATE/DROP INDEX CONCURRENTLY`; apply with the usual non-transactional Alembic path.
- Cancel endpoint response shape changes from `RunOut` to `RunStatusOut` (Agate UI already refreshes after cancel).
- CI now runs PostgreSQL locking tests for competing finalizers and cancel-vs-completion races.


Made with [Cursor](https://cursor.com)