### PR TITLE
Fix post-deploy geocoder venue and country boundary gaps

### DIFF
--- a/docs/development/nodes.md
+++ b/docs/development/nodes.md
@@ -123,6 +123,25 @@ Consolidate QA also routes state/country contradictions to `needs_review` with
 different admin label (for example Oregon resolved as Maryland). Stylebook or
 canonical cache hits skip this check.
 
+For **place** rows, consolidate still requires house-number agreement between
+`components.address` and the provider display label when that number is present.
+When the label omits the house number (common for Pelias venue hits), a
+**Pelias-only** exception may keep the point if structured evidence is decisive:
+
+- exact house-number + jurisdiction evidence in Pelias properties, or
+- exact normalized POI-name identity (`components.place.name` vs `pelias_name`)
+  plus explicit city and state agreement from Pelias locality/region fields.
+
+POI-identity accepts set `address_verification: unverified` and
+`geocode_qa_code: poi_identity_match`. Wrong venue names and jurisdiction
+mismatches still go to `needs_review` with `geocode_component_mismatch`.
+This exception does **not** loosen Stylebook/cache linking sanity.
+
+Place geocoding passes extracted `components.address` into Pelias structured
+queries (venue name remains in free-text search). Router `no_web_search` skips
+*upfront* Brave/DuckDuckGo when a street line is already present; Place may still
+run web search as a **fallback** after inconclusive Pelias.
+
 ### Extract prompts
 
 Keep static instructions, field rules, and output-format guidance before the input

--- a/docs/development/nodes.md
+++ b/docs/development/nodes.md
@@ -113,9 +113,12 @@ or coordinates. Shared coordinates alone never collapse differently named places
 
 Address display formatting is identity-preserving: a numbered address must retain
 its house number and meaningful street tokens after any model-assisted polish.
-Recognized country rows use structured ISO identity and can be accepted without
-resolver geometry. Natural features use only jurisdiction explicitly present in
-their extracted location string.
+Recognized country rows use structured ISO identity as the accept gate and can be
+accepted without resolver geometry. When Pelias returns a matching ``country``-layer
+bbox, consolidate attaches that polygon (`geocode_disposition:
+accepted_with_pelias_boundary`); otherwise the row stays identity-only
+(`accepted_authoritative_identity`) and Places shows “No geography.” Natural
+features use only jurisdiction explicitly present in their extracted location string.
 
 Consolidate QA also routes state/country contradictions to `needs_review` with
 `geocode_qa_code: geocode_subnational_mismatch` when the extract names a US state

--- a/packages/backfield-agate/src/agate_nodes/geocode_agent/models/__init__.py
+++ b/packages/backfield-agate/src/agate_nodes/geocode_agent/models/__init__.py
@@ -8,6 +8,7 @@ from .area.street_road import StreetRoad
 from .area.span import Span
 from .area.region import Region
 from .area.natural import NaturalPlace
+from .area.country import Country
 from .point.point import Point
 from .point.address import Address
 from .point.place import Place
@@ -24,6 +25,7 @@ __all__ = [
     "Span",
     "Region",
     "NaturalPlace",
+    "Country",
     "Point",
     "Address",
     "Place",

--- a/packages/backfield-agate/src/agate_nodes/geocode_agent/models/area/country.py
+++ b/packages/backfield-agate/src/agate_nodes/geocode_agent/models/area/country.py
@@ -1,0 +1,134 @@
+"""Country-level Pelias boundary lookup (ISO identity remains the accept gate)."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+from agate_utils.geocoding.geocoding_types import GeocodingResult
+from agate_utils.geocoding.pelias import (
+    geocode_search_candidates as pelias_search_candidates,
+)
+from agate_utils.geocoding.pelias import (
+    geocode_structured_candidates as pelias_structured_candidates,
+)
+
+from .area import Area
+
+logger = logging.getLogger(__name__)
+
+
+class Country(Area):
+    """Model for country-level locations.
+
+    PlaceExtract / GeocodeAgent already require a valid ISO alpha-2 identity.
+    This model only asks Pelias for a country-layer bbox polygon that matches
+    that code. No Geocodio/Nominatim/LLM fallback — miss → identity-only row.
+    """
+
+    def _expected_country_code(self) -> str:
+        return str(self.country or "").strip().upper()
+
+    def _prep(self) -> dict[str, Any]:
+        code = self._expected_country_code()
+        return {
+            "pelias_structured": {
+                "country": code or self.name,
+                "size": 5,
+                "layers": "country",
+            },
+            "pelias_search": {
+                "text": self.name,
+                "size": 5,
+                "layers": "country",
+                **({"boundary.country": code.lower()} if len(code) == 2 else {}),
+            },
+        }
+
+    def _candidate_country_code(self, result: GeocodingResult) -> str:
+        if not result or not result.result:
+            return ""
+        conf = result.result.confidence or {}
+        return str(conf.get("pelias_country_code") or "").strip().upper()
+
+    def _score_area_candidate(self, result: GeocodingResult, *, expected_layer: str) -> int:
+        """Require country layer, matching ISO code, and a bbox polygon."""
+        if not result or not result.result:
+            return -10_000
+        layer = self._candidate_layer(result)
+        if expected_layer and layer and layer != expected_layer:
+            return -10_000
+        if layer and layer != "country":
+            return -10_000
+        expected = self._expected_country_code()
+        got = self._candidate_country_code(result)
+        if expected and got and got != expected:
+            return -10_000
+        if expected and not got:
+            return -10_000
+        if not self._candidate_has_bbox(result):
+            return -10_000
+        return super()._score_area_candidate(result, expected_layer=expected_layer or "country")
+
+    async def geocode(
+        self,
+        pelias_api_key: Optional[str] = None,
+        geocodio_api_key: Optional[str] = None,
+        openai_api_key: Optional[str] = None,
+    ) -> Optional[GeocodingResult]:
+        """Pelias country-layer bbox only; never invent geometry via other providers."""
+        del geocodio_api_key, openai_api_key  # unused — countries stay Pelias-only
+        logger.info("Geocoding country boundary: %s (%s)", self.name, self._expected_country_code())
+        if not pelias_api_key:
+            logger.info("No Pelias key for country '%s'; skipping boundary lookup", self.name)
+            return None
+
+        try:
+            prep_data = self._prep()
+        except Exception as exc:
+            logger.error("Country prep failed for %s: %s", self.name, exc)
+            return None
+
+        # Structured first (country code is the strongest signal).
+        try:
+            structured_params = dict(prep_data.get("pelias_structured") or {})
+            candidates = await pelias_structured_candidates(
+                api_key=pelias_api_key,
+                **structured_params,
+            )
+            chosen = self._choose_best_area_candidate(candidates, expected_layer="country")
+            if chosen is not None:
+                logger.info(
+                    "Pelias structured country bbox for %s (wof=%s)",
+                    self.name,
+                    self._is_wof_candidate(chosen),
+                )
+                self.geocoding_result = chosen
+                return chosen
+        except Exception as exc:
+            logger.warning("Pelias structured country lookup failed for %s: %s", self.name, exc)
+
+        # Free-text search constrained to country layer.
+        try:
+            search_params = dict(prep_data.get("pelias_search") or {})
+            text = str(search_params.pop("text") or "").strip()
+            if text:
+                candidates = await pelias_search_candidates(
+                    text=text,
+                    api_key=pelias_api_key,
+                    **search_params,
+                )
+                chosen = self._choose_best_area_candidate(candidates, expected_layer="country")
+                if chosen is not None:
+                    logger.info(
+                        "Pelias search country bbox for %s (wof=%s)",
+                        self.name,
+                        self._is_wof_candidate(chosen),
+                    )
+                    self.geocoding_result = chosen
+                    return chosen
+        except Exception as exc:
+            logger.warning("Pelias search country lookup failed for %s: %s", self.name, exc)
+
+        logger.info("No Pelias country bbox for %s; identity-only fallback", self.name)
+        return None

--- a/packages/backfield-agate/src/agate_nodes/geocode_agent/models/point/place.py
+++ b/packages/backfield-agate/src/agate_nodes/geocode_agent/models/point/place.py
@@ -1,13 +1,28 @@
 import json
 import logging
 from pathlib import Path
-from typing import Dict, Any, Optional
+from typing import Any, Dict, Optional
+
+from pydantic import Field
 
 from agate_utils.geocoding.geocoding_types import GeocodingResult
+from agate_utils.geocoding.nominatim import geocode_address
+from agate_utils.geocoding.geocodio import geocode_search as geocodio_search
+from agate_utils.geocoding.pelias import (
+    geocode_search as pelias_search,
+    geocode_search_candidates,
+    geocode_structured as pelias_structured,
+    geocode_structured_candidates,
+)
 from agate_utils.llm import call_llm
 from agate_utils.search import SearchResponse, brave_place_search, search_web_duckduckgo
 
 from ...llm_auth import has_llm_auth
+from ...poi_evidence import (
+    components_from_place_fields,
+    is_decisive_pelias_candidate,
+    select_uniquely_decisive_candidate,
+)
 from .address import Address
 
 logger = logging.getLogger(__name__)
@@ -17,21 +32,44 @@ logger = logging.getLogger(__name__)
 class Place(Address):
     """Model for place-level locations (POIs, landmarks, venues, etc.)."""
 
-    def __init__(self, **kwargs):
+    street_address: Optional[str] = Field(
+        default=None,
+        description="Extracted street line from PlaceExtract components.address",
+    )
+
+    def __init__(self, **kwargs: Any):
         super().__init__(**kwargs)
+        raw = self.street_address
+        if isinstance(raw, str):
+            cleaned = raw.strip()
+            object.__setattr__(self, "street_address", cleaned or None)
         self._input_addressability: Optional[bool] = None
         self._original_text: Optional[str] = None
         self._geocode_hints: Optional[str] = None
         self._failure_reason: Optional[str] = None
+        self._web_search_used: bool = False
+        self._web_search_fallback_used: bool = False
 
     def _geocode_hints_prompt_value(self) -> str:
         raw = (self._geocode_hints or "").strip()
         return raw if raw else "(none)"
 
+    def _extract_components(self) -> dict[str, Any]:
+        return components_from_place_fields(
+            name=self.name,
+            street_address=self.street_address,
+            city=self.city,
+            state_abbr=self.state_abbr,
+            country=self.country,
+        )
+
     ########## PRIVATE/HELPER METHODS ##########
 
     def _prep(self) -> Dict[str, Any]:
+        street = (self.street_address or "").strip()
         parts = [self.name]
+        if street:
+            parts.append(street)
         if self.city:
             parts.append(self.city)
         if self.state_abbr:
@@ -40,9 +78,13 @@ class Place(Address):
             parts.append(self.country)
         full_place = ", ".join(parts)
 
+        # Prefer the extracted street line for structured Pelias when present so
+        # house-number QA can pass; venue name remains in free-text search.
+        structured_address = street if street else self.name
+
         return {
             "pelias_structured": {
-                "address": self.name,
+                "address": structured_address,
                 "locality": self.city or None,
                 "region": self.state_abbr or None,
                 "country": self.country or "USA",
@@ -247,24 +289,181 @@ class Place(Address):
             return None
 
     def _update_prep_with_address(self, address_data: Dict[str, str]) -> Dict[str, Any]:
-        address_parts = [
-            address_data.get("street"),
-            address_data.get("city"),
-            address_data.get("state"),
-            address_data.get("zipcode"),
-        ]
+        street = str(address_data.get("street") or "").strip()
+        if street:
+            self.street_address = street
+        city = str(address_data.get("city") or "").strip()
+        if city:
+            self.city = city
+        state = str(address_data.get("state") or "").strip()
+        if state:
+            self.state_abbr = state
+        zipcode = str(address_data.get("zipcode") or "").strip()
+        country = str(address_data.get("country") or self.country or "USA").strip()
+
+        address_parts = [street or None, city or None, state or None, zipcode or None]
         full_address = ", ".join(part for part in address_parts if part)
+
+        # Keep venue name in free-text query when we discovered a street line.
+        search_parts = [self.name]
+        if street:
+            search_parts.append(street)
+        if city:
+            search_parts.append(city)
+        if state:
+            search_parts.append(state)
+        full_place = ", ".join(search_parts)
 
         return {
             "pelias_structured": {
-                "address": address_data.get("street"),
-                "locality": address_data.get("city"),
-                "region": address_data.get("state"),
-                "postalcode": address_data.get("zipcode"),
-                "country": address_data.get("country", "USA"),
+                "address": street or self.name,
+                "locality": city or self.city or None,
+                "region": state or self.state_abbr or None,
+                "postalcode": zipcode or None,
+                "country": country or "USA",
             },
-            "full_address": full_address,
+            "full_place": full_place,
+            "full_address": full_address or full_place,
         }
+
+    def _acceptable_result(self, result: GeocodingResult | None) -> bool:
+        if not result or not self._is_good_point_result(result):
+            return False
+        return is_decisive_pelias_candidate(self._extract_components(), result)
+
+    def _select_from_candidates(
+        self,
+        candidates: list[GeocodingResult],
+        query: str,
+        openai_api_key: str | None,
+    ) -> GeocodingResult | None:
+        """Accept only a uniquely decisive Pelias candidate (LLM cannot invent certainty)."""
+        components = self._extract_components()
+        unique = select_uniquely_decisive_candidate(components, candidates)
+        if unique is not None:
+            return unique
+
+        # Ambiguous decisive set → fail closed.
+        decisive = [c for c in candidates if is_decisive_pelias_candidate(components, c)]
+        if len(decisive) > 1:
+            logger.info(
+                "Place '%s' has %d decisive Pelias candidates with different identities; "
+                "sending to needs_review",
+                self.name,
+                len(decisive),
+            )
+            return None
+
+        # Optional LLM ranking only when zero decisive candidates so far; still must be decisive.
+        if openai_api_key and len(candidates) > 1:
+            picked = self._pick_pelias_candidate_with_llm(candidates, query, openai_api_key)
+            if picked is not None and is_decisive_pelias_candidate(components, picked):
+                return picked
+        return None
+
+    async def _geocode_pelias_decisive(
+        self,
+        *,
+        pelias_api_key: str | None,
+        openai_api_key: str | None,
+    ) -> GeocodingResult | None:
+        if not pelias_api_key:
+            return None
+
+        try:
+            prep_data = self._prep()
+        except Exception as exc:
+            logger.error("Place prep failed for %s: %s", self.name, exc)
+            return None
+
+        full_address = str(prep_data.get("full_address") or prep_data.get("full_place") or "")
+        pelias_bias = self._pelias_search_bias_kwargs()
+        components = self._extract_components()
+
+        # Structured candidates first when we have a street line or venue name.
+        try:
+            structured_params = {
+                k: v for k, v in (prep_data.get("pelias_structured") or {}).items() if v
+            }
+            structured = await geocode_structured_candidates(
+                **structured_params,
+                api_key=pelias_api_key,
+                size=5,
+            )
+            selected = self._select_from_candidates(structured, full_address, openai_api_key)
+            if selected is not None:
+                logger.info("Pelias structured decisive success for place %s", self.name)
+                self.geocoding_result = selected
+                return selected
+            # Single-feature structured fallback when multi-candidate returned nothing decisive
+            # but the top hit is decisive under evidence rules.
+            if not structured:
+                single = await pelias_structured(**structured_params, api_key=pelias_api_key)
+                if single is not None and is_decisive_pelias_candidate(components, single):
+                    self.geocoding_result = single
+                    return single
+        except Exception as exc:
+            logger.warning("Pelias structured candidates failed for place %s: %s", self.name, exc)
+
+        # Free-text search (venue + optional street).
+        try:
+            if openai_api_key:
+                candidates = await geocode_search_candidates(
+                    text=full_address,
+                    api_key=pelias_api_key,
+                    size=5,
+                    **pelias_bias,
+                )
+                selected = self._select_from_candidates(candidates, full_address, openai_api_key)
+                if selected is not None:
+                    logger.info("Pelias search decisive success for place %s", self.name)
+                    self.geocoding_result = selected
+                    return selected
+            else:
+                result = await pelias_search(
+                    text=full_address,
+                    api_key=pelias_api_key,
+                    **pelias_bias,
+                )
+                if result is not None and is_decisive_pelias_candidate(components, result):
+                    self.geocoding_result = result
+                    return result
+        except Exception as exc:
+            logger.warning("Pelias search failed for place %s: %s", self.name, exc)
+
+        return None
+
+    def _apply_discovered_address(self, address_data: Dict[str, str]) -> None:
+        self._prep = lambda: self._update_prep_with_address(address_data)
+
+    async def _try_web_search_address_discovery(
+        self,
+        *,
+        brave_search_api_key: str | None,
+        openai_api_key: str,
+        is_fallback: bool,
+    ) -> bool:
+        """Run Brave/DDG address discovery; return True when prep was updated."""
+        search_response = self._search_for_address(
+            brave_search_api_key,
+            self._original_text or "",
+            openai_api_key,
+            allow_web_search=True,
+        )
+        self._web_search_used = True
+        if is_fallback:
+            self._web_search_fallback_used = True
+        if not search_response:
+            return False
+        address_data = self._extract_and_parse_address(
+            search_response.query,
+            search_response,
+            openai_api_key,
+        )
+        if not address_data:
+            return False
+        self._apply_discovered_address(address_data)
+        return True
 
     ########## PUBLIC METHODS ##########
 
@@ -283,10 +482,12 @@ class Place(Address):
             logger.warning("No LLM auth provided; falling back to Address geocoding")
             return await super().geocode(pelias_api_key, geocodio_api_key, openai_api_key)
 
+        openai_key = openai_api_key or ""
+
         if self._input_addressability is not None:
             addressability = "addressable" if self._input_addressability else "not addressable"
         else:
-            addressability = self._check_if_addressable(openai_api_key)
+            addressability = self._check_if_addressable(openai_key)
 
         if addressability == "not addressable":
             logger.info("Place '%s' marked not addressable; skipping", self.name)
@@ -294,25 +495,97 @@ class Place(Address):
 
         if addressability == "has address":
             mock_results = SearchResponse(success=True, results=[], query=self.name)
-            address_data = self._extract_and_parse_address(self.name, mock_results, openai_api_key)
-            if address_data:
-                self._prep = lambda: self._update_prep_with_address(address_data)
-
-        elif addressability == "addressable":
-            search_response = self._search_for_address(
-                brave_search_api_key,
-                self._original_text or "",
-                openai_api_key,
-                allow_web_search=allow_web_search,
+            address_data = self._extract_and_parse_address(
+                self.name,
+                mock_results,
+                openai_key,
             )
-            if search_response:
-                address_data = self._extract_and_parse_address(
-                    search_response.query,
-                    search_response,
-                    openai_api_key,
-                )
-                if address_data:
-                    self._prep = lambda: self._update_prep_with_address(address_data)
+            if address_data:
+                self._apply_discovered_address(address_data)
 
-        return await super().geocode(pelias_api_key, geocodio_api_key, openai_api_key)
+        elif addressability == "addressable" and allow_web_search:
+            await self._try_web_search_address_discovery(
+                brave_search_api_key=brave_search_api_key,
+                openai_api_key=openai_key,
+                is_fallback=False,
+            )
+
+        result = await self._geocode_pelias_decisive(
+            pelias_api_key=pelias_api_key,
+            openai_api_key=openai_api_key,
+        )
+        if result is not None:
+            return result
+
+        # Web search as fallback when direct Pelias was inconclusive (even if router
+        # chose no_web_search upfront — address may already have been present).
+        if not self._web_search_used and addressability == "addressable":
+            logger.info(
+                "Place '%s' Pelias inconclusive; trying web search fallback",
+                self.name,
+            )
+            discovered = await self._try_web_search_address_discovery(
+                brave_search_api_key=brave_search_api_key,
+                openai_api_key=openai_key,
+                is_fallback=True,
+            )
+            if discovered:
+                result = await self._geocode_pelias_decisive(
+                    pelias_api_key=pelias_api_key,
+                    openai_api_key=openai_api_key,
+                )
+                if result is not None:
+                    return result
+
+        # Geocodio / Nominatim last resorts: keep only when the label carries the
+        # extracted house number (non-Pelias providers lack structured POI fields).
+        try:
+            prep_data = self._prep()
+        except Exception as exc:
+            logger.error("Place prep failed for %s: %s", self.name, exc)
+            return None
+        full_address = str(prep_data.get("full_address") or prep_data.get("full_place") or "")
+
+        from .address import _ADDRESS_NUMBER_RE
+
+        def _label_has_requested_number(label: str) -> bool:
+            requested = (self.street_address or "").strip()
+            number_match = _ADDRESS_NUMBER_RE.search(requested) if requested else None
+            if number_match is None:
+                return False
+            return number_match.group(1).lower() in {
+                m.lower() for m in _ADDRESS_NUMBER_RE.findall(label)
+            }
+
+        if geocodio_api_key:
+            try:
+                result = geocodio_search(query=full_address, api_key=geocodio_api_key)
+                if (
+                    result
+                    and self._is_good_point_result(result)
+                    and result.result is not None
+                    and _label_has_requested_number(str(result.result.processed_str or ""))
+                ):
+                    logger.info("Geocodio success for place %s", self.name)
+                    self.geocoding_result = result
+                    return result
+            except Exception as exc:
+                logger.warning("Geocodio failed for place %s: %s", self.name, exc)
+
+        try:
+            result = geocode_address(address=full_address, user_agent="agate/1.0")
+            if (
+                result
+                and self._is_good_point_result(result)
+                and result.result is not None
+                and _label_has_requested_number(str(result.result.processed_str or ""))
+            ):
+                logger.info("Nominatim success for place %s", self.name)
+                self.geocoding_result = result
+                return result
+        except Exception as exc:
+            logger.warning("Nominatim failed for place %s: %s", self.name, exc)
+
+        logger.warning("All geocoding services failed for place %s", self.name)
+        return None
 

--- a/packages/backfield-agate/src/agate_nodes/geocode_agent/nodes/consolidate.py
+++ b/packages/backfield-agate/src/agate_nodes/geocode_agent/nodes/consolidate.py
@@ -511,7 +511,7 @@ async def consolidate_node(state: AgentState) -> AgentState:
     if location_type == "country" and isinstance(country_identity, dict):
         country_name = str(country_identity.get("name") or "").strip()
         country_code = str(country_identity.get("abbr") or "").strip().upper()
-        country_entry = {
+        country_entry: dict[str, Any] = {
             "id": f"iso-country:{country_code}",
             "original_text": original_text,
             "location": country_name,
@@ -523,6 +523,31 @@ async def consolidate_node(state: AgentState) -> AgentState:
         canonical_id = country_identity.get("canonical_id")
         if canonical_id:
             country_entry["canonical_id"] = str(canonical_id)
+
+        # Optional Pelias (or cache) country-layer bbox — identity remains authoritative.
+        if geocoding_result is not None and getattr(geocoding_result, "result", None) is not None:
+            geom = geocoding_result.result.geometry
+            geom_type = getattr(geom, "type", None)
+            geom_coords = getattr(geom, "coordinates", None)
+            if geom_type and geom_coords is not None:
+                result_payload: dict[str, Any] = {
+                    "id": geocoding_result.result.id,
+                    "formatted_address": geocoding_result.result.processed_str,
+                    "geometry": {
+                        "type": geom_type,
+                        "coordinates": geom_coords,
+                    },
+                }
+                conf = getattr(geocoding_result.result, "confidence", None) or {}
+                if isinstance(conf, dict) and conf.get("canonical_id") and "canonical_id" not in country_entry:
+                    country_entry["canonical_id"] = str(conf["canonical_id"]).strip()
+                country_entry["geocode"] = {
+                    "geocode_type": geocoding_result.geocoder,
+                    "result": result_payload,
+                }
+                if geom_type == "Polygon":
+                    country_entry["geocode_disposition"] = "accepted_with_pelias_boundary"
+
         for key, value in extra_fields.items():
             if key != "description":
                 country_entry[key] = value

--- a/packages/backfield-agate/src/agate_nodes/geocode_agent/nodes/consolidate.py
+++ b/packages/backfield-agate/src/agate_nodes/geocode_agent/nodes/consolidate.py
@@ -10,6 +10,11 @@ from backfield_entities.ingest.geocode_cache.sanity import (
     explicit_location_components_match_labels,
 )
 
+from ..poi_evidence import (
+    is_pelias_geocoder,
+    pelias_poi_result_acceptable,
+    poi_acceptance_is_address_unverified,
+)
 from ..types import AgentState
 from .emit_location_line import (
     compute_emit_location_line,
@@ -693,17 +698,31 @@ async def consolidate_node(state: AgentState) -> AgentState:
         match_label=formatted_line,
         match_formatted_address=formatted_line,
     ):
-        qa_entry = _point_entry_without_geometry(
-            {
-                **location_entry,
-                "geocode_component_mismatch": True,
-                "geocode_qa_code": "geocode_component_mismatch",
-            }
+        # Precision-first POI exception: Pelias venue labels often omit house numbers.
+        # Accept when POI identity + city/state agree (or exact address evidence exists
+        # in structured Pelias fields). Does not loosen the shared cache sanity gate.
+        poi_exception = (
+            location_type == "place"
+            and is_pelias_geocoder(geocoding_result.geocoder)
+            and pelias_poi_result_acceptable(comps_dict, geocoding_result)
         )
-        _attach_router_audit(qa_entry, state)
-        consolidated["places"]["needs_review"].append(qa_entry)
-        state["final_output"] = consolidated
-        return state
+        if poi_exception:
+            if poi_acceptance_is_address_unverified(comps_dict, geocoding_result):
+                location_entry["address_verification"] = "unverified"
+                location_entry["geocode_qa_code"] = "poi_identity_match"
+            # else: exact address evidence in Pelias structured fields — keep as normal point
+        else:
+            qa_entry = _point_entry_without_geometry(
+                {
+                    **location_entry,
+                    "geocode_component_mismatch": True,
+                    "geocode_qa_code": "geocode_component_mismatch",
+                }
+            )
+            _attach_router_audit(qa_entry, state)
+            consolidated["places"]["needs_review"].append(qa_entry)
+            state["final_output"] = consolidated
+            return state
     subnational_mismatch = _geocode_subnational_label_mismatch_qa(
         location_type,
         comps_dict,
@@ -806,6 +825,11 @@ async def consolidate_node(state: AgentState) -> AgentState:
         for key, value in extra_fields.items():
             if key not in ["description"]:  # Description is already handled above
                 point_entry[key] = value
+
+        # Preserve POI-exception provenance set earlier on location_entry.
+        for provenance_key in ("address_verification", "geocode_qa_code"):
+            if provenance_key in location_entry:
+                point_entry[provenance_key] = location_entry[provenance_key]
 
         _attach_router_audit(point_entry, state)
 

--- a/packages/backfield-agate/src/agate_nodes/geocode_agent/nodes/geocode.py
+++ b/packages/backfield-agate/src/agate_nodes/geocode_agent/nodes/geocode.py
@@ -162,7 +162,14 @@ def _create_model(location_type: str, location_text: str, components: dict, stat
         city_name = components.get("city", "")
         state_info = components.get("state", {})
         state_abbr = state_info.get("abbr") if isinstance(state_info, dict) else None
-        model = Place(name=place_name, city=city_name, state_abbr=state_abbr, country=country_code)
+        street_address = str(components.get("address") or "").strip() or None
+        model = Place(
+            name=place_name,
+            city=city_name,
+            state_abbr=state_abbr,
+            country=country_code,
+            street_address=street_address,
+        )
         model._input_addressability = is_addressable
         model._original_text = state.get("original_text", "")
         hints = state.get("geocode_hints") or normalized_geocode_hints(state.get("extra_fields"))
@@ -638,12 +645,13 @@ async def orchestrate_external_geocode(state: AgentState) -> AgentState:
             geocode_kwargs = {"openai_api_key": openai_api_key}
         else:
             if isinstance(model, Place):
-                # Advanced graph sets ``allow_web_search`` from route_strategy; baseline graph omits it (default True).
+                # Advanced graph sets ``allow_web_search`` from route_strategy; baseline graph
+                # omits it (default True). ``allow_web_search=False`` skips *upfront* search;
+                # Place.geocode may still fall back to web search after inconclusive Pelias.
+                # Always pass the Brave key so that fallback path can run.
                 raw_allow = state.get("allow_web_search")
                 allow_web = True if raw_allow is None else bool(raw_allow)
-                geocode_kwargs["brave_search_api_key"] = (
-                    brave_search_api_key if allow_web else None
-                )
+                geocode_kwargs["brave_search_api_key"] = brave_search_api_key
                 geocode_kwargs["allow_web_search"] = allow_web
             if isinstance(model, StreetRoad):
                 geocode_kwargs["original_text"] = state.get("original_text", "")
@@ -652,6 +660,16 @@ async def orchestrate_external_geocode(state: AgentState) -> AgentState:
 
         state["geocoding_result"] = result
         state["geocoding_model"] = model
+
+        if isinstance(model, Place) and getattr(model, "_web_search_fallback_used", False):
+            audit = state.get("router_audit")
+            if isinstance(audit, dict):
+                state["router_audit"] = {
+                    **audit,
+                    "web_search_fallback_used": True,
+                }
+            else:
+                state["router_audit"] = {"web_search_fallback_used": True}
 
         if isinstance(model, Place) and hasattr(model, "_failure_reason") and model._failure_reason:
             state["geocoding_failure_reason"] = model._failure_reason

--- a/packages/backfield-agate/src/agate_nodes/geocode_agent/nodes/geocode.py
+++ b/packages/backfield-agate/src/agate_nodes/geocode_agent/nodes/geocode.py
@@ -16,6 +16,7 @@ from ..models import (
     Address,
     Area,
     City,
+    Country,
     County,
     Intersection,
     NaturalPlace,
@@ -112,6 +113,13 @@ def _create_model(location_type: str, location_text: str, components: dict, stat
         state_info = components.get("state", {})
         state_name = state_info.get("name") if isinstance(state_info, dict) else location_text
         return State(name=state_name, country=country_code)
+
+    if location_type == "country":
+        identity = _country_component_identity(components)
+        if identity is None:
+            return None
+        country_name, code = identity
+        return Country(name=country_name, country=code)
 
     if location_type == "county":
         county_name = components.get("county", location_text)
@@ -530,21 +538,45 @@ async def resolve_cache_or_miss(state: AgentState) -> AgentState:
 
         country_name, country_code = country_identity
         canonical_id = None
+        cache_polygon: object | None = None
         if geocoding_result is not None:
             confidence = getattr(geocoding_result.result, "confidence", None)
             if isinstance(confidence, dict):
                 raw_canonical_id = confidence.get("canonical_id")
                 if raw_canonical_id is not None:
                     canonical_id = str(raw_canonical_id).strip() or None
-        state["geocoding_result"] = None
-        state["geocoding_model"] = None
+            geom = getattr(getattr(geocoding_result, "result", None), "geometry", None)
+            if getattr(geom, "type", None) == "Polygon":
+                cache_polygon = geocoding_result
+
         state["geocoding_failure_reason"] = None
         state["country_terminal_identity"] = {
             "name": country_name,
             "abbr": country_code,
             "canonical_id": canonical_id,
         }
-        state["skip_external_geocode"] = True
+        if cache_polygon is not None:
+            # Stylebook/cache already supplied a country polygon — keep it.
+            state["geocoding_result"] = cache_polygon
+            state["geocoding_model"] = None
+            state["skip_external_geocode"] = True
+            _adv_info(
+                state,
+                "[CACHE SUCCESS] Country polygon from cache/canonical: %s",
+                getattr(getattr(cache_polygon, "result", None), "processed_str", country_name),
+            )
+            return state
+
+        # ISO identity accepted; allow Pelias country-layer bbox lookup next.
+        state["geocoding_result"] = None
+        state["geocoding_model"] = None
+        state["skip_external_geocode"] = False
+        _adv_info(
+            state,
+            "[COUNTRY IDENTITY] %s (%s) — attempting Pelias country bbox",
+            country_name,
+            country_code,
+        )
         return state
 
     if geocoding_result:
@@ -676,10 +708,14 @@ async def orchestrate_external_geocode(state: AgentState) -> AgentState:
         elif isinstance(model, Intersection) and not result:
             state["geocoding_failure_reason"] = "Intersection geocoding failed"
         elif not result:
-            state["geocoding_failure_reason"] = (
-                state.get("geocoding_failure_reason")
-                or f"Geocoding produced no result for {location_type}"
-            )
+            # Country identity is already accepted; a missing Pelias bbox is not a hard failure.
+            if location_type == "country" and state.get("country_terminal_identity"):
+                state["geocoding_failure_reason"] = None
+            else:
+                state["geocoding_failure_reason"] = (
+                    state.get("geocoding_failure_reason")
+                    or f"Geocoding produced no result for {location_type}"
+                )
         else:
             state["geocoding_failure_reason"] = None
 
@@ -688,6 +724,12 @@ async def orchestrate_external_geocode(state: AgentState) -> AgentState:
                 _adv_info(state, "Geocoding success: %s", result.result.processed_str)
             except Exception as e:
                 logger.error("Error logging geocoding success: %s", e)
+        elif location_type == "country" and state.get("country_terminal_identity"):
+            _adv_info(
+                state,
+                "No Pelias country bbox for %s; keeping ISO identity-only row",
+                location_text,
+            )
         else:
             logger.warning("Geocoding failed for %s", location_text)
 

--- a/packages/backfield-agate/src/agate_nodes/geocode_agent/nodes/route_strategy.py
+++ b/packages/backfield-agate/src/agate_nodes/geocode_agent/nodes/route_strategy.py
@@ -36,6 +36,7 @@ _STRUCTURAL_LOCATION_TYPES: frozenset[str] = frozenset(
         "span",
         "intersection_road",
         "intersection_highway",
+        "country",
     }
 )
 
@@ -72,9 +73,13 @@ def _router_audit_log(payload: dict) -> None:
 
 async def route_strategy_node(state: AgentState) -> AgentState:
     """After ``resolve_cache_or_miss``: LLM-picks strategy, or skip on cache hit."""
-    country_dispatch_complete = (
+    # Unresolved countries, or countries that already have geometry / skipped external.
+    country_dispatch_complete = state.get("geocoding_failure_reason") == "country_identity_unresolved" or (
         state.get("country_terminal_identity") is not None
-        or state.get("geocoding_failure_reason") == "country_identity_unresolved"
+        and (
+            state.get("geocoding_result") is not None
+            or bool(state.get("skip_external_geocode"))
+        )
     )
     if state.get("geocoding_result") is not None or country_dispatch_complete:
         state["router_audit"] = None

--- a/packages/backfield-agate/src/agate_nodes/geocode_agent/poi_evidence.py
+++ b/packages/backfield-agate/src/agate_nodes/geocode_agent/poi_evidence.py
@@ -1,0 +1,336 @@
+"""Precision-first POI evidence checks for external Pelias place geocoding.
+
+Deliberately separate from ``backfield_entities.ingest.geocode_cache.sanity`` so
+Stylebook/cache linking keeps its stricter house-number-in-label gate.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from agate_utils.geocoding.geocoding_types import GeocodingResult
+from backfield_entities.canonical.jurisdiction import jurisdiction_from_components
+from backfield_entities.ingest.geocode_cache.sanity import named_location_heads_compatible
+
+_HOUSE_NUMBER_TOKEN_RE = re.compile(r"(?<![A-Za-z0-9])(\d+[A-Za-z]?)(?![A-Za-z0-9])")
+_NON_ALNUM_RE = re.compile(r"[^a-z0-9]+")
+
+_PELIAS_GEOCODER_PREFIXES: frozenset[str] = frozenset(
+    {
+        "pelias",
+        "pelias_search",
+        "pelias_structured",
+    }
+)
+
+
+def is_pelias_geocoder(geocoder: str | None) -> bool:
+    """True when the result came from a Pelias / Geocode.Earth path."""
+    name = (geocoder or "").strip().lower()
+    if not name:
+        return False
+    if name in _PELIAS_GEOCODER_PREFIXES:
+        return True
+    return name.startswith("pelias")
+
+
+def _compare_key(text: str) -> str:
+    return _NON_ALNUM_RE.sub(" ", (text or "").strip().lower()).strip()
+
+
+def _confidence(result: GeocodingResult | None) -> dict[str, Any]:
+    if result is None or result.result is None:
+        return {}
+    raw = getattr(result.result, "confidence", None)
+    return raw if isinstance(raw, dict) else {}
+
+
+def place_name_from_components(components: dict[str, Any] | None) -> str:
+    """Extracted venue / POI name from PlaceExtract components."""
+    comps = components if isinstance(components, dict) else {}
+    place = comps.get("place")
+    if isinstance(place, dict):
+        name = str(place.get("name") or "").strip()
+        if name:
+            return name
+    if isinstance(place, str) and place.strip():
+        return place.strip()
+    return ""
+
+
+def street_address_from_components(components: dict[str, Any] | None) -> str:
+    comps = components if isinstance(components, dict) else {}
+    return str(comps.get("address") or "").strip()
+
+
+def components_from_place_fields(
+    *,
+    name: str,
+    street_address: str | None,
+    city: str | None,
+    state_abbr: str | None,
+    country: str | None,
+) -> dict[str, Any]:
+    """Build a components-shaped dict from a Place model for evidence checks."""
+    comps: dict[str, Any] = {
+        "place": {"name": str(name or "").strip()},
+    }
+    if street_address and str(street_address).strip():
+        comps["address"] = str(street_address).strip()
+    if city and str(city).strip():
+        comps["city"] = str(city).strip()
+    if state_abbr and str(state_abbr).strip():
+        comps["state"] = {"abbr": str(state_abbr).strip().upper()}
+    if country and str(country).strip():
+        cc = str(country).strip().upper()
+        comps["country"] = {"abbr": cc[:2] if len(cc) >= 2 else cc}
+    return comps
+
+
+def _requested_house_number(components: dict[str, Any] | None) -> str | None:
+    addr = street_address_from_components(components)
+    if not addr:
+        return None
+    match = _HOUSE_NUMBER_TOKEN_RE.search(addr)
+    if match is None:
+        return None
+    return match.group(1).lower()
+
+
+def _candidate_house_numbers(result: GeocodingResult) -> set[str]:
+    conf = _confidence(result)
+    numbers: set[str] = set()
+    structured = str(conf.get("pelias_housenumber") or "").strip()
+    if structured:
+        for token in _HOUSE_NUMBER_TOKEN_RE.findall(structured):
+            numbers.add(token.lower())
+    label = ""
+    if result.result is not None:
+        label = str(result.result.processed_str or "")
+    for token in _HOUSE_NUMBER_TOKEN_RE.findall(label):
+        numbers.add(token.lower())
+    return numbers
+
+
+def house_number_conflicts(
+    components: dict[str, Any] | None,
+    result: GeocodingResult,
+) -> bool:
+    """True when extract and provider both declare house numbers and they differ."""
+    requested = _requested_house_number(components)
+    if requested is None:
+        return False
+    candidate_numbers = _candidate_house_numbers(result)
+    if not candidate_numbers:
+        return False
+    return requested not in candidate_numbers
+
+
+def house_number_matches(
+    components: dict[str, Any] | None,
+    result: GeocodingResult,
+) -> bool:
+    """True when the extract's house number appears in Pelias structured or label evidence."""
+    requested = _requested_house_number(components)
+    if requested is None:
+        return False
+    return requested in _candidate_house_numbers(result)
+
+
+def _city_tokens(value: str) -> set[str]:
+    return {t for t in _compare_key(value).split() if len(t) >= 2}
+
+
+def city_agrees(components: dict[str, Any] | None, result: GeocodingResult) -> bool:
+    """Require explicit city agreement when the extract declares a city."""
+    comps = components if isinstance(components, dict) else {}
+    expected_city = str(comps.get("city") or "").strip()
+    if not expected_city:
+        return True
+    conf = _confidence(result)
+    candidates = [
+        str(conf.get("pelias_locality") or "").strip(),
+        str(conf.get("pelias_localadmin") or "").strip(),
+        str(conf.get("pelias_borough") or "").strip(),
+    ]
+    expected_tokens = _city_tokens(expected_city)
+    if not expected_tokens:
+        return True
+    for cand in candidates:
+        if not cand:
+            continue
+        if named_location_heads_compatible(expected_city, cand):
+            return True
+        cand_tokens = _city_tokens(cand)
+        if expected_tokens and expected_tokens <= cand_tokens:
+            return True
+        if expected_tokens and cand_tokens and expected_tokens == cand_tokens:
+            return True
+    return False
+
+
+def state_agrees(components: dict[str, Any] | None, result: GeocodingResult) -> bool:
+    """Require explicit state/region agreement when the extract declares a subdivision."""
+    comps = components if isinstance(components, dict) else {}
+    _country, expected_subdivision, _city = jurisdiction_from_components(comps)
+    if not expected_subdivision:
+        return True
+    conf = _confidence(result)
+    region_a = str(conf.get("pelias_region_a") or "").strip().upper()[:2]
+    if region_a and region_a == expected_subdivision:
+        return True
+    region = str(conf.get("pelias_region") or "").strip()
+    if region and named_location_heads_compatible(expected_subdivision, region):
+        return True
+    # Fall back to label parse only when structured region is absent.
+    if not region_a and not region:
+        return False
+    return False
+
+
+def country_agrees(components: dict[str, Any] | None, result: GeocodingResult) -> bool:
+    comps = components if isinstance(components, dict) else {}
+    expected_country, _sub, _city = jurisdiction_from_components(comps)
+    if not expected_country:
+        return True
+    conf = _confidence(result)
+    code = str(conf.get("pelias_country_code") or "").strip().upper()[:2]
+    if code and code == expected_country:
+        return True
+    if code and code != expected_country:
+        return False
+    return True
+
+
+def jurisdiction_agrees(components: dict[str, Any] | None, result: GeocodingResult) -> bool:
+    return (
+        country_agrees(components, result)
+        and state_agrees(components, result)
+        and city_agrees(components, result)
+    )
+
+
+def poi_names_match(components: dict[str, Any] | None, result: GeocodingResult) -> bool:
+    """Exact normalized POI identity (case, punctuation, leading 'the' only)."""
+    place_name = place_name_from_components(components)
+    if not place_name:
+        return False
+    conf = _confidence(result)
+    pelias_name = str(conf.get("pelias_name") or "").strip()
+    if not pelias_name:
+        return False
+    return named_location_heads_compatible(place_name, pelias_name)
+
+
+def has_exact_address_evidence(
+    components: dict[str, Any] | None,
+    result: GeocodingResult,
+) -> bool:
+    """Street-number evidence plus compatible jurisdiction."""
+    if not house_number_matches(components, result):
+        return False
+    if house_number_conflicts(components, result):
+        return False
+    return jurisdiction_agrees(components, result)
+
+
+def has_poi_identity_evidence(
+    components: dict[str, Any] | None,
+    result: GeocodingResult,
+) -> bool:
+    """Venue-name identity plus city/state agreement; no house-number conflict."""
+    if house_number_conflicts(components, result):
+        return False
+    if not poi_names_match(components, result):
+        return False
+    # POI exception requires explicit city and state agreement (fail closed).
+    comps = components if isinstance(components, dict) else {}
+    if not str(comps.get("city") or "").strip():
+        return False
+    _country, subdivision, _city = jurisdiction_from_components(comps)
+    if not subdivision:
+        return False
+    if not city_agrees(components, result):
+        return False
+    if not state_agrees(components, result):
+        return False
+    if not country_agrees(components, result):
+        return False
+    return True
+
+
+def is_decisive_pelias_candidate(
+    components: dict[str, Any] | None,
+    result: GeocodingResult | None,
+) -> bool:
+    """True when a Pelias candidate may be auto-accepted under precision-first rules."""
+    if result is None or result.result is None:
+        return False
+    if not is_pelias_geocoder(result.geocoder):
+        return False
+    if getattr(result.result.geometry, "type", None) != "Point":
+        return False
+    if house_number_conflicts(components, result):
+        return False
+    if not country_agrees(components, result):
+        return False
+    if has_exact_address_evidence(components, result):
+        return True
+    return has_poi_identity_evidence(components, result)
+
+
+def _candidate_identity_key(result: GeocodingResult) -> str:
+    conf = _confidence(result)
+    gid = str(conf.get("pelias_gid") or "").strip()
+    if gid:
+        return f"gid:{gid}"
+    source = str(conf.get("pelias_source") or "").strip()
+    source_id = str(conf.get("pelias_source_id") or "").strip()
+    if source and source_id:
+        return f"src:{source}:{source_id}"
+    if result.result is not None and result.result.id:
+        return f"id:{result.result.id}"
+    coords = ""
+    if result.result is not None and getattr(result.result.geometry, "type", None) == "Point":
+        coords = ",".join(str(c) for c in result.result.geometry.coordinates)
+    name = str(conf.get("pelias_name") or "").strip().lower()
+    return f"fallback:{name}:{coords}"
+
+
+def select_uniquely_decisive_candidate(
+    components: dict[str, Any] | None,
+    candidates: list[GeocodingResult],
+) -> GeocodingResult | None:
+    """Return the sole decisive candidate, or None when ambiguous / empty."""
+    decisive = [c for c in candidates if is_decisive_pelias_candidate(components, c)]
+    if not decisive:
+        return None
+    identities = {_candidate_identity_key(c) for c in decisive}
+    if len(identities) != 1:
+        return None
+    return decisive[0]
+
+
+def pelias_poi_result_acceptable(
+    components: dict[str, Any] | None,
+    geocoding_result: GeocodingResult | None,
+) -> bool:
+    """Consolidate-gate exception: keep geometry when POI identity evidence is decisive.
+
+    Used only when ``explicit_location_components_match_labels`` fails for a
+    ``place`` row (typically missing house number in the display label).
+    """
+    return is_decisive_pelias_candidate(components, geocoding_result)
+
+
+def poi_acceptance_is_address_unverified(
+    components: dict[str, Any] | None,
+    geocoding_result: GeocodingResult | None,
+) -> bool:
+    """True when acceptance rests on POI identity rather than street-number evidence."""
+    if geocoding_result is None:
+        return False
+    if has_exact_address_evidence(components, geocoding_result):
+        return False
+    return has_poi_identity_evidence(components, geocoding_result)

--- a/packages/backfield-agate/src/agate_nodes/geocode_agent/prompts/route_strategy.md
+++ b/packages/backfield-agate/src/agate_nodes/geocode_agent/prompts/route_strategy.md
@@ -7,8 +7,8 @@ Respond with **only** a JSON object (no markdown fences) with keys:
 
 Meanings:
 
-- **web_search**: For **place** resolution that may need a street address, allow **Brave Search** (when configured) and **DuckDuckGo** as fallback to find snippets, then parse an address and geocode it. Use this whenever a place might need the web to supply a missing street line.
-- **no_web_search**: **Neither Brave nor DuckDuckGo** runs. Use only structured geocoders (Pelias, etc.) and existing components.
+- **web_search**: For **place** resolution that may need a street address, run **Brave Search** (when configured) and **DuckDuckGo** *upfront* to find snippets, then parse an address and geocode it. Use this whenever a place is missing a street line and likely needs the web to supply one.
+- **no_web_search**: Skip *upfront* Brave/DuckDuckGo. Use structured geocoders (Pelias, etc.) and existing components first. For **place** rows, if Pelias is still inconclusive the runtime may still run web search as a **fallback** after direct geocoding fails—so choosing `no_web_search` when `components.address` is already present is correct (use the extracted street line with Pelias; do not spend an upfront search).
 
 ## When to prefer **web_search**
 
@@ -17,7 +17,7 @@ Meanings:
 ## When to use **no_web_search**
 
 - Clearly structural types that do not benefit from web search: **state**, **county**, **city**, **neighborhood**, **address** (already has a street line), **street_road**, **intersection***, **span**, **region***, **natural**.
-- **place** with a full numeric street address already present in **components.address** (or equivalent) so web search adds little.
+- **place** with a full numeric street address already present in **components.address** (or equivalent). Pelias should receive that street line directly; web search is only a post-Pelias fallback if needed.
 - Non-addressable natural POIs where search would not resolve a street address.
 
 Use **geocode_hints** for geographic disambiguation (street, neighborhood, nearby

--- a/packages/backfield-agate/src/agate_nodes/geocode_agent/prompts/route_strategy.md
+++ b/packages/backfield-agate/src/agate_nodes/geocode_agent/prompts/route_strategy.md
@@ -16,7 +16,7 @@ Meanings:
 
 ## When to use **no_web_search**
 
-- Clearly structural types that do not benefit from web search: **state**, **county**, **city**, **neighborhood**, **address** (already has a street line), **street_road**, **intersection***, **span**, **region***, **natural**.
+- Clearly structural types that do not benefit from web search: **state**, **county**, **city**, **neighborhood**, **address** (already has a street line), **street_road**, **intersection***, **span**, **region***, **natural**, **country** (ISO identity + optional Pelias country-layer bbox).
 - **place** with a full numeric street address already present in **components.address** (or equivalent). Pelias should receive that street line directly; web search is only a post-Pelias fallback if needed.
 - Non-addressable natural POIs where search would not resolve a street address.
 

--- a/packages/backfield-agate/src/agate_utils/geocoding/pelias.py
+++ b/packages/backfield-agate/src/agate_utils/geocoding/pelias.py
@@ -151,6 +151,11 @@ def _pelias_feature_to_result(
         "pelias_confidence": properties.get("confidence"),
         "pelias_has_bbox": bool(bbox and len(bbox) == 4),
         "pelias_bbox": bbox if isinstance(bbox, list) and len(bbox) == 4 else None,
+        # Structured address / POI identity for consolidate QA (not display-label only).
+        "pelias_name": properties.get("name"),
+        "pelias_housenumber": properties.get("housenumber"),
+        "pelias_street": properties.get("street"),
+        "pelias_postalcode": properties.get("postalcode"),
         # Useful for jurisdiction filtering in area models.
         "pelias_country_code": properties.get("country_code"),
         "pelias_country": properties.get("country"),

--- a/packages/backfield-agate/tests/test_geocode_country.py
+++ b/packages/backfield-agate/tests/test_geocode_country.py
@@ -3,14 +3,23 @@
 from __future__ import annotations
 
 import asyncio
+from unittest.mock import AsyncMock, patch
 
 import pytest
+from agate_nodes.geocode_agent.models.area.country import Country
 from agate_nodes.geocode_agent.nodes.consolidate import consolidate_node
 from agate_nodes.geocode_agent.nodes.geocode import (
     orchestrate_external_geocode,
     resolve_cache_or_miss,
 )
 from agate_nodes.geocode_agent.nodes.route_strategy import route_strategy_node
+from agate_utils.geocoding.geocoding_types import (
+    GeocodingResult,
+    GeocodingResultData,
+    GeometryPoint,
+    GeometryPolygon,
+    bbox_west_south_east_north_to_polygon_coordinates,
+)
 
 
 @pytest.mark.parametrize(
@@ -21,11 +30,12 @@ from agate_nodes.geocode_agent.nodes.route_strategy import route_strategy_node
         ("IN", "India", "IN"),
     ],
 )
-def test_recognized_country_is_terminal_without_external_geometry(
+def test_recognized_country_falls_back_to_identity_without_pelias_bbox(
     raw_name: str,
     canonical_name: str,
     country_code: str,
 ) -> None:
+    """Without a Pelias key/hit, countries remain accepted identity-only (no geography)."""
     state = {
         "location_text": raw_name,
         "location_type": "country",
@@ -35,6 +45,7 @@ def test_recognized_country_is_terminal_without_external_geometry(
         "original_text": raw_name,
         "extra_fields": {},
         "use_cache": False,
+        "pelias_api_key": None,
     }
 
     asyncio.run(resolve_cache_or_miss(state))
@@ -45,18 +56,110 @@ def test_recognized_country_is_terminal_without_external_geometry(
     places = state["final_output"]["places"]
     assert places["needs_review"] == []
     assert places["points"] == []
-    assert state.get("geocode_strategy") is None
-    assert places["areas"]["other"] == [
-        {
-            "id": f"iso-country:{country_code}",
-            "original_text": raw_name,
-            "location": canonical_name,
-            "type": "country",
-            "description": "Recognized country",
-            "country_code": country_code,
-            "geocode_disposition": "accepted_authoritative_identity",
-        }
-    ]
+    assert state.get("country_terminal_identity", {}).get("abbr") == country_code
+    assert len(places["areas"]["other"]) == 1
+    entry = places["areas"]["other"][0]
+    assert entry["id"] == f"iso-country:{country_code}"
+    assert entry["location"] == canonical_name
+    assert entry["type"] == "country"
+    assert entry["country_code"] == country_code
+    assert entry["geocode_disposition"] == "accepted_authoritative_identity"
+    assert "geocode" not in entry
+    assert state.get("geocode_strategy") == "no_web_search"
+
+
+def test_recognized_country_attaches_pelias_bbox_when_available() -> None:
+    polygon = GeometryPolygon(
+        coordinates=bbox_west_south_east_north_to_polygon_coordinates(
+            [-141.0, 41.7, -52.6, 83.1]
+        ),
+    )
+    pelias_result = GeocodingResult(
+        geocoder="pelias_structured",
+        input_str="Canada",
+        result=GeocodingResultData(
+            id="whosonfirst:country:85633041",
+            processed_str="Canada",
+            geometry=polygon,
+            confidence={
+                "pelias_layer": "country",
+                "pelias_country_code": "CA",
+                "pelias_has_bbox": True,
+                "pelias_bbox": [-141.0, 41.7, -52.6, 83.1],
+                "pelias_source": "whosonfirst",
+                "pelias_gid": "whosonfirst:country:85633041",
+            },
+        ),
+    )
+
+    state = {
+        "location_text": "Canada",
+        "location_type": "country",
+        "location_components": {
+            "country": {"name": "Canada", "abbr": "CA"},
+        },
+        "original_text": "Canada",
+        "extra_fields": {},
+        "use_cache": False,
+        "pelias_api_key": "test-key",
+    }
+
+    async def run() -> None:
+        await resolve_cache_or_miss(state)
+        await route_strategy_node(state)
+        with patch.object(Country, "geocode", new=AsyncMock(return_value=pelias_result)):
+            await orchestrate_external_geocode(state)
+        await consolidate_node(state)
+
+    asyncio.run(run())
+
+    places = state["final_output"]["places"]
+    assert places["needs_review"] == []
+    assert len(places["areas"]["other"]) == 1
+    entry = places["areas"]["other"][0]
+    assert entry["id"] == "iso-country:CA"
+    assert entry["geocode_disposition"] == "accepted_with_pelias_boundary"
+    assert entry["geocode"]["geocode_type"] == "pelias_structured"
+    assert entry["geocode"]["result"]["geometry"]["type"] == "Polygon"
+
+
+def test_country_model_rejects_mismatched_or_point_only_candidates() -> None:
+    model = Country(name="Canada", country="CA")
+    point = GeocodingResult(
+        geocoder="pelias_search",
+        input_str="Canada",
+        result=GeocodingResultData(
+            id="gid:point",
+            processed_str="Canada",
+            geometry=GeometryPoint(coordinates=[-106.0, 56.0]),
+            confidence={
+                "pelias_layer": "country",
+                "pelias_country_code": "CA",
+                "pelias_has_bbox": False,
+            },
+        ),
+    )
+    wrong_code = GeocodingResult(
+        geocoder="pelias_search",
+        input_str="Canada",
+        result=GeocodingResultData(
+            id="gid:us",
+            processed_str="United States",
+            geometry=GeometryPolygon(
+                coordinates=bbox_west_south_east_north_to_polygon_coordinates(
+                    [-125.0, 24.0, -66.0, 49.0]
+                ),
+            ),
+            confidence={
+                "pelias_layer": "country",
+                "pelias_country_code": "US",
+                "pelias_has_bbox": True,
+                "pelias_bbox": [-125.0, 24.0, -66.0, 49.0],
+            },
+        ),
+    )
+    assert model._choose_best_area_candidate([point], expected_layer="country") is None
+    assert model._choose_best_area_candidate([wrong_code], expected_layer="country") is None
 
 
 @pytest.mark.parametrize("raw_name", ["Atlantis", "North Exampleland"])

--- a/packages/backfield-agate/tests/test_poi_evidence.py
+++ b/packages/backfield-agate/tests/test_poi_evidence.py
@@ -1,0 +1,378 @@
+"""Synthetic regression tests for Pelias POI evidence and consolidate exception."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from agate_nodes.geocode_agent.models.point.place import Place
+from agate_nodes.geocode_agent.nodes.consolidate import consolidate_node
+from agate_nodes.geocode_agent.poi_evidence import (
+    has_exact_address_evidence,
+    has_poi_identity_evidence,
+    is_decisive_pelias_candidate,
+    pelias_poi_result_acceptable,
+    select_uniquely_decisive_candidate,
+)
+from agate_utils.geocoding.geocoding_types import (
+    GeocodingResult,
+    GeocodingResultData,
+    GeometryPoint,
+)
+
+
+def _pelias_result(
+    *,
+    label: str,
+    name: str | None = None,
+    housenumber: str | None = None,
+    street: str | None = None,
+    locality: str | None = "Chicago",
+    region_a: str | None = "IL",
+    country_code: str | None = "US",
+    gid: str = "openstreetmap:venue:1",
+    lon: float = -87.65,
+    lat: float = 41.95,
+    geocoder: str = "pelias_search",
+) -> GeocodingResult:
+    confidence: dict = {
+        "pelias_name": name,
+        "pelias_housenumber": housenumber,
+        "pelias_street": street,
+        "pelias_locality": locality,
+        "pelias_region_a": region_a,
+        "pelias_country_code": country_code,
+        "pelias_gid": gid,
+        "pelias_layer": "venue",
+    }
+    return GeocodingResult(
+        geocoder=geocoder,
+        input_str=label,
+        result=GeocodingResultData(
+            id=gid,
+            processed_str=label,
+            geometry=GeometryPoint(coordinates=[lon, lat]),
+            confidence=confidence,
+        ),
+    )
+
+
+def _venue_components(
+    *,
+    name: str,
+    address: str,
+    city: str = "Chicago",
+    state_abbr: str = "IL",
+) -> dict:
+    return {
+        "place": {"name": name, "addressable": True},
+        "address": address,
+        "city": city,
+        "state": {"name": "Illinois", "abbr": state_abbr},
+        "country": {"name": "United States", "abbr": "US"},
+    }
+
+
+# --- Labeled set modeled on Sun-Times venues (synthetic Pelias payloads) ---
+
+@pytest.mark.parametrize(
+    "name,address,label,pelias_name,expect_accept",
+    [
+        (
+            "Martyrs",
+            "3855 N. Lincoln Ave.",
+            "Martyrs, North Side, Chicago, IL, USA",
+            "Martyrs",
+            True,
+        ),
+        (
+            "The Salt Shed",
+            "1357 N Elston Ave",
+            "Salt Shed, Chicago, IL, USA",
+            "Salt Shed",
+            True,
+        ),
+        (
+            "Music Box Theatre",
+            "3733 N Southport Ave",
+            "Music Box Theatre, Chicago, IL, USA",
+            "Music Box Theatre",
+            True,
+        ),
+        (
+            "Chicago Shakespeare Theater",
+            "800 E Grand Ave",
+            "Chicago Shakespeare Theater, Chicago, IL, USA",
+            "Chicago Shakespeare Theater",
+            True,
+        ),
+        # Wrong venue identity — must reject
+        (
+            "Urban Theater Company",
+            "1000 N Wells St",
+            "Lookingglass Theatre Company, Chicago, IL, USA",
+            "Lookingglass Theatre Company",
+            False,
+        ),
+        (
+            "Drury Lane Theatre",
+            "100 Drury Lane",
+            "Drury Lane, Missouri, USA",
+            "Drury Lane",
+            False,
+        ),
+        (
+            "Milwaukee Art Museum",
+            "700 N Art Museum Dr",
+            "Milwaukee Art Museum, Jacksonville, FL, USA",
+            "Milwaukee Art Museum",
+            False,
+        ),
+        # Intentional non-match: Theater vs Theatre spelling
+        (
+            "Chicago Shakespeare Theater",
+            "800 E Grand Ave",
+            "Chicago Shakespeare Theatre, Chicago, IL, USA",
+            "Chicago Shakespeare Theatre",
+            False,
+        ),
+    ],
+)
+def test_labeled_venue_outcomes(
+    name: str,
+    address: str,
+    label: str,
+    pelias_name: str,
+    expect_accept: bool,
+) -> None:
+    comps = _venue_components(name=name, address=address)
+    # Drury Lane wrong state / Milwaukee wrong city need matching jurisdiction fields
+    locality = "Chicago"
+    region_a = "IL"
+    if "Missouri" in label:
+        locality = "St Louis"
+        region_a = "MO"
+        comps["city"] = "Oakbrook Terrace"
+        comps["state"] = {"name": "Illinois", "abbr": "IL"}
+    if "Jacksonville" in label:
+        locality = "Jacksonville"
+        region_a = "FL"
+
+    result = _pelias_result(
+        label=label,
+        name=pelias_name,
+        locality=locality,
+        region_a=region_a,
+        country_code="US",
+        gid=f"openstreetmap:venue:{name}",
+    )
+    assert pelias_poi_result_acceptable(comps, result) is expect_accept
+
+
+def test_missing_pelias_name_fails_closed() -> None:
+    comps = _venue_components(name="Martyrs", address="3855 N. Lincoln Ave.")
+    result = _pelias_result(
+        label="Martyrs, Chicago, IL, USA",
+        name=None,
+        locality="Chicago",
+        region_a="IL",
+    )
+    assert has_poi_identity_evidence(comps, result) is False
+    assert pelias_poi_result_acceptable(comps, result) is False
+
+
+def test_conflicting_house_number_rejects() -> None:
+    comps = _venue_components(name="Martyrs", address="3855 N. Lincoln Ave.")
+    result = _pelias_result(
+        label="2400 N Lincoln Ave, Chicago, IL, USA",
+        name="Martyrs",
+        housenumber="2400",
+        street="N Lincoln Ave",
+        locality="Chicago",
+        region_a="IL",
+    )
+    assert is_decisive_pelias_candidate(comps, result) is False
+
+
+def test_exact_address_evidence_accepts_without_venue_name() -> None:
+    comps = _venue_components(name="Martyrs", address="3855 N. Lincoln Ave.")
+    result = _pelias_result(
+        label="3855 N Lincoln Ave, Chicago, IL, USA",
+        name=None,
+        housenumber="3855",
+        street="N Lincoln Ave",
+        locality="Chicago",
+        region_a="IL",
+    )
+    assert has_exact_address_evidence(comps, result) is True
+    assert pelias_poi_result_acceptable(comps, result) is True
+    # Address evidence path is not "unverified"
+    from agate_nodes.geocode_agent.poi_evidence import poi_acceptance_is_address_unverified
+
+    assert poi_acceptance_is_address_unverified(comps, result) is False
+
+
+def test_same_name_different_city_rejects() -> None:
+    comps = _venue_components(name="Music Box", address="100 Main St", city="Chicago")
+    result = _pelias_result(
+        label="Music Box, Evanston, IL, USA",
+        name="Music Box",
+        locality="Evanston",
+        region_a="IL",
+    )
+    assert pelias_poi_result_acceptable(comps, result) is False
+
+
+def test_uniquely_decisive_candidate_required() -> None:
+    comps = _venue_components(name="Martyrs", address="3855 N. Lincoln Ave.")
+    a = _pelias_result(
+        label="Martyrs, Chicago, IL, USA",
+        name="Martyrs",
+        gid="openstreetmap:venue:a",
+        lon=-87.65,
+        lat=41.95,
+    )
+    b = _pelias_result(
+        label="Martyrs, Chicago, IL, USA",
+        name="Martyrs",
+        gid="openstreetmap:venue:b",
+        lon=-87.70,
+        lat=41.90,
+    )
+    assert select_uniquely_decisive_candidate(comps, [a, b]) is None
+    assert select_uniquely_decisive_candidate(comps, [a]) is a
+    # Same identity (shared gid) is fine
+    b_same = _pelias_result(
+        label="Martyrs, Chicago, IL, USA",
+        name="Martyrs",
+        gid="openstreetmap:venue:a",
+        lon=-87.65,
+        lat=41.95,
+    )
+    assert select_uniquely_decisive_candidate(comps, [a, b_same]) is a
+
+
+def test_place_prep_uses_street_address_for_structured_pelias() -> None:
+    place = Place(
+        name="Martyrs",
+        city="Chicago",
+        state_abbr="IL",
+        country="US",
+        street_address="3855 N. Lincoln Ave.",
+    )
+    prep = place._prep()
+    assert prep["pelias_structured"]["address"] == "3855 N. Lincoln Ave."
+    assert "Martyrs" in prep["full_address"]
+    assert "3855 N. Lincoln Ave." in prep["full_address"]
+
+
+def test_place_prep_falls_back_to_venue_name_without_street() -> None:
+    place = Place(name="Martyrs", city="Chicago", state_abbr="IL", country="US")
+    prep = place._prep()
+    assert prep["pelias_structured"]["address"] == "Martyrs"
+
+
+def _place_consolidate_state(
+    *,
+    components: dict,
+    result: GeocodingResult,
+) -> dict:
+    return {
+        "location_type": "place",
+        "location_text": place_name_text(components),
+        "location_components": components,
+        "original_text": "Mention in article",
+        "geocode_hints": "",
+        "geocoding_result": result,
+        "extra_fields": {},
+        "advanced_quiet_logs": True,
+    }
+
+
+def place_name_text(components: dict) -> str:
+    place = components.get("place") or {}
+    name = place.get("name") if isinstance(place, dict) else str(place or "")
+    city = components.get("city") or ""
+    return f"{name}, {city}" if city else str(name)
+
+
+def test_consolidate_keeps_poi_identity_match_with_unverified_marker() -> None:
+    comps = _venue_components(name="Martyrs", address="3855 N. Lincoln Ave.")
+    result = _pelias_result(
+        label="Martyrs, North Side, Chicago, IL, USA",
+        name="Martyrs",
+        locality="Chicago",
+        region_a="IL",
+        gid="openstreetmap:venue:martyrs",
+    )
+    # Label has no house number → shared gate fails; exception should keep geometry.
+    from backfield_entities.ingest.geocode_cache.sanity import (
+        explicit_location_components_match_labels,
+    )
+
+    assert (
+        explicit_location_components_match_labels(
+            components=comps,
+            location_text="Martyrs, Chicago",
+            match_label=result.result.processed_str,
+        )
+        is False
+    )
+
+    state = _place_consolidate_state(components=comps, result=result)
+
+    async def run() -> dict:
+        with patch(
+            "agate_nodes.geocode_agent.nodes.consolidate.compute_emit_location_line",
+            new=AsyncMock(return_value="Martyrs, Chicago, IL"),
+        ):
+            return await consolidate_node(state)
+
+    output = asyncio.run(run())
+    points = output["final_output"]["places"]["points"]
+    review = output["final_output"]["places"]["needs_review"]
+    assert len(review) == 0
+    assert len(points) == 1
+    assert points[0]["address_verification"] == "unverified"
+    assert points[0]["geocode_qa_code"] == "poi_identity_match"
+    assert points[0]["geocode"]["result"]["geometry"]["type"] == "Point"
+
+
+def test_consolidate_rejects_wrong_venue_identity() -> None:
+    comps = _venue_components(name="Urban Theater Company", address="1000 N Wells St")
+    result = _pelias_result(
+        label="Lookingglass Theatre Company, Chicago, IL, USA",
+        name="Lookingglass Theatre Company",
+        locality="Chicago",
+        region_a="IL",
+        gid="openstreetmap:venue:lookingglass",
+    )
+    state = _place_consolidate_state(components=comps, result=result)
+
+    async def run() -> dict:
+        with patch(
+            "agate_nodes.geocode_agent.nodes.consolidate.compute_emit_location_line",
+            new=AsyncMock(return_value="Lookingglass Theatre Company, Chicago, IL"),
+        ):
+            return await consolidate_node(state)
+
+    output = asyncio.run(run())
+    points = output["final_output"]["places"]["points"]
+    review = output["final_output"]["places"]["needs_review"]
+    assert len(points) == 0
+    assert len(review) == 1
+    assert review[0]["geocode_qa_code"] == "geocode_component_mismatch"
+    assert "geometry" not in review[0].get("geocode", {}).get("result", {})
+
+
+def test_non_pelias_geocoder_does_not_get_poi_exception() -> None:
+    comps = _venue_components(name="Martyrs", address="3855 N. Lincoln Ave.")
+    result = _pelias_result(
+        label="Martyrs, Chicago, IL, USA",
+        name="Martyrs",
+        locality="Chicago",
+        region_a="IL",
+        geocoder="nominatim",
+    )
+    assert pelias_poi_result_acceptable(comps, result) is False

--- a/tests/test_geocode_place_web_search.py
+++ b/tests/test_geocode_place_web_search.py
@@ -94,3 +94,86 @@ def test_place_prep_includes_full_address_alias() -> None:
     prep = place._prep()
     assert prep.get("full_address") == prep.get("full_place")
     assert "Spyhouse" in (prep.get("full_address") or "")
+
+
+def test_place_prep_prefers_street_address_for_structured_query() -> None:
+    place = Place(
+        name="Spyhouse",
+        city="St Paul",
+        state_abbr="MN",
+        country="US",
+        street_address="400 Sibley St",
+    )
+    prep = place._prep()
+    assert prep["pelias_structured"]["address"] == "400 Sibley St"
+    assert "Spyhouse" in prep["full_address"]
+    assert "400 Sibley St" in prep["full_address"]
+
+
+def test_place_web_search_fallback_after_inconclusive_pelias() -> None:
+    """allow_web_search=False skips upfront search but still falls back after Pelias miss."""
+    import asyncio
+
+    from agate_utils.geocoding.geocoding_types import (
+        GeocodingResult,
+        GeocodingResultData,
+        GeometryPoint,
+    )
+
+    place = Place(
+        name="Cafe",
+        city="St Paul",
+        state_abbr="MN",
+        country="US",
+        street_address="100 Main St",
+    )
+    place._input_addressability = True
+    place._original_text = "Cafe in St Paul"
+
+    decisive = GeocodingResult(
+        geocoder="pelias_search",
+        input_str="Cafe",
+        result=GeocodingResultData(
+            id="gid:1",
+            processed_str="Cafe, St Paul, MN, USA",
+            geometry=GeometryPoint(coordinates=[-93.1, 44.95]),
+            confidence={
+                "pelias_name": "Cafe",
+                "pelias_locality": "St Paul",
+                "pelias_region_a": "MN",
+                "pelias_country_code": "US",
+                "pelias_gid": "gid:1",
+            },
+        ),
+    )
+
+    async def run() -> GeocodingResult | None:
+        async def fake_web(**_kwargs: object) -> bool:
+            place._web_search_used = True
+            place._web_search_fallback_used = True
+            return True
+
+        with (
+            patch.object(place, "_geocode_pelias_decisive", side_effect=[None, decisive]) as pelias,
+            patch.object(
+                place,
+                "_try_web_search_address_discovery",
+                side_effect=fake_web,
+            ) as web,
+            patch(
+                "agate_nodes.geocode_agent.models.point.place.has_llm_auth",
+                return_value=True,
+            ),
+        ):
+            out = await place.geocode(
+                pelias_api_key="k",
+                openai_api_key="sk",
+                brave_search_api_key="brave",
+                allow_web_search=False,
+            )
+            assert place._web_search_fallback_used is True
+            web.assert_called_once()
+            assert pelias.call_count == 2
+            return out
+
+    assert asyncio.run(run()) is decisive


### PR DESCRIPTION
## Summary
- Keep Pelias venue pins when labels omit house numbers: pass extracted street addresses into Place geocoding, preserve Pelias structured evidence, and accept uniquely decisive POI identity matches without loosening Stylebook/cache sanity.
- After ISO country identity succeeds, attach a matching Pelias `country`-layer bbox when available; otherwise keep identity-only acceptance.
- Document the consolidate QA / router web-search fallback behavior and cover both paths with regression tests.

## Test plan
- [ ] `make lint` / `make test` (or at least `packages/backfield-agate/tests/test_poi_evidence.py`, `test_geocode_country.py`, and `tests/test_geocode_place_web_search.py`)
- [ ] Rebuild/restart the worker so Docker picks up `backfield-agate` changes
- [ ] Smoke a venue with a street address whose Pelias label omits the house number — expect accept with `poi_identity_match` / unverified address when evidence is decisive
- [ ] Smoke a recognized country extract — expect Pelias boundary when present, identity-only fallback when not
- [ ] Confirm a wrong-venue / jurisdiction mismatch still goes to `needs_review` with `geocode_component_mismatch`


Made with [Cursor](https://cursor.com)