### PR TITLE
Scope S3 ingestion ledger reads by project

### DIFF
--- a/apps/worker/src/worker/s3_ingestion_ledger.py
+++ b/apps/worker/src/worker/s3_ingestion_ledger.py
@@ -67,6 +67,7 @@ def _set_first_s3_input_source_id(spec_json: str, source_id: str) -> str:
 def find_succeeded_matching_metadata(
     session: Session,
     *,
+    project_id: int,
     source_id: str,
     item_id: str,
     listing: S3ObjectListing,
@@ -74,6 +75,7 @@ def find_succeeded_matching_metadata(
     rows = list(
         session.exec(
             select(AgateS3IngestionLedger).where(
+                AgateS3IngestionLedger.project_id == project_id,
                 AgateS3IngestionLedger.source_id == source_id,
                 AgateS3IngestionLedger.logical_item_id == item_id,
                 AgateS3IngestionLedger.status == LEDGER_STATUS_SUCCEEDED,
@@ -94,12 +96,14 @@ def find_succeeded_matching_metadata(
 def find_row_for_fingerprint(
     session: Session,
     *,
+    project_id: int,
     source_id: str,
     item_id: str,
     content_fingerprint: str,
 ) -> AgateS3IngestionLedger | None:
     return session.exec(
         select(AgateS3IngestionLedger).where(
+            AgateS3IngestionLedger.project_id == project_id,
             AgateS3IngestionLedger.source_id == source_id,
             AgateS3IngestionLedger.logical_item_id == item_id,
             AgateS3IngestionLedger.content_fingerprint == content_fingerprint,
@@ -130,6 +134,7 @@ def claim_ledger_revision(
 
     existing = find_row_for_fingerprint(
         session,
+        project_id=project_id,
         source_id=source_id,
         item_id=item_id,
         content_fingerprint=content_fingerprint,
@@ -184,6 +189,7 @@ def claim_ledger_revision(
     observed_status = existing.status
     reclaim_filter = [
         AgateS3IngestionLedger.id == existing.id,
+        AgateS3IngestionLedger.project_id == project_id,
         AgateS3IngestionLedger.status == observed_status,
     ]
     if observed_status == LEDGER_STATUS_PROCESSING:
@@ -220,6 +226,7 @@ def claim_ledger_revision(
 def attach_processed_item(
     session: Session,
     *,
+    project_id: int,
     ledger_id: str,
     claim_token: str,
     processed_item_id: int,
@@ -228,6 +235,7 @@ def attach_processed_item(
         update(AgateS3IngestionLedger)
         .where(
             AgateS3IngestionLedger.id == ledger_id,
+            AgateS3IngestionLedger.project_id == project_id,
             AgateS3IngestionLedger.claim_token == claim_token,
             AgateS3IngestionLedger.status == LEDGER_STATUS_PROCESSING,
         )

--- a/apps/worker/src/worker/tasks.py
+++ b/apps/worker/src/worker/tasks.py
@@ -945,6 +945,7 @@ def execute_s3_batch_setup(run_id: str) -> None:
 
                     if not reprocess_unchanged and find_succeeded_matching_metadata(
                         session,
+                        project_id=project_id,
                         source_id=source_id,
                         item_id=item_logical_id,
                         listing=listing,
@@ -977,6 +978,7 @@ def execute_s3_batch_setup(run_id: str) -> None:
                     fingerprint = sha256_hex(raw_bytes)
                     existing_fp = find_row_for_fingerprint(
                         session,
+                        project_id=project_id,
                         source_id=source_id,
                         item_id=item_logical_id,
                         content_fingerprint=fingerprint,
@@ -1036,6 +1038,7 @@ def execute_s3_batch_setup(run_id: str) -> None:
                         continue
                     attach_processed_item(
                         session,
+                        project_id=project_id,
                         ledger_id=claim.ledger_id,
                         claim_token=claim.claim_token,
                         processed_item_id=int(row.id),

--- a/tests/worker/test_s3_ingestion_ledger.py
+++ b/tests/worker/test_s3_ingestion_ledger.py
@@ -24,6 +24,8 @@ from worker import tasks as worker_tasks
 from worker.s3_ingestion_ledger import (
     S3_INGESTION_EXTERNAL_SOURCE,
     claim_ledger_revision,
+    find_row_for_fingerprint,
+    find_succeeded_matching_metadata,
     mark_ledger_succeeded,
 )
 from worker.substrate.content.article import _upsert_article
@@ -175,6 +177,83 @@ def test_first_scan_processes_second_unchanged_skips(ledger_engine, monkeypatch)
         assert summary["s3_batch"]["skipped_unchanged"] == 1
         assert summary["s3_batch"]["valid_executed"] == 0
         assert len(session.exec(select(AgateS3IngestionLedger)).all()) == 1
+
+
+def test_ledger_identity_lookups_are_project_scoped(ledger_engine):
+    engine, _graph_id, project_id = ledger_engine
+    listing = S3ObjectListing(
+        key="p/good.json",
+        etag='"v1"',
+        size_bytes=10,
+        last_modified=datetime(2024, 1, 1),
+    )
+    with Session(engine) as session:
+        project = session.get(BackfieldProject, project_id)
+        assert project is not None
+        other_project = BackfieldProject(
+            organization_id=int(project.organization_id),
+            name="Other",
+            slug="other-ledger-project",
+        )
+        session.add(other_project)
+        session.flush()
+        other_project_id = int(other_project.id)  # type: ignore[arg-type]
+        row = AgateS3IngestionLedger(
+            project_id=project_id,
+            source_id="shared-source",
+            logical_item_id="my-bucket/p/good.json",
+            bucket="my-bucket",
+            key="p/good.json",
+            content_fingerprint="shared-fingerprint",
+            etag="v1",
+            size_bytes=10,
+            last_modified=datetime(2024, 1, 1, tzinfo=UTC),
+            status="succeeded",
+            attempt_count=1,
+        )
+        session.add(row)
+        session.commit()
+
+        assert (
+            find_succeeded_matching_metadata(
+                session,
+                project_id=project_id,
+                source_id="shared-source",
+                item_id="my-bucket/p/good.json",
+                listing=listing,
+            )
+            is not None
+        )
+        assert (
+            find_row_for_fingerprint(
+                session,
+                project_id=project_id,
+                source_id="shared-source",
+                item_id="my-bucket/p/good.json",
+                content_fingerprint="shared-fingerprint",
+            )
+            is not None
+        )
+        assert (
+            find_succeeded_matching_metadata(
+                session,
+                project_id=other_project_id,
+                source_id="shared-source",
+                item_id="my-bucket/p/good.json",
+                listing=listing,
+            )
+            is None
+        )
+        assert (
+            find_row_for_fingerprint(
+                session,
+                project_id=other_project_id,
+                source_id="shared-source",
+                item_id="my-bucket/p/good.json",
+                content_fingerprint="shared-fingerprint",
+            )
+            is None
+        )
 
 
 def test_changed_contents_start_new_revision(ledger_engine, monkeypatch):


### PR DESCRIPTION
## Summary
- scope metadata and fingerprint lookups to the active project
- include project identity in reclaim and processed-item attachment updates
- add regression coverage for cross-project source identity reuse

This is the expand phase of the S3 ledger isolation rollout. The existing global uniqueness constraint remains until these readers are deployed and old workers are drained.

## Test plan
- [x] `make lint`
- [x] `make test`
- [x] `uv run pytest tests/worker/test_s3_ingestion_ledger.py`

Made with [Cursor](https://cursor.com)