### PR TITLE
Fix Playground execute button spacing and disabled cursor

### DIFF
--- a/apps/api-playground/src/components/EndpointExplorer.tsx
+++ b/apps/api-playground/src/components/EndpointExplorer.tsx
@@ -607,7 +607,7 @@ export default function EndpointExplorer({
       )}
 
       <button
-        className="execute-button"
+        className={`execute-button${executing ? " is-executing" : ""}`}
         type="button"
         disabled={executing || !apiKey}
         aria-describedby={error ? "request-error" : undefined}

--- a/apps/api-playground/src/styles.css
+++ b/apps/api-playground/src/styles.css
@@ -73,7 +73,7 @@ button {
 }
 
 button:disabled {
-  cursor: wait;
+  cursor: not-allowed;
   opacity: 0.55;
 }
 
@@ -1203,6 +1203,15 @@ legend {
 
 .execute-button {
   min-width: 140px;
+  margin-top: 8px;
+}
+
+.execute-button.is-executing:disabled {
+  cursor: wait;
+}
+
+.execute-button + .result-note {
+  margin: 10px 0 0;
 }
 
 .result-block,


### PR DESCRIPTION
## Summary
- Add space above the Execute request button and between the button and the “Add a project API key…” helper note.
- Use `not-allowed` for disabled controls by default, and `wait` only while a request is in flight.

## Test plan
- [ ] Open API Playground without a project API key; confirm gap between Execute request and the helper note
- [ ] Confirm disabled button cursor is `not-allowed`, then with a key submit a request and confirm `wait` while sending


Made with [Cursor](https://cursor.com)