### PR TITLE
Scope S3 ingestion ledger identities by project

### DIFF
--- a/docs/architecture/database.md
+++ b/docs/architecture/database.md
@@ -43,9 +43,9 @@ All schema changes use the single Alembic chain under `packages/backfield-db/ale
 - `agate_processed_item` stores per-document input, immutable model result, review overlay,
   reviewed output, status, article provenance, and an optional link to an S3 ingestion ledger
   revision (`ingestion_ledger_id`).
-- `agate_s3_ingestion_ledger` stores cross-run S3 Input object revisions keyed by
-  `source_id` + `logical_item_id` + `content_fingerprint`, with claim/lease state so unchanged
-  objects are skipped and failed or abandoned claims can retry.
+- `agate_s3_ingestion_ledger` stores cross-run S3 Input object revisions keyed by project,
+  `source_id`, `logical_item_id`, and `content_fingerprint`, with claim/lease state so unchanged
+  objects are skipped within a project and failed or abandoned claims can retry.
 - `agate_node_timing` stores per-node wall-clock measurements for processed items.
 
 ### Substrate content and entities

--- a/docs/operations/migrations.md
+++ b/docs/operations/migrations.md
@@ -43,6 +43,10 @@ Back up production data before applying schema changes and verify the current
 
 ## Active upgrade warnings
 
+- The project-scoped S3 ingestion ledger migration (`068_s3_ledger_project_scope`) permits
+  otherwise-identical revisions in different projects. After such rows exist, downgrading to
+  `067_s3_ingestion_ledger` cannot restore the former global uniqueness constraint without
+  manually reconciling those rows. Prefer forward repair after deployment.
 - The location-canonical UUID migration (`019_sb_loc_canon_uuid`) drops and recreates location
   canonical-linked tables and does not preserve their rows. A database whose current revision is
   before this migration must not be upgraded in place when that catalog data matters. Rebuild a

--- a/packages/backfield-db/alembic/versions/068_s3_ledger_project_scope.py
+++ b/packages/backfield-db/alembic/versions/068_s3_ledger_project_scope.py
@@ -1,0 +1,58 @@
+"""Scope S3 ingestion ledger identities to projects."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "068_s3_ledger_project_scope"
+down_revision: str | None = "067_s3_ingestion_ledger"
+branch_labels: Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.drop_constraint(
+        "uq_agate_s3_ingestion_ledger_revision",
+        "agate_s3_ingestion_ledger",
+        type_="unique",
+    )
+    op.create_unique_constraint(
+        "uq_agate_s3_ingestion_ledger_revision",
+        "agate_s3_ingestion_ledger",
+        ["project_id", "source_id", "logical_item_id", "content_fingerprint"],
+    )
+    op.drop_index(
+        "ix_agate_s3_ingestion_ledger_source_item",
+        table_name="agate_s3_ingestion_ledger",
+    )
+    op.create_index(
+        "ix_agate_s3_ingestion_ledger_source_item",
+        "agate_s3_ingestion_ledger",
+        ["project_id", "source_id", "logical_item_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_agate_s3_ingestion_ledger_source_item",
+        table_name="agate_s3_ingestion_ledger",
+    )
+    op.create_index(
+        "ix_agate_s3_ingestion_ledger_source_item",
+        "agate_s3_ingestion_ledger",
+        ["source_id", "logical_item_id"],
+        unique=False,
+    )
+    op.drop_constraint(
+        "uq_agate_s3_ingestion_ledger_revision",
+        "agate_s3_ingestion_ledger",
+        type_="unique",
+    )
+    op.create_unique_constraint(
+        "uq_agate_s3_ingestion_ledger_revision",
+        "agate_s3_ingestion_ledger",
+        ["source_id", "logical_item_id", "content_fingerprint"],
+    )

--- a/packages/backfield-db/src/backfield_db/models.py
+++ b/packages/backfield-db/src/backfield_db/models.py
@@ -2096,12 +2096,18 @@ class AgateS3IngestionLedger(SQLModel, table=True):
     __tablename__ = "agate_s3_ingestion_ledger"
     __table_args__ = (
         UniqueConstraint(
+            "project_id",
             "source_id",
             "logical_item_id",
             "content_fingerprint",
             name="uq_agate_s3_ingestion_ledger_revision",
         ),
-        Index("ix_agate_s3_ingestion_ledger_source_item", "source_id", "logical_item_id"),
+        Index(
+            "ix_agate_s3_ingestion_ledger_source_item",
+            "project_id",
+            "source_id",
+            "logical_item_id",
+        ),
         Index("ix_agate_s3_ingestion_ledger_status_lease", "status", "lease_expires_at"),
         Index("ix_agate_s3_ingestion_ledger_project", "project_id"),
     )

--- a/tests/worker/test_s3_ingestion_ledger.py
+++ b/tests/worker/test_s3_ingestion_ledger.py
@@ -256,6 +256,49 @@ def test_ledger_identity_lookups_are_project_scoped(ledger_engine):
         )
 
 
+def test_identical_revisions_are_processed_independently_by_project(ledger_engine, monkeypatch):
+    engine, graph_id, project_id = ledger_engine
+    s3 = _MutableS3()
+    first_run_id = _run_setup(engine, graph_id, s3, monkeypatch)
+
+    with Session(engine) as session:
+        project = session.get(BackfieldProject, project_id)
+        assert project is not None
+        other_project = BackfieldProject(
+            organization_id=int(project.organization_id),
+            name="Other",
+            slug="other-ledger-project",
+        )
+        session.add(other_project)
+        session.flush()
+        other_project_id = int(other_project.id)  # type: ignore[arg-type]
+        other_graph = AgateGraph(
+            name="Other graph",
+            spec_json=_spec("src-fixed"),
+            project_id=other_project_id,
+        )
+        session.add(other_graph)
+        session.commit()
+        session.refresh(other_graph)
+        other_graph_id = str(other_graph.id)
+
+    second_run_id = _run_setup(engine, other_graph_id, s3, monkeypatch)
+
+    with Session(engine) as session:
+        first_items = session.exec(
+            select(AgateProcessedItem).where(AgateProcessedItem.run_id == first_run_id)
+        ).all()
+        second_items = session.exec(
+            select(AgateProcessedItem).where(AgateProcessedItem.run_id == second_run_id)
+        ).all()
+        ledgers = session.exec(select(AgateS3IngestionLedger)).all()
+
+        assert len(first_items) == 1
+        assert len(second_items) == 1
+        assert len(ledgers) == 2
+        assert {row.project_id for row in ledgers} == {project_id, other_project_id}
+
+
 def test_changed_contents_start_new_revision(ledger_engine, monkeypatch):
     engine, graph_id, _pid = ledger_engine
     s3 = _MutableS3()


### PR DESCRIPTION
## Summary
- replace global S3 revision uniqueness with project-scoped uniqueness
- add project identity to the source-item lookup index
- document downgrade constraints and verify identical revisions process independently across projects

This is the contract phase after #115. Merge and deploy only after project-scoped readers are live and old workers are drained.

## Test plan
- [x] `make lint`
- [x] `make test`
- [x] `uv run pytest tests/worker/test_s3_ingestion_ledger.py`
- [x] `uv run pytest packages/backfield-db/tests/test_migrate.py`

Made with [Cursor](https://cursor.com)