### PR TITLE
Decouple location matching from geocode quality

### DIFF
--- a/apps/worker/src/worker/substrate/canonical/adjudication.py
+++ b/apps/worker/src/worker/substrate/canonical/adjudication.py
@@ -62,26 +62,19 @@ def _recall_context_for_adjudication(
     plan: CanonicalPersistPlan,
     location: SubstrateLocation,
 ) -> dict[str, Any] | None:
-    """Return recall context for ambiguous matches or forced ``political_district`` adjudication."""
+    """Return the closed recall set for ambiguous or fuzzy-match adjudication."""
+    _ = location
     for r in plan.resolution_reasons:
         if not isinstance(r, dict):
             continue
-        if str(r.get("code") or "") == "ambiguous_canonical_match":
+        if str(r.get("code") or "") in {
+            "ambiguous_canonical_match",
+            "ambiguous_exact_canonical_match",
+            "linked_fuzzy_autolink",
+        }:
             ids = r.get("recall_canonical_ids")
             if isinstance(ids, list) and ids:
                 return r
-    lt = (location.location_type or "").strip().lower()
-    if lt == "political_district" and plan.decision == CanonicalPersistDecision.LINK_EXISTING:
-        for r in plan.resolution_reasons:
-            if not isinstance(r, dict):
-                continue
-            if str(r.get("code") or "") == "linked_fuzzy_autolink":
-                ids = r.get("recall_canonical_ids")
-                if isinstance(ids, list) and ids:
-                    return {
-                        "recall_canonical_ids": list(ids),
-                        "code": "linked_fuzzy_autolink",
-                    }
     return None
 
 
@@ -171,8 +164,9 @@ def prepare_location_adjudication(
 
     lines = "\n".join(
         f"- id={cid} label={label!r} location_type={lt!r} district_key={dk!r} "
-        f"district_kind={kind!r} district_number={num!r}"
-        for cid, label, lt, dk, kind, num, _fa, _gt in candidates
+        f"district_kind={kind!r} district_number={num!r} formatted_address={fa!r} "
+        f"geometry_type={gt!r}"
+        for cid, label, lt, dk, kind, num, fa, gt in candidates
     )
     floor = ADJUDICATION_LINK_MIN_CONFIDENCE
     district_block = ""
@@ -212,7 +206,10 @@ def prepare_location_adjudication(
         "only appears as geographic context in the suffix (e.g. a restaurant inside a park).\n"
         f"{district_rules}"
         "- When any candidate is only a rough geographic association, choose decision="
-        "\"no_match\" or \"uncertain\". Prefer that over a stretched link.\n"
+        '"no_match" or "uncertain". Prefer that over a stretched link.\n'
+        "- Missing coordinates or a missing formatted address are unknown evidence, not a "
+        "conflict. Do not reject an otherwise definitive same-place identity only because "
+        "geography is absent.\n"
         f"- Use confidence {floor} or higher only for definitive same-place identity you would "
         f"publish in a catalog; otherwise use confidence below {floor} "
         f"(the system will not link).\n\n"

--- a/docs/architecture/canonicalization.md
+++ b/docs/architecture/canonicalization.md
@@ -43,14 +43,19 @@ address, and name-anchor checks. The same final commit gate protects rules, cach
 refresh paths. `BACKFIELD_STRICT_CANONICAL_GATES=0` disables the additional recall gates, but not
 base compatibility or final link validation.
 
-Resolved locations without a safe match generally materialize a canonical. These categories stay
-review-oriented:
+Canonical identity matching is independent of geocode quality. A missing or rejected map result is
+unknown evidence rather than an identity conflict: exact and fuzzy canonical recall still run, and
+linking to an existing canonical does not copy substrate geography into the canonical. Geocode
+quality remains visible as a review warning alongside the link, create, or defer recommendation.
 
-- private residences and ordinary addresses;
+Locations without a safe match may recommend a geography-free canonical. Automatic ingest keeps
+that recommendation pending when geography is missing or review-required, and keeps address-like
+creation recommendations editorial even when a map result exists. These categories retain
+additional policy restrictions:
+
+- private residences;
 - roadway spans;
 - road and highway intersections;
-- streets without the required resolved geometry;
-- extraction or geocode results already marked for review.
 
 Intersections and spans never auto-materialize, although they may link to an existing compatible
 canonical. Exact and fuzzy candidates for addresses, intersections, and named places must preserve
@@ -60,7 +65,8 @@ Political districts use structured district identity when available.
 Every extracted location has one terminal disposition: an accepted location or a reason-coded
 review row. Explicit structured country, subdivision, postal code, and address precision constrain
 resolver results. Rejected, imprecise, and mail-only results do not retain provider identity,
-geometry, H3, or cache eligibility and cannot materialize canonicals.
+geometry, H3, or cache eligibility; they can still link by identity or produce an editorial create
+recommendation.
 Recognized country identity comes from its ISO code and does not require resolver geometry.
 Unknown country labels remain unclassified rather than inheriting a default country. Address
 display values retain their house number and street identity, and point reconciliation does not

--- a/docs/development/entities/overview.md
+++ b/docs/development/entities/overview.md
@@ -52,18 +52,20 @@ Canonical policy uses the shared `CanonicalPersistPlan` contract:
 - `MATERIALIZE_NEW` creates a canonical when policy allows it.
 - `DEFER` records review reasons and leaves the substrate row in the queue.
 
-Rules are type-specific. Location identity includes resolved geography and
-jurisdiction constraints. Person identity uses normalized name and affiliation;
-title is not part of the substrate identity fingerprint. Organization policy uses
-its own name and organization signals. Projects may use rules-only or AI-assisted
-canonical adjudication; model-assisted links must still satisfy the shared
-confidence threshold.
+Rules are type-specific. Location identity uses names, types, and available
+geography and jurisdiction constraints; absent geography is neutral rather than a
+conflict. Person identity uses normalized name and affiliation; title is not part
+of the substrate identity fingerprint. Organization policy uses its own name and
+organization signals. Projects may use rules-only or AI-assisted canonical
+adjudication; model-assisted links must still satisfy the shared confidence
+threshold.
 
 PlaceExtract and GeocodeAgent preserve one terminal row for every extracted
 location. Explicit country, subdivision, postal, and address components constrain
 resolver acceptance. A rejected or review-required result retains its reason and
-audit context but not provider identity, geometry, H3, or cache eligibility, and it
-cannot create a canonical.
+audit context but not provider identity, geometry, H3, or cache eligibility. It
+can still link to an existing canonical, or recommend a geography-free canonical
+for editorial acceptance; automatic ingest does not create that canonical.
 Recognized countries use ISO identity without requiring geometry; unknown country
 labels never inherit a domestic default. Address displays must preserve the
 structured house number and street, and article-level reconciliation keeps

--- a/packages/backfield-entities/src/backfield_entities/entities/location/persist.py
+++ b/packages/backfield-entities/src/backfield_entities/entities/location/persist.py
@@ -29,6 +29,7 @@ from backfield_entities.canonical.slug import (
 )
 from backfield_entities.entities.location.policy import plan_has_ambiguous_canonical_match
 from backfield_entities.entities.location.recall import location_alias_lookup_keys
+from backfield_entities.entities.location.types import is_address_like_location_type
 from backfield_entities.geo.h3_index import apply_h3_fields
 from backfield_entities.text.match_normalize import normalize_match_text
 
@@ -466,7 +467,13 @@ def apply_candidate_ai_review_recommendation(
     reasons = [
         r
         for r in reasons
-        if str(r.get("code") or "") not in ("canonical_suggestion", "canonical_adjudication")
+        if str(r.get("code") or "")
+        not in (
+            "canonical_suggestion",
+            "canonical_adjudication",
+            "deferred_policy",
+            "geocode_quality_warning",
+        )
     ]
     for r in plan.resolution_reasons:
         if isinstance(r, dict):
@@ -481,6 +488,21 @@ def apply_candidate_ai_review_recommendation(
     location.canonical_review_reasons_json = reasons
     session.add(location)
     return has_suggestion
+
+
+def materialization_requires_editorial_review(
+    location: SubstrateLocation,
+    *,
+    places_bucket: str,
+) -> bool:
+    """True when a create recommendation must not be auto-applied."""
+    status = str(location.status or "").strip().lower()
+    return (
+        places_bucket == "needs_review"
+        or status in {"needs_review", "failed"}
+        or is_address_like_location_type(location.location_type)
+        or location.geometry_json is None
+    )
 
 
 def apply_canonical_persist_plan(
@@ -501,6 +523,19 @@ def apply_canonical_persist_plan(
     extra = _canonical_suggestion_from_rules_plan(plan)
     if extra is not None and not has_suggestion:
         reasons.append(extra)
+    if (
+        plan.decision == CanonicalPersistDecision.MATERIALIZE_NEW
+        and auto_apply_canonicalization
+        and materialization_requires_editorial_review(location, places_bucket=places_bucket)
+    ):
+        apply_canonical_persist_plan_review_only(
+            session,
+            stylebook_id=stylebook_id,
+            location=location,
+            plan=plan,
+            places_bucket=places_bucket,
+        )
+        return
     if plan.decision == CanonicalPersistDecision.DEFER:
         if auto_apply_canonicalization and _resolution_includes_private_place_or_residence(plan):
             location.canonical_link_status = CANONICAL_LINK_WAIVED

--- a/packages/backfield-entities/src/backfield_entities/entities/location/policy.py
+++ b/packages/backfield-entities/src/backfield_entities/entities/location/policy.py
@@ -195,27 +195,28 @@ def _address_place_kind_from_entry(entry: dict[str, Any] | None) -> str:
     return ADDRESS_PLACE_KIND_UNKNOWN
 
 
-def _should_defer(
-    *,
-    places_bucket: str,
+def _address_place_kind(
     location: SubstrateLocation,
-    entry: dict[str, Any] | None = None,
-) -> bool:
-    if places_bucket == "needs_review":
-        return True
-    st = str(location.status or "")
-    if st in ("needs_review", "failed"):
-        return True
-    lt = (location.location_type or "").strip().lower()
+    entry: dict[str, Any] | None,
+) -> str:
     kind = _address_place_kind_from_entry(entry)
-    if is_address_like_location_type(lt) and kind == ADDRESS_PLACE_KIND_PRIVATE_RESIDENCE:
-        return True
-    if lt == "address" and kind != ADDRESS_PLACE_KIND_PUBLIC_NAMED:
-        return True
-    # Roadway spans are not auto-canonicalized; editors can link or create later from the queue.
-    if lt == "span":
-        return True
-    return False
+    if kind != ADDRESS_PLACE_KIND_UNKNOWN:
+        return kind
+    details = location.source_details_json
+    if isinstance(details, dict):
+        return _address_place_kind_from_entry(details)
+    return ADDRESS_PLACE_KIND_UNKNOWN
+
+
+def _is_private_place_or_residence(
+    location: SubstrateLocation,
+    entry: dict[str, Any] | None,
+) -> bool:
+    lt = (location.location_type or "").strip().lower()
+    return (
+        is_address_like_location_type(lt)
+        and _address_place_kind(location, entry) == ADDRESS_PLACE_KIND_PRIVATE_RESIDENCE
+    )
 
 
 _NO_AUTOMATIC_CANONICAL_MATERIALIZATION_TYPES: frozenset[str] = frozenset(
@@ -268,15 +269,6 @@ _HEAD_ANCHOR_GATED_TYPES: frozenset[str] = frozenset(
         "natural",
     }
 )
-
-
-def _location_type_allows_autocreate_without_strict_geometry(location_type: str | None) -> bool:
-    lt = (location_type or "").strip().lower()
-    if lt in _NO_AUTOMATIC_CANONICAL_MATERIALIZATION_TYPES:
-        return False
-    if "span" in lt:
-        return False
-    return True
 
 
 def _should_apply_head_anchor_gate(location_type: str | None) -> bool:
@@ -371,15 +363,6 @@ def _match_basis_for_audit(location_type: str | None) -> str:
     if (location_type or "").strip().lower() == "address":
         return "string_and_point_geometry"
     return "string_only"
-
-
-def _should_materialize_new_strict(location: SubstrateLocation) -> bool:
-    """Legacy gate for excluded types: only materialize with resolved geocode + geometry."""
-    if location.geometry_json is None:
-        return False
-    if str(location.status or "") != "resolved":
-        return False
-    return True
 
 
 _JURISDICTION_SCORE_GATE_SUBSTRATE_TYPES: frozenset[str] = frozenset(
@@ -790,26 +773,16 @@ def _best_allowed_recall_score(
 
 
 def _should_materialize_when_no_canonical_match(location: SubstrateLocation) -> bool:
-    """After exact match + fuzzy tiers: whether to create a new canonical.
+    """After exact match + fuzzy tiers: whether to recommend a new canonical.
 
-    Most location types get a canonical when nothing linked and recall is not ambiguous,
-    as long as the row is not a hard geocode failure and has a normalized name.
-
-    Address and street-road types keep the strict geometry rule. Spans and
-    intersections never materialize automatically (editors can still link them to
-    existing canonicals or create canonicals manually from the queue).
+    Missing or rejected geography is not evidence against the extracted identity. Most
+    named location types may therefore recommend a geography-free canonical. Persistence
+    separately prevents review-required geography from auto-materializing.
     """
     lt = (location.location_type or "").strip().lower()
     if lt in _NEVER_AUTO_MATERIALIZE_TYPES:
         return False
-    if _location_type_allows_autocreate_without_strict_geometry(location.location_type):
-        st = str(location.status or "")
-        if st == "failed":
-            return False
-        if not str(location.normalized_name or "").strip():
-            return False
-        return True
-    return _should_materialize_new_strict(location)
+    return bool(str(location.normalized_name or "").strip())
 
 
 def _intra_strict_group_ambiguous(
@@ -849,7 +822,7 @@ def substrate_may_materialize_canonical_after_recall(location: SubstrateLocation
     return _should_materialize_when_no_canonical_match(location)
 
 
-def decide_location_canonical_persist_plan(
+def _decide_location_identity_plan(
     session: Session,
     *,
     stylebook_id: int,
@@ -857,48 +830,37 @@ def decide_location_canonical_persist_plan(
     location: SubstrateLocation,
     entry: dict[str, Any],
 ) -> CanonicalPersistPlan:
-    """Decide how persistence should treat Stylebook canonicalization for this substrate row.
+    """Decide canonical identity without treating missing geography as a conflict.
 
     ``entry`` carries PlaceExtract extras (e.g. ``address_place_kind``) for address deferral rules.
     """
-    if _should_defer(places_bucket=places_bucket, location=location, entry=entry):
-        lt = (location.location_type or "").strip().lower()
-        kind = _address_place_kind_from_entry(entry)
-        if is_address_like_location_type(lt) and kind == ADDRESS_PLACE_KIND_PRIVATE_RESIDENCE:
-            return CanonicalPersistPlan(
-                decision=CanonicalPersistDecision.DEFER,
-                resolution_reasons=(
-                    {
-                        "code": "private_place_or_residence",
-                        "message": "Private place or residence",
-                        "location_type": location.location_type,
-                        "places_bucket": places_bucket,
-                        "substrate_status": str(location.status or ""),
-                    },
-                ),
-            )
-        if lt == "span":
-            return CanonicalPersistPlan(
-                decision=CanonicalPersistDecision.DEFER,
-                resolution_reasons=(
-                    {
-                        "code": "road_span_not_canonicalized",
-                        "message": (
-                            "Road spans are not auto-canonicalized; "
-                            "defer for manual review or linking."
-                        ),
-                        "location_type": location.location_type,
-                        "places_bucket": places_bucket,
-                        "substrate_status": str(location.status or ""),
-                    },
-                ),
-            )
+    if _is_private_place_or_residence(location, entry):
         return CanonicalPersistPlan(
             decision=CanonicalPersistDecision.DEFER,
-            resolution_reasons=defer_reason_payload(
-                places_bucket=places_bucket,
-                location=location,
-                entry=entry,
+            resolution_reasons=(
+                {
+                    "code": "private_place_or_residence",
+                    "message": "Private place or residence",
+                    "location_type": location.location_type,
+                    "places_bucket": places_bucket,
+                    "substrate_status": str(location.status or ""),
+                },
+            ),
+        )
+    if (location.location_type or "").strip().lower() == "span":
+        return CanonicalPersistPlan(
+            decision=CanonicalPersistDecision.DEFER,
+            resolution_reasons=(
+                {
+                    "code": "road_span_not_canonicalized",
+                    "message": (
+                        "Road spans are not auto-canonicalized; "
+                        "defer for manual review or linking."
+                    ),
+                    "location_type": location.location_type,
+                    "places_bucket": places_bucket,
+                    "substrate_status": str(location.status or ""),
+                },
             ),
         )
 
@@ -1144,6 +1106,56 @@ def decide_location_canonical_persist_plan(
     )
 
 
+def _geocode_quality_warning_payload(
+    *,
+    places_bucket: str,
+    location: SubstrateLocation,
+    entry: dict[str, Any] | None,
+) -> tuple[dict[str, Any], ...]:
+    status = str(location.status or "").strip().lower()
+    if places_bucket != "needs_review" and status not in {"needs_review", "failed"}:
+        return ()
+    warning = dict(
+        defer_reason_payload(
+            places_bucket=places_bucket,
+            location=location,
+            entry=entry,
+        )[0]
+    )
+    warning["code"] = "geocode_quality_warning"
+    return (warning,)
+
+
+def decide_location_canonical_persist_plan(
+    session: Session,
+    *,
+    stylebook_id: int,
+    places_bucket: str,
+    location: SubstrateLocation,
+    entry: dict[str, Any],
+) -> CanonicalPersistPlan:
+    """Decide identity, preserving geocode concerns as non-blocking review warnings."""
+    plan = _decide_location_identity_plan(
+        session,
+        stylebook_id=stylebook_id,
+        places_bucket=places_bucket,
+        location=location,
+        entry=entry,
+    )
+    warnings = _geocode_quality_warning_payload(
+        places_bucket=places_bucket,
+        location=location,
+        entry=entry,
+    )
+    if not warnings:
+        return plan
+    return CanonicalPersistPlan(
+        decision=plan.decision,
+        existing_canonical_id=plan.existing_canonical_id,
+        resolution_reasons=warnings + plan.resolution_reasons,
+    )
+
+
 def plan_has_ambiguous_canonical_match(plan: CanonicalPersistPlan) -> bool:
     """True when rules deferred with an ambiguous fuzzy recall (LLM adjudication hook)."""
     for r in plan.resolution_reasons:
@@ -1162,9 +1174,6 @@ def plan_requires_llm_canonical_adjudication(
     """True when AI-assisted mode should run LLM adjudication."""
     if plan_has_ambiguous_canonical_match(plan):
         return True
-    lt = (location.location_type or "").strip().lower()
-    if lt != "political_district":
-        return False
     if plan.decision != CanonicalPersistDecision.LINK_EXISTING:
         return False
     for r in plan.resolution_reasons:

--- a/tests/entities/test_canonical_strict_gates.py
+++ b/tests/entities/test_canonical_strict_gates.py
@@ -24,6 +24,10 @@ from backfield_entities.canonical.link_matrix import (
     link_pair_allowed,
 )
 from backfield_entities.canonical.match_score import RECALL_MIN_SCORE
+from backfield_entities.canonical.plan_types import (
+    CanonicalPersistDecision,
+    CanonicalPersistPlan,
+)
 from backfield_entities.catalog.bootstrap import ensure_default_stylebook_for_organization
 from backfield_entities.entities.location.policy import (
     _jurisdiction_pair_demotes_recall_score,
@@ -256,6 +260,105 @@ def test_decide_links_imported_canonical_by_normalized_label_without_alias(
             isinstance(r, dict) and r.get("code") == "linked_exact_normalized_label"
             for r in plan.resolution_reasons
         )
+
+
+def test_needs_review_location_still_links_exact_canonical_without_geometry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("BACKFIELD_STRICT_CANONICAL_GATES", "1")
+    engine = _make_engine()
+    with Session(engine) as session:
+        _, sb_id = _bootstrap(session, org_slug="review-exact-location")
+        canon = StylebookLocationCanonical(
+            stylebook_id=sb_id,
+            label="Navy Pier, Chicago, IL",
+            slug="navy-pier-chicago-il",
+            location_type="place",
+            status="active",
+        )
+        session.add(canon)
+        session.commit()
+        session.refresh(canon)
+        location = SubstrateLocation(
+            project_id=1,
+            name="Navy Pier, Chicago, IL",
+            normalized_name="navy pier, chicago, il",
+            location_type="place",
+            status="needs_review",
+            canonical_link_status="pending",
+            geometry_json=None,
+            identity_fingerprint="fp-review-exact-location",
+        )
+        session.add(location)
+        session.commit()
+
+        plan = decide_location_canonical_persist_plan(
+            session,
+            stylebook_id=sb_id,
+            places_bucket="needs_review",
+            location=location,
+            entry={"geocode_qa_code": "geocode_component_mismatch"},
+        )
+
+        assert plan.decision.value == "link_existing"
+        assert plan.existing_canonical_id == str(canon.id)
+        codes = [str(reason.get("code") or "") for reason in plan.resolution_reasons]
+        assert codes[0] == "geocode_quality_warning"
+        assert "linked_exact_normalized_label" in codes
+
+
+def test_failed_location_without_match_recommends_geography_free_canonical() -> None:
+    engine = _make_engine()
+    with Session(engine) as session:
+        _, sb_id = _bootstrap(session, org_slug="review-create-location")
+        location = SubstrateLocation(
+            project_id=1,
+            name="New Community Center, Chicago, IL",
+            normalized_name="new community center, chicago, il",
+            location_type="place",
+            status="failed",
+            canonical_link_status="pending",
+            geometry_json=None,
+            identity_fingerprint="fp-review-create-location",
+        )
+        session.add(location)
+        session.commit()
+
+        plan = decide_location_canonical_persist_plan(
+            session,
+            stylebook_id=sb_id,
+            places_bucket="needs_review",
+            location=location,
+            entry={},
+        )
+
+        assert plan.decision.value == "materialize_new"
+        assert [reason.get("code") for reason in plan.resolution_reasons] == [
+            "geocode_quality_warning",
+            "materialized_new_canonical",
+        ]
+
+
+def test_ai_assisted_mode_adjudicates_fuzzy_autolink_for_any_location_type() -> None:
+    location = SubstrateLocation(
+        project_id=1,
+        name="Illinois Quantum & Microelectronics Park, Chicago, IL",
+        normalized_name="illinois quantum & microelectronics park, chicago, il",
+        location_type="place",
+        identity_fingerprint="fp-fuzzy-ai-review",
+    )
+    plan = CanonicalPersistPlan(
+        decision=CanonicalPersistDecision.LINK_EXISTING,
+        existing_canonical_id="canonical-id",
+        resolution_reasons=(
+            {
+                "code": "linked_fuzzy_autolink",
+                "recall_canonical_ids": ["canonical-id"],
+            },
+        ),
+    )
+
+    assert plan_requires_llm_canonical_adjudication(plan, location) is True
 
 
 @pytest.mark.parametrize(

--- a/tests/entities/test_canonical_type_gate.py
+++ b/tests/entities/test_canonical_type_gate.py
@@ -537,7 +537,7 @@ def test_decide_canonical_persist_plan_address_does_not_link_neighborhood_alias(
             entry={"address_place_kind": "public_named"},
         )
 
-    assert plan.decision == CanonicalPersistDecision.DEFER
+    assert plan.decision == CanonicalPersistDecision.MATERIALIZE_NEW
     assert plan.existing_canonical_id is None
 
 

--- a/tests/stylebook_api/test_candidate_review_display.py
+++ b/tests/stylebook_api/test_candidate_review_display.py
@@ -80,3 +80,19 @@ def test_deferred_policy_needs_review_line() -> None:
     assert format_candidate_review_lines(raw) == [
         "Flagged during geocoding — confirm before linking in Stylebook",
     ]
+
+
+def test_geocode_quality_warning_is_visible_beside_recommendation() -> None:
+    raw = [
+        {
+            "code": "geocode_quality_warning",
+            "message": "Flagged during geocoding — confirm before linking in Stylebook",
+        },
+        {
+            "code": "canonical_suggestion",
+            "suggested_action": "link_existing",
+        },
+    ]
+    assert format_candidate_review_lines(raw) == [
+        "Flagged during geocoding — confirm before linking in Stylebook",
+    ]

--- a/tests/worker/test_location_candidate_ai_review.py
+++ b/tests/worker/test_location_candidate_ai_review.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from backfield_db import (
+    BackfieldOrganization,
+    BackfieldProject,
+    BackfieldWorkspace,
+    StylebookLocationAlias,
+    StylebookLocationCanonical,
+    SubstrateLocation,
+)
+from backfield_entities.canonical.link import CANONICAL_LINK_PENDING
+from backfield_entities.catalog.bootstrap import ensure_default_stylebook_for_organization
+from sqlmodel import Session, SQLModel, create_engine
+from worker.substrate.candidates.ai_review import _process_location_candidate_review
+
+
+def _bootstrap(session: Session) -> tuple[int, int]:
+    organization = BackfieldOrganization(name="Candidate Review", slug="candidate-review")
+    session.add(organization)
+    session.commit()
+    session.refresh(organization)
+    organization_id = int(organization.id)  # type: ignore[arg-type]
+    stylebook = ensure_default_stylebook_for_organization(session, organization_id)
+    stylebook_id = int(stylebook.id)  # type: ignore[arg-type]
+    workspace = BackfieldWorkspace(
+        organization_id=organization_id,
+        stylebook_id=stylebook_id,
+        name="Candidate Review",
+        slug="candidate-review",
+    )
+    session.add(workspace)
+    session.commit()
+    session.refresh(workspace)
+    project = BackfieldProject(
+        organization_id=organization_id,
+        workspace_id=int(workspace.id),  # type: ignore[arg-type]
+        name="Candidate Review",
+        slug="candidate-review",
+    )
+    session.add(project)
+    session.commit()
+    session.refresh(project)
+    return int(project.id), stylebook_id  # type: ignore[arg-type]
+
+
+def test_ai_review_links_near_location_despite_missing_geography(monkeypatch) -> None:
+    engine = create_engine("sqlite://", echo=False)
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as session:
+        project_id, stylebook_id = _bootstrap(session)
+        canonical = StylebookLocationCanonical(
+            stylebook_id=stylebook_id,
+            label="Robie House, Hyde Park, Chicago, IL",
+            slug="robie-house-hyde-park-chicago-il",
+            location_type="place",
+            status="active",
+        )
+        session.add(canonical)
+        session.commit()
+        session.refresh(canonical)
+        canonical_id = str(canonical.id)
+        session.add(
+            StylebookLocationAlias(
+                location_canonical_id=canonical_id,
+                alias_text=str(canonical.label),
+                normalized_alias="robie house, hyde park, chicago, il",
+                provenance="stylebook_ui_manual",
+                suppressed=False,
+            )
+        )
+        candidate = SubstrateLocation(
+            project_id=project_id,
+            name="Robie House, Chicago, IL",
+            normalized_name="robie house, chicago, il",
+            location_type="place",
+            status="needs_review",
+            canonical_link_status=CANONICAL_LINK_PENDING,
+            geometry_json=None,
+            identity_fingerprint="candidate-review-robie-house",
+        )
+        session.add(candidate)
+        session.commit()
+        session.refresh(candidate)
+        candidate_id = int(candidate.id)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(
+        "worker.substrate.canonical.adjudication.call_llm",
+        lambda *_args, **_kwargs: (
+            '{"decision":"link_existing",'
+            f'"canonical_id":"{canonical_id}",'
+            '"confidence":0.97,"same_identity":true,'
+            '"conflicting_identity_evidence":false,'
+            '"rationale":"The names identify the same landmark."}'
+        ),
+    )
+
+    has_recommendation = _process_location_candidate_review(
+        engine,
+        stylebook_id=stylebook_id,
+        project_id=project_id,
+        location_id=candidate_id,
+        model="gpt-test",
+        model_config_id=None,
+    )
+
+    assert has_recommendation is True
+    with Session(engine) as session:
+        candidate = session.get(SubstrateLocation, candidate_id)
+        assert candidate is not None
+        assert candidate.stylebook_location_canonical_id is None
+        assert candidate.canonical_link_status == CANONICAL_LINK_PENDING
+        reasons = candidate.canonical_review_reasons_json
+        assert isinstance(reasons, list)
+        assert any(reason.get("code") == "geocode_quality_warning" for reason in reasons)
+        assert any(reason.get("code") == "canonical_adjudication" for reason in reasons)
+        assert any(
+            reason.get("code") == "canonical_suggestion"
+            and reason.get("source") == "candidate_ai_review"
+            and reason.get("suggested_action") == "link_existing"
+            and reason.get("stylebook_location_canonical_id") == canonical_id
+            for reason in reasons
+        )

--- a/tests/worker/test_substrate_persistence.py
+++ b/tests/worker/test_substrate_persistence.py
@@ -2055,8 +2055,8 @@ def test_persist_fuzzy_links_preseeded_canonical_when_alias_normalization_differ
         assert_canonical_link_invariant(locs[0])
 
 
-def test_persist_materializes_canonical_for_city_without_geometry_when_no_match() -> None:
-    """Non-excluded types auto-materialize when there is no link, even without geometry JSON."""
+def test_persist_recommends_canonical_for_city_without_geometry_when_no_match() -> None:
+    """Geography-free create plans stay pending instead of auto-materializing."""
     engine = create_engine("sqlite://", echo=False)
     SQLModel.metadata.create_all(engine)
 
@@ -2110,16 +2110,19 @@ def test_persist_materializes_canonical_for_city_without_geometry_when_no_match(
         locs = session.exec(select(SubstrateLocation)).all()
         assert len(locs) == 1
         assert locs[0].geometry_json is None
-        assert locs[0].canonical_link_status == CANONICAL_LINK_LINKED
-        assert locs[0].stylebook_location_canonical_id is not None
+        assert locs[0].canonical_link_status == CANONICAL_LINK_PENDING
+        assert locs[0].stylebook_location_canonical_id is None
+        reasons = locs[0].canonical_review_reasons_json
+        assert isinstance(reasons, list)
+        assert any(
+            isinstance(reason, dict)
+            and reason.get("code") == "canonical_suggestion"
+            and reason.get("suggested_action") == "materialize_new"
+            for reason in reasons
+        )
 
         canon_rows = session.exec(select(StylebookLocationCanonical)).all()
-        assert len(canon_rows) == 1
-        fk = locs[0].stylebook_location_canonical_id
-        canon = session.get(StylebookLocationCanonical, str(fk))
-        assert canon is not None
-        assert canon.location_type == "city"
-        assert canon.formatted_address and "Peoria" in canon.formatted_address
+        assert canon_rows == []
         assert_canonical_link_invariant(locs[0])
 
 


### PR DESCRIPTION
## Summary
- Run exact and fuzzy location canonical recall even when geocode status is `needs_review` / `failed` or geography is missing, instead of short-circuiting to defer.
- Treat geography-free create recommendations as editorial-only so auto-apply does not materialize them; surface geocode quality as a warning, not a match blocker.
- Broaden AI adjudication for fuzzy location matches regardless of geocode quality, and cover the behavior with policy, persistence, display, and worker regressions.

## Test plan
- [x] `make lint`
- [x] `make test`
- [x] `make smoke-fast`
- [ ] Spot-check Stylebook candidates that previously deferred despite an exact/near catalog match (e.g. named venues) and confirm they recommend link or create with a geocode warning when appropriate
- [ ] Confirm “Review with AI” adjudicates fuzzy near-matches that previously stayed on deferred policy
- [ ] Confirm auto-apply still does not create candidates that lack usable geography


Made with [Cursor](https://cursor.com)