### PR TITLE
Upgrade LiteLLM and refresh stylebook rail after catalog edits

### DIFF
--- a/apps/agate-ui/src/components/AppSidebar.tsx
+++ b/apps/agate-ui/src/components/AppSidebar.tsx
@@ -119,15 +119,33 @@ export default function AppSidebar() {
     }
   }, [])
 
+  const loadStylebooks = useCallback(async () => {
+    if (organizationId == null) {
+      setStylebooks([])
+      return
+    }
+    try {
+      const rows = await listStylebookCatalogs(organizationId)
+      setStylebooks(rows)
+    } catch (err) {
+      console.error('Failed to fetch stylebooks:', err)
+    }
+  }, [organizationId])
+
   useEffect(() => {
     void loadWorkspaces()
     void loadProjects()
   }, [loadWorkspaces, loadProjects])
 
   useEffect(() => {
+    void loadStylebooks()
+  }, [loadStylebooks])
+
+  useEffect(() => {
     const onChanged = () => {
       void loadWorkspaces()
       void loadProjects()
+      void loadStylebooks()
     }
     window.addEventListener('agate:projects-changed', onChanged)
     window.addEventListener('agate:workspaces-changed', onChanged)
@@ -135,17 +153,7 @@ export default function AppSidebar() {
       window.removeEventListener('agate:projects-changed', onChanged)
       window.removeEventListener('agate:workspaces-changed', onChanged)
     }
-  }, [loadWorkspaces, loadProjects])
-
-  useEffect(() => {
-    if (organizationId == null) {
-      setStylebooks([])
-      return
-    }
-    void listStylebookCatalogs(organizationId)
-      .then(setStylebooks)
-      .catch((err) => console.error('Failed to fetch stylebooks:', err))
-  }, [organizationId])
+  }, [loadWorkspaces, loadProjects, loadStylebooks])
 
   const hubLinkClass =
     'flex items-center gap-3 rounded-md px-2 py-2 text-sm font-medium transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring text-muted-foreground hover:text-foreground'

--- a/apps/core-api/src/core_api/ai_model_catalog.py
+++ b/apps/core-api/src/core_api/ai_model_catalog.py
@@ -71,6 +71,35 @@ class CuratedAiModelTemplate:
 # Insertion order controls default API list order and Preset dropdown order within each provider.
 CURATED_TEMPLATES: dict[str, CuratedAiModelTemplate] = {
     # --- OpenAI ---
+    # GPT-5.6 family: bare gpt-5.6 aliases to sol; terra/luna are named capability tiers.
+    "openai:gpt-5.6": CuratedAiModelTemplate(
+        template_id="openai:gpt-5.6",
+        provider="openai",
+        provider_model_id="gpt-5.6",
+        label="GPT-5.6",
+        capabilities=(AI_CAPABILITY_TEXT, AI_CAPABILITY_JSON),
+    ),
+    "openai:gpt-5.6-sol": CuratedAiModelTemplate(
+        template_id="openai:gpt-5.6-sol",
+        provider="openai",
+        provider_model_id="gpt-5.6-sol",
+        label="GPT-5.6 Sol",
+        capabilities=(AI_CAPABILITY_TEXT, AI_CAPABILITY_JSON),
+    ),
+    "openai:gpt-5.6-terra": CuratedAiModelTemplate(
+        template_id="openai:gpt-5.6-terra",
+        provider="openai",
+        provider_model_id="gpt-5.6-terra",
+        label="GPT-5.6 Terra",
+        capabilities=(AI_CAPABILITY_TEXT, AI_CAPABILITY_JSON),
+    ),
+    "openai:gpt-5.6-luna": CuratedAiModelTemplate(
+        template_id="openai:gpt-5.6-luna",
+        provider="openai",
+        provider_model_id="gpt-5.6-luna",
+        label="GPT-5.6 Luna",
+        capabilities=(AI_CAPABILITY_TEXT, AI_CAPABILITY_JSON),
+    ),
     "openai:gpt-5.5": CuratedAiModelTemplate(
         template_id="openai:gpt-5.5",
         provider="openai",

--- a/apps/stylebook-ui/src/components/Layout.tsx
+++ b/apps/stylebook-ui/src/components/Layout.tsx
@@ -229,6 +229,19 @@ export default function Layout({ children, headerContent }: LayoutProps) {
     }
   }, [])
 
+  const loadStylebooks = useCallback(async () => {
+    if (orgId == null) {
+      setStylebooks([])
+      return
+    }
+    try {
+      const rows = await fetchOrganizationStylebooks(orgId)
+      setStylebooks(rows)
+    } catch (err) {
+      console.error("Failed to fetch stylebooks:", err)
+    }
+  }, [orgId])
+
   useEffect(() => {
     void loadWorkspaces()
   }, [loadWorkspaces, location.pathname])
@@ -236,6 +249,7 @@ export default function Layout({ children, headerContent }: LayoutProps) {
   useEffect(() => {
     const onChanged = () => {
       void loadWorkspaces()
+      void loadStylebooks()
     }
     window.addEventListener("agate:projects-changed", onChanged)
     window.addEventListener("agate:workspaces-changed", onChanged)
@@ -243,7 +257,7 @@ export default function Layout({ children, headerContent }: LayoutProps) {
       window.removeEventListener("agate:projects-changed", onChanged)
       window.removeEventListener("agate:workspaces-changed", onChanged)
     }
-  }, [loadWorkspaces])
+  }, [loadWorkspaces, loadStylebooks])
 
   useEffect(() => {
     void fetchMe()
@@ -254,11 +268,8 @@ export default function Layout({ children, headerContent }: LayoutProps) {
   }, [])
 
   useEffect(() => {
-    if (orgId == null) return
-    void fetchOrganizationStylebooks(orgId)
-      .then(setStylebooks)
-      .catch((err) => console.error("Failed to fetch stylebooks:", err))
-  }, [orgId])
+    void loadStylebooks()
+  }, [loadStylebooks])
 
   /** Every stylebook catalog URL keeps workflow project scope in the query (``project_scope=``). */
   useEffect(() => {

--- a/docs/development/local-setup.md
+++ b/docs/development/local-setup.md
@@ -7,10 +7,11 @@ This checkout is for **local development and source inspection**. Published Comp
 
 Install:
 
-- Python 3.11
+- Python 3.11+
 - [uv](https://docs.astral.sh/uv/)
 - Docker Engine with Compose v2
 - Node.js 20 when building or typechecking the UIs outside Docker
+- On macOS hosts: a recent Rust toolchain (`rustc` ≥ 1.86 via [rustup](https://rustup.rs/)) so `uv sync` can build LiteLLM from source (PyPI ships Linux/Windows wheels only for current LiteLLM releases)
 
 Run commands from the repository root.
 

--- a/packages/backfield-ai/pyproject.toml
+++ b/packages/backfield-ai/pyproject.toml
@@ -9,7 +9,7 @@ classifiers = [
 ]
 dependencies = [
     "pydantic>=2.0.0",
-    "litellm>=1.55.0",
+    "litellm>=1.93.0",
     "backfield-db",
     "backfield-observability",
 ]

--- a/tests/core_api/test_core_api.py
+++ b/tests/core_api/test_core_api.py
@@ -880,6 +880,10 @@ def test_ai_models_catalog_org_admin_flow(
     opts = curated.json()
     ids = {o["curated_id"] for o in opts}
     assert "openai:gpt-5-nano" in ids
+    assert "openai:gpt-5.6" in ids
+    assert "openai:gpt-5.6-sol" in ids
+    assert "openai:gpt-5.6-terra" in ids
+    assert "openai:gpt-5.6-luna" in ids
     assert all("provider" in o and "capabilities" in o for o in opts)
 
     empty = client.get(f"/v1/organizations/{org_id}/ai-models")

--- a/uv.lock
+++ b/uv.lock
@@ -356,7 +356,7 @@ dependencies = [
 requires-dist = [
     { name = "backfield-db", editable = "packages/backfield-db" },
     { name = "backfield-observability", editable = "packages/backfield-observability" },
-    { name = "litellm", specifier = ">=1.55.0" },
+    { name = "litellm", specifier = ">=1.93.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
 ]
 
@@ -1716,7 +1716,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.83.14"
+version = "1.94.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1732,9 +1732,20 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8d/7c/c095649380adc96c8630273c1768c2ad1e74aa2ee1dd8dd05d218a60569f/litellm-1.83.14.tar.gz", hash = "sha256:24aef9b47cdc424c833e32f3727f411741c690832cd1fe4405e0077144fe09c9", size = 14836599, upload-time = "2026-04-26T03:16:10.176Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/74/074301e709bcaad5d81cb057886d16465a2dbf9a1537d6e5af5cffc5b944/litellm-1.94.0.tar.gz", hash = "sha256:12dc4f39a0d82f91cf30a6bce439b457bdff52e694ce87094878e6d521b6e4f5", size = 16266278, upload-time = "2026-07-28T20:21:51.146Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/5c/1b5691575420135e90578543b2bf219497caa33cfd0af64cb38f30288450/litellm-1.83.14-py3-none-any.whl", hash = "sha256:92b11ba2a32cf80707ddf388d18526696c7999a21b418c5e3b6eda1243d2cfdb", size = 16457054, upload-time = "2026-04-26T03:16:05.72Z" },
+    { url = "https://files.pythonhosted.org/packages/58/05/5823bf524cc8c31b9fd95591a4b92517bb9b8991e9362e7dcd98982d3a07/litellm-1.94.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:18dd2f06259f1d1cfb2182fe4de7cfa144ce55773d87808bd2ce7189f0b90616", size = 20685787, upload-time = "2026-07-28T20:21:20.778Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/b6/4da45a08fd9711648ff1ec8e5b3dadff192d259fa757be59a3160b0eb991/litellm-1.94.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:3271146afe729c95ed83f745de1dff3423a9f28f8c99f666c37b56aed976b336", size = 20673679, upload-time = "2026-07-28T20:21:23.362Z" },
+    { url = "https://files.pythonhosted.org/packages/72/1b/2b99bb3f207139250893db6e87bb2b1bc4217d60637c7d13b6a527f76f68/litellm-1.94.0-cp311-cp311-win_amd64.whl", hash = "sha256:9ddc7f1d9193622f47b6e800045926f86f7ebaeca4215a34c86e3a4154eb790d", size = 20274502, upload-time = "2026-07-28T20:21:25.71Z" },
+    { url = "https://files.pythonhosted.org/packages/25/60/d3961c7366cb1ae503113cb2ea759c3719483b8ce57f0314e040ccbd1296/litellm-1.94.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:078b66ab2727dbd5fae013f146a08fe1614421fbd3234a5fb6028e3c263ffa27", size = 20681671, upload-time = "2026-07-28T20:21:28.003Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/7b/18c36457f82e9ce10dbdc560f79da84afc11c20697e289b939db211e86d1/litellm-1.94.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:205d6ef259391d5b5076e82b2a8a30c63050611e584f7c2d516ff89cf408c6bb", size = 20664567, upload-time = "2026-07-28T20:21:31.064Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/30/f68bc8675eeae77c7ede7fa5d6528d865c3a6e3be054f1c0be963ceb704c/litellm-1.94.0-cp312-cp312-win_amd64.whl", hash = "sha256:bf648a12004d183d79461b980402c6c36ba39ca0029c7cd3775d5b6ac20e8947", size = 20268587, upload-time = "2026-07-28T20:21:33.536Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/e8/57da5e96ca050df18939205e4ee002b980d8d60fae1a94d63db89abd67a9/litellm-1.94.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:c7ea7b8a0ae43dab9c099da352bfaf43f7ec64a1c5c2b52b66b2ac75837a8e86", size = 20682372, upload-time = "2026-07-28T20:21:36.044Z" },
+    { url = "https://files.pythonhosted.org/packages/22/da/0282d815b7a329e0b35e008381c0f9ff8494b2174bd2ad600ba54b05a65c/litellm-1.94.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:a3fc60884d06607664b9eae39347f3e125744cbca92814a2f33a4d27204eda82", size = 20665506, upload-time = "2026-07-28T20:21:38.754Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/2e/b0506b0308b36b41fda0a195e07a2202541cd9c71750d75653e6149bfc34/litellm-1.94.0-cp313-cp313-win_amd64.whl", hash = "sha256:dd05c0dee67325f5a580e2adc43fbe21c0ab8b2f2641991b33d096f10fe8c665", size = 20268579, upload-time = "2026-07-28T20:21:41.401Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/72/95b02787b339df2b3a1d7abb95d670250845205cc523f47f1c54cd1dff7d/litellm-1.94.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:cb820276c4ddd0fdc1232bc9ce55165e5baade4854218e36206568e5cf4af24c", size = 20680792, upload-time = "2026-07-28T20:21:43.756Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/fa/9988351539f7b96a76cbe27bdf8cc3aa5bf30b94c34cddae54114c434b54/litellm-1.94.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:3858e8c1a08b7400dcf105030cb84753fee2acfe7d10b01f1a450dd4576eea22", size = 20671329, upload-time = "2026-07-28T20:21:46.356Z" },
+    { url = "https://files.pythonhosted.org/packages/48/8e/71147c4f78ef8b0e46b585e7c3baa1bb635e79ff188a60feec2e0eaea6ba/litellm-1.94.0-cp314-cp314-win_amd64.whl", hash = "sha256:430127afdb317b98e2f3e4fab1c857fd72117292b5edd7d655e1aae51f213ef6", size = 20270705, upload-time = "2026-07-28T20:21:48.675Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Bump LiteLLM from 1.83.14 to 1.94.0 and raise the floor to `>=1.93.0` so GPT-5.6 pricing/metadata and routing stay current.
- Add curated OpenAI presets for GPT-5.6 (default, Sol, Terra, Luna) in the org AI model catalog.
- Refetch stylebook catalogs in the Agate and Stylebook left rails when `agate:workspaces-changed` / `agate:projects-changed` fires, so create/rename updates the rail without a full page reload.
- Document the macOS `rustc` ≥ 1.86 requirement for building LiteLLM from source (PyPI wheels are Linux/Windows only for current releases).

## Project scope check

- [x] This change targets local development / source inspection (production self-hosting is unsupported in this repo)
- [x] Docs under `docs/` updated if behavior, architecture, or operations changed
- [x] First-admin provisioning still uses `backfield init` / `backfield seed` only (no HTTP/env bootstrap paths)

## Test plan

- [x] `make lint`
- [x] `make test`
- [ ] `make ui-typecheck ui-test` (if UI/TypeScript changed)
- [ ] `make smoke-fast` (if live-stack behavior changed)
- [ ] `make smoke` (if golden-path / provider-dependent runtime changed; configure **Settings → AI models**)
- [ ] On Agate **Settings → Stylebooks**, create and rename a stylebook and confirm the left-rail Stylebook section updates without refresh
- [ ] Confirm GPT-5.6 presets appear under curated options / Settings → AI models after deploy

## Notes for reviewers

- Existing org catalogs are not auto-seeded with the new presets; admins still add them via curated options.
- Docker/Linux installs use prebuilt LiteLLM wheels; only macOS host `uv sync` needs a recent Rust toolchain.
- Stylebook rail refresh piggybacks on the existing `agate:workspaces-changed` notify from ManageCatalogs (no new event).


Made with [Cursor](https://cursor.com)