### PR TITLE
Establish project Stylebook ownership

### DIFF
--- a/apps/agate-api/src/api/routers/projects.py
+++ b/apps/agate-api/src/api/routers/projects.py
@@ -20,13 +20,13 @@ from backfield_db import (
     AgateProcessedItem,
     AgateRun,
     BackfieldAiCallRecord,
-    BackfieldOrganization,
     BackfieldProject,
     BackfieldProjectSecret,
     BackfieldWorkspace,
     Stylebook,
 )
 from backfield_db.crypto import encrypt_secret, fernet_from_env
+from backfield_entities.catalog.resolve import resolve_stylebook_id_for_project_id
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 from sqlalchemy import case, func, or_
@@ -75,7 +75,7 @@ def _set_system_prompt(project: BackfieldProject, value: str | None) -> None:
 class ProjectCreate(BaseModel):
     name: str
     slug: str | None = None
-    workspace_id: int | None = None
+    workspace_id: int
 
 
 class ProjectUpdate(BaseModel):
@@ -93,27 +93,28 @@ class ProjectOut(BaseModel):
     created_at: datetime
     updated_at: datetime
     workspace_id: int | None = None
+    stylebook_id: int | None = None
+    stylebook_name: str | None = None
+    stylebook_slug: str | None = None
     workspace_stylebook_id: int | None = None
     workspace_stylebook_name: str | None = None
     workspace_stylebook_slug: str | None = None
 
 
 def _project_to_out(session: Session, p: BackfieldProject) -> ProjectOut:
-    wid = int(p.workspace_id) if p.workspace_id is not None else None
-    sid: int | None = None
-    sname: str | None = None
-    sslug: str | None = None
-    if wid is not None:
-        ws = session.get(BackfieldWorkspace, wid)
-        if ws is not None and ws.stylebook_id is not None:
-            sb = session.get(Stylebook, int(ws.stylebook_id))
-            if sb is not None and sb.id is not None:
-                sid = int(sb.id)
-                sname = str(sb.name)
-                sslug = str(sb.slug)
-    d = _settings_dict(p)
     if p.id is None:
         raise HTTPException(500, "Project row missing id")
+    try:
+        sid = resolve_stylebook_id_for_project_id(session, int(p.id))
+    except LookupError:
+        sid = None
+    except ValueError as error:
+        raise HTTPException(500, "Invalid project Stylebook ownership") from error
+    stylebook = session.get(Stylebook, sid) if sid is not None else None
+    sname = str(stylebook.name) if stylebook is not None else None
+    sslug = str(stylebook.slug) if stylebook is not None else None
+    wid = int(p.workspace_id) if p.workspace_id is not None else None
+    d = _settings_dict(p)
     return ProjectOut(
         id=int(p.id),
         name=p.name,
@@ -123,6 +124,9 @@ def _project_to_out(session: Session, p: BackfieldProject) -> ProjectOut:
         created_at=p.created_at,
         updated_at=p.updated_at,
         workspace_id=wid,
+        stylebook_id=sid,
+        stylebook_name=sname,
+        stylebook_slug=sslug,
         workspace_stylebook_id=sid,
         workspace_stylebook_name=sname,
         workspace_stylebook_slug=sslug,
@@ -151,31 +155,6 @@ def list_projects(
     return [_project_to_out(session, r) for r in rows if r.id is not None]
 
 
-def _default_organization_id(session: Session) -> int:
-    """Fallback org for unscoped creates (service tokens / legacy no-workspace path)."""
-    org = session.exec(
-        select(BackfieldOrganization).where(BackfieldOrganization.slug == "default")
-    ).first()
-    if org is None or org.id is None:
-        raise HTTPException(500, "Default organization missing; run migrations")
-    return int(org.id)
-
-
-def _organization_id_for_unscoped_create(session: Session, auth: dict[str, Any]) -> int:
-    """Resolve org when ``workspace_id`` is omitted.
-
-    Session creates use the session's organization. Service tokens (and any other
-    unscoped callers) fall back to the seeded ``default`` organization.
-    """
-    if auth["type"] == "session" and auth.get("organization_id") is not None:
-        organization_id = int(auth["organization_id"])
-        org = session.get(BackfieldOrganization, organization_id)
-        if org is None or org.id is None:
-            raise HTTPException(400, "Organization not found")
-        return int(org.id)
-    return _default_organization_id(session)
-
-
 @router.post("", response_model=ProjectOut)
 def create_project(
     body: ProjectCreate,
@@ -189,27 +168,24 @@ def create_project(
     if existing:
         raise HTTPException(409, "Slug already exists")
 
-    workspace_id: int | None = None
-    if body.workspace_id is not None:
-        ws = session.get(BackfieldWorkspace, int(body.workspace_id))
-        if ws is None or ws.id is None:
-            raise HTTPException(400, "Workspace not found")
-        workspace_id = int(ws.id)
-        organization_id = int(ws.organization_id)
-        require_session_may_assign_project_to_workspace(
-            session,
-            auth,
-            workspace_id=workspace_id,
-            organization_id=organization_id,
-        )
-    else:
-        organization_id = _organization_id_for_unscoped_create(session, auth)
+    ws = session.get(BackfieldWorkspace, int(body.workspace_id))
+    if ws is None or ws.id is None:
+        raise HTTPException(400, "Workspace not found")
+    workspace_id = int(ws.id)
+    organization_id = int(ws.organization_id)
+    require_session_may_assign_project_to_workspace(
+        session,
+        auth,
+        workspace_id=workspace_id,
+        organization_id=organization_id,
+    )
 
     p = BackfieldProject(
         organization_id=organization_id,
         name=body.name.strip(),
         slug=slug,
         workspace_id=workspace_id,
+        stylebook_id=int(ws.stylebook_id),
     )
     session.add(p)
     session.commit()

--- a/apps/agate-ui/src/components/ProjectDialog.tsx
+++ b/apps/agate-ui/src/components/ProjectDialog.tsx
@@ -94,6 +94,7 @@ export default function ProjectDialog({
           : NaN
       const wid =
         widLocked ?? (Number.isFinite(widSelect) ? widSelect : null)
+      if (wid == null) return
       await onSave({ name: name.trim(), workspace_id: wid })
       onOpenChange(false)
       setName('')

--- a/apps/agate-ui/src/lib/api.ts
+++ b/apps/agate-ui/src/lib/api.ts
@@ -51,6 +51,9 @@ export interface Project {
   created_at: string
   updated_at?: string
   workspace_id?: number | null
+  stylebook_id?: number | null
+  stylebook_name?: string | null
+  stylebook_slug?: string | null
   workspace_stylebook_id?: number | null
   workspace_stylebook_name?: string | null
   /** Stable catalog slug for Stylebook UI routes when the workspace resolves a Stylebook. */
@@ -294,7 +297,7 @@ export interface RunCreate {
 export interface ProjectCreate {
   name: string
   slug?: string
-  workspace_id?: number | null
+  workspace_id: number
 }
 
 export interface ProjectUpdate {
@@ -1168,7 +1171,7 @@ export async function createProject(data: ProjectCreate): Promise<Project> {
     body: JSON.stringify({
       name: data.name,
       slug: data.slug,
-      workspace_id: data.workspace_id ?? null,
+      workspace_id: data.workspace_id,
     }),
   }) as Promise<Project>
 }

--- a/docs/api/agate.md
+++ b/docs/api/agate.md
@@ -23,13 +23,17 @@ Project, flow, and run access is checked against the resource's project. Organiz
 `/projects` owns project creation, listing, detail, updates, deletion, statistics, tracked AI cost, and encrypted project secrets.
 
 - List responses are filtered to visible projects.
-- When `workspace_id` is provided, the project inherits that workspace's `organization_id`.
-  Session users must belong to that organization; members need workspace membership, and
-  org admins may assign any workspace in their org. API keys cannot create projects.
-- When `workspace_id` is omitted (legacy / service / scripts), session creates use the
-  session's organization; service tokens fall back to the seeded `default` organization.
+- Project creation requires `workspace_id` and copies that workspace's Stylebook into the
+  project's direct ownership field. Session users must belong to the workspace organization;
+  members need workspace membership, and org admins may assign any workspace in their org.
+  The required workspace is the explicit organization context for service-token callers; the
+  endpoint never falls back to a default organization. API keys cannot create projects.
 - Secret responses contain metadata, never secret values.
-- Project responses expose the assigned workspace and effective workspace Stylebook context when available.
+- Project responses expose direct `stylebook_id`, `stylebook_name`, and `stylebook_slug` fields
+  while retaining the `workspace_stylebook_*` response fields for compatibility. During rollout,
+  reads resolve the direct project Stylebook first, then the workspace Stylebook, then the
+  organization default (or first catalog by id for a legacy organization with no marked default).
+  A later workspace Stylebook change does not alter existing projects.
 
 ### Flows and templates
 

--- a/docs/architecture/canonicalization.md
+++ b/docs/architecture/canonicalization.md
@@ -125,10 +125,12 @@ Catalog selection follows one current rule:
 
 1. An explicit Stylebook row id, validated against the project's organization.
 2. A supplied Stylebook slug, including slug redirects.
-3. The organization's default Stylebook, falling back to the first catalog by id when no row is
+3. The project's direct Stylebook ownership.
+4. The project's workspace Stylebook during the rolling-compatibility window.
+5. The organization's default Stylebook, falling back to the first catalog by id when no row is
    marked default.
 
-Backfield Output uses explicit id or organization default. Stylebook routes can use slug or
-organization default. GeocodeAgent does not use this fallback: its project-scoped substrate cache
-works without a Stylebook id, while canonical lookup, adjudication, and materialization require
-the node's explicit Stylebook id.
+Backfield Output uses an explicit id or the project ownership chain. Stylebook routes can use a
+slug or that same ownership chain. GeocodeAgent does not use this fallback: its project-scoped
+substrate cache works without a Stylebook id, while canonical lookup, adjudication, and
+materialization require the node's explicit Stylebook id.

--- a/docs/architecture/database.md
+++ b/docs/architecture/database.md
@@ -22,6 +22,9 @@ All schema changes use the single Alembic chain under `packages/backfield-db/ale
 
 - Organizations, workspaces, projects, and users:
   `backfield_organization`, `backfield_workspace`, `backfield_project`, `backfield_user`.
+  Projects store both their workspace and a direct Stylebook ownership reference. The direct
+  reference is nullable during rollout, indexed for project-to-catalog joins, and is copied from
+  the selected workspace when a project is created.
 - Access grants and API keys: `backfield_organization_membership`,
   `backfield_workspace_membership`, `backfield_project_membership`,
   `backfield_api_credential`.
@@ -89,12 +92,14 @@ shared entity rows are not trusted because sibling batch items may reuse the sam
   `stylebook_candidate_ai_review`.
 
 Canonical ids are UUID strings. Canonical slugs are unique within a Stylebook, and aliases are
-unique by canonical plus normalized alias. A Stylebook belongs to one organization; projects use
-an explicit same-organization Stylebook or the organization's default.
+unique by canonical plus normalized alias. A Stylebook belongs to one organization. Catalog reads
+prefer the project's direct Stylebook, then its workspace Stylebook for rolling compatibility,
+then the organization's default. Changing a workspace's Stylebook affects future project creation
+but does not rewrite existing project ownership.
 
-Deleting a Stylebook reassigns workspaces and graph Stylebook refs, resets linked substrate rows
-to pending, removes non-cascading dependents (activity, bundle jobs, cleanup and candidate AI
-review rows), and deletes canonical trees before the catalog row itself.
+Deleting a Stylebook reassigns projects, workspaces, and graph Stylebook refs, resets linked
+substrate rows to pending, removes non-cascading dependents (activity, bundle jobs, cleanup and
+candidate AI review rows), and deletes canonical trees before the catalog row itself.
 
 ## Shared entity field contracts
 

--- a/docs/operations/migrations.md
+++ b/docs/operations/migrations.md
@@ -3,6 +3,24 @@
 Backfield has one Alembic chain in `packages/backfield-db/alembic`. Run it once as a standalone
 operation; API and worker processes do not migrate on startup.
 
+## Tenancy preflight
+
+Before applying organization-tenancy migrations to retained data, run the read-only audit:
+
+```bash
+backfield tenancy-audit --json
+```
+
+The command supports databases before the additive project `stylebook_id` column exists, emits a
+typed JSON report, and exits `1` when it finds blockers. It checks orphaned projects;
+project/workspace and workspace/Stylebook organization mismatches; unresolved or
+cross-organization direct project Stylebooks; conflicting or multi-Stylebook graph node
+references; linked location, person, and organization canonicals from another Stylebook; and
+duplicate project slugs within an organization. The audit does not create workspaces, rewrite
+projects or graphs, or change canonical links. Canonical-link mismatches are aggregated by
+project, entity type, expected Stylebook, and actual Stylebook, with an affected count and a
+five-id sample so large datasets still produce practical reports.
+
 ## Local workflow
 
 With the Compose stack configuration:

--- a/packages/backfield-cli/src/backfield_cli/console.py
+++ b/packages/backfield-cli/src/backfield_cli/console.py
@@ -38,6 +38,7 @@ CLI_COMMANDS: tuple[tuple[str, str], ...] = (
     ("backfield ps", "List running containers"),
     ("backfield restart", "Restart services"),
     ("backfield doctor", "Check your local setup"),
+    ("backfield tenancy-audit --json", "Report tenancy migration blockers"),
     ("backfield migrate", "Apply database migrations"),
     ("backfield seed", "Ensure org and admin user exist"),
     ("backfield reset-db", "Wipe local database and volumes"),

--- a/packages/backfield-cli/src/backfield_cli/main.py
+++ b/packages/backfield-cli/src/backfield_cli/main.py
@@ -10,6 +10,7 @@ from backfield_cli import init as init_cmd
 from backfield_cli import migrate as migrate_cmd
 from backfield_cli import seed as seed_cmd
 from backfield_cli import stack_cmd
+from backfield_cli import tenancy_audit as tenancy_audit_cmd
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -19,6 +20,7 @@ def main(argv: list[str] | None = None) -> int:
     seed_cmd.register_subcommand(subparsers)
     init_cmd.register_subcommand(subparsers)
     doctor_cmd.register_subcommand(subparsers)
+    tenancy_audit_cmd.register_subcommand(subparsers)
     stack_cmd.register_subcommands(subparsers)
     args = parser.parse_args(argv)
     handler = getattr(args, "handler", None)

--- a/packages/backfield-cli/src/backfield_cli/tenancy_audit.py
+++ b/packages/backfield-cli/src/backfield_cli/tenancy_audit.py
@@ -1,0 +1,46 @@
+"""Read-only organization tenancy preflight command."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+
+from backfield_db.session import get_engine
+from backfield_db.tenancy_audit import audit_tenancy
+from sqlmodel import Session
+
+from backfield_cli.console import CONSOLE
+
+logger = logging.getLogger(__name__)
+
+
+def register_subcommand(subparsers) -> None:
+    parser = subparsers.add_parser(
+        "tenancy-audit",
+        help="Report project workspace and Stylebook migration blockers",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print the typed audit report as JSON",
+    )
+    parser.set_defaults(handler=_run)
+
+
+def _run(args: argparse.Namespace) -> int:
+    try:
+        with Session(get_engine()) as session:
+            report = audit_tenancy(session)
+    except Exception as error:
+        logger.error("Tenancy audit failed: %s", error)
+        return 2
+
+    if args.json:
+        print(report.to_json())
+    elif report.ok:
+        CONSOLE.print("[green]Tenancy audit passed: no blockers found.[/green]")
+    else:
+        CONSOLE.print(f"[red]Tenancy audit found {report.blocker_count} blocker(s):[/red]")
+        for blocker in report.blockers:
+            CONSOLE.print(f"  [red]{blocker.code.value}[/red] {blocker.message}")
+    return 0 if report.ok else 1

--- a/packages/backfield-cli/tests/test_cli.py
+++ b/packages/backfield-cli/tests/test_cli.py
@@ -5,6 +5,12 @@ from __future__ import annotations
 import json
 
 from backfield_cli.main import main
+from backfield_db.tenancy_audit import (
+    TenancyAuditBlocker,
+    TenancyAuditReport,
+    TenancyBlockerCode,
+)
+from sqlalchemy import create_engine
 
 
 def test_backfield_migrate_subcommand_delegates(monkeypatch) -> None:
@@ -61,3 +67,35 @@ def test_backfield_seed_subcommand_delegates(monkeypatch, capsys) -> None:
 def test_backfield_seed_subcommand_requires_password(monkeypatch) -> None:
     monkeypatch.setattr("backfield_db.seed.run_seed", lambda **_kwargs: None)
     assert main(["seed", "--admin-email", "admin@example.com"]) == 1
+
+
+def test_tenancy_audit_json_exits_nonzero_for_blockers(monkeypatch, capsys) -> None:
+    report = TenancyAuditReport(
+        ok=False,
+        blocker_count=1,
+        blockers=[
+            TenancyAuditBlocker(
+                code=TenancyBlockerCode.ORPHAN_PROJECT,
+                message="project 1 has no workspace",
+                project_id=1,
+            )
+        ],
+    )
+    monkeypatch.setattr("backfield_cli.tenancy_audit.get_engine", lambda: create_engine("sqlite://"))
+    monkeypatch.setattr("backfield_cli.tenancy_audit.audit_tenancy", lambda _session: report)
+
+    assert main(["tenancy-audit", "--json"]) == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+    assert payload["blocker_count"] == 1
+    assert payload["blockers"][0]["code"] == "orphan_project"
+
+
+def test_tenancy_audit_json_exits_zero_when_clean(monkeypatch, capsys) -> None:
+    report = TenancyAuditReport(ok=True, blocker_count=0, blockers=[])
+    monkeypatch.setattr("backfield_cli.tenancy_audit.get_engine", lambda: create_engine("sqlite://"))
+    monkeypatch.setattr("backfield_cli.tenancy_audit.audit_tenancy", lambda _session: report)
+
+    assert main(["tenancy-audit", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {"ok": True, "blocker_count": 0, "blockers": []}

--- a/packages/backfield-db/alembic/versions/069_project_stylebook_ownership.py
+++ b/packages/backfield-db/alembic/versions/069_project_stylebook_ownership.py
@@ -1,0 +1,217 @@
+"""Add direct project Stylebook ownership and backfill workspace assignments."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.engine import Connection
+
+revision: str = "069_project_stylebook_ownership"
+down_revision: str | None = "068_s3_ledger_project_scope"
+branch_labels: Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _stylebook_for_orphan_projects(conn: Connection, organization_id: int) -> int:
+    rows = conn.execute(
+        sa.text(
+            """
+            SELECT id, is_default
+            FROM stylebook
+            WHERE organization_id = :organization_id
+            ORDER BY id
+            """
+        ),
+        {"organization_id": organization_id},
+    ).fetchall()
+    defaults = [int(row[0]) for row in rows if bool(row[1])]
+    if len(defaults) == 1:
+        return defaults[0]
+    if len(defaults) > 1:
+        raise RuntimeError(
+            f"organization {organization_id} has multiple default Stylebooks"
+        )
+    if len(rows) == 1:
+        return int(rows[0][0])
+    if not rows:
+        raise RuntimeError(
+            f"organization {organization_id} has projects but no Stylebook"
+        )
+    raise RuntimeError(
+        f"organization {organization_id} has projects but no default Stylebook"
+    )
+
+
+def _general_workspace_id(
+    conn: Connection,
+    *,
+    organization_id: int,
+    stylebook_id: int,
+) -> int:
+    row = conn.execute(
+        sa.text(
+            """
+            SELECT id, stylebook_id
+            FROM backfield_workspace
+            WHERE organization_id = :organization_id AND slug = 'general'
+            """
+        ),
+        {"organization_id": organization_id},
+    ).fetchone()
+    if row is not None:
+        if int(row[1]) != stylebook_id:
+            raise RuntimeError(
+                f"organization {organization_id} General workspace does not use "
+                f"Stylebook {stylebook_id}"
+            )
+        return int(row[0])
+
+    conn.execute(
+        sa.text(
+            """
+            INSERT INTO backfield_workspace (organization_id, stylebook_id, name, slug)
+            VALUES (:organization_id, :stylebook_id, 'General', 'general')
+            """
+        ),
+        {
+            "organization_id": organization_id,
+            "stylebook_id": stylebook_id,
+        },
+    )
+    created = conn.execute(
+        sa.text(
+            """
+            SELECT id
+            FROM backfield_workspace
+            WHERE organization_id = :organization_id AND slug = 'general'
+            """
+        ),
+        {"organization_id": organization_id},
+    ).fetchone()
+    if created is None:
+        raise RuntimeError(
+            f"failed to create General workspace for organization {organization_id}"
+        )
+    return int(created[0])
+
+
+def _backfill_project_stylebooks(conn: Connection) -> None:
+    invalid = conn.execute(
+        sa.text(
+            """
+            SELECT p.id, p.organization_id, w.organization_id, s.organization_id
+            FROM backfield_project AS p
+            LEFT JOIN backfield_workspace AS w ON w.id = p.workspace_id
+            LEFT JOIN stylebook AS s ON s.id = w.stylebook_id
+            WHERE p.workspace_id IS NOT NULL
+              AND (
+                w.id IS NULL
+                OR w.organization_id <> p.organization_id
+                OR s.id IS NULL
+                OR s.organization_id <> p.organization_id
+              )
+            ORDER BY p.id
+            """
+        )
+    ).fetchone()
+    if invalid is not None:
+        raise RuntimeError(
+            f"project {int(invalid[0])} has a cross-organization or invalid "
+            "workspace/Stylebook relationship"
+        )
+
+    conn.execute(
+        sa.text(
+            """
+            UPDATE backfield_project
+            SET stylebook_id = (
+                SELECT w.stylebook_id
+                FROM backfield_workspace AS w
+                WHERE w.id = backfield_project.workspace_id
+            )
+            WHERE workspace_id IS NOT NULL
+            """
+        )
+    )
+
+    orphan_organizations = conn.execute(
+        sa.text(
+            """
+            SELECT DISTINCT organization_id
+            FROM backfield_project
+            WHERE workspace_id IS NULL
+            ORDER BY organization_id
+            """
+        )
+    ).fetchall()
+    for row in orphan_organizations:
+        organization_id = int(row[0])
+        stylebook_id = _stylebook_for_orphan_projects(conn, organization_id)
+        workspace_id = _general_workspace_id(
+            conn,
+            organization_id=organization_id,
+            stylebook_id=stylebook_id,
+        )
+        conn.execute(
+            sa.text(
+                """
+                UPDATE backfield_project
+                SET workspace_id = :workspace_id, stylebook_id = :stylebook_id
+                WHERE organization_id = :organization_id AND workspace_id IS NULL
+                """
+            ),
+            {
+                "organization_id": organization_id,
+                "workspace_id": workspace_id,
+                "stylebook_id": stylebook_id,
+            },
+        )
+
+    remaining = conn.execute(
+        sa.text(
+            """
+            SELECT id
+            FROM backfield_project
+            WHERE workspace_id IS NULL OR stylebook_id IS NULL
+            ORDER BY id
+            """
+        )
+    ).fetchone()
+    if remaining is not None:
+        raise RuntimeError(f"project {int(remaining[0])} could not be backfilled")
+
+
+def upgrade() -> None:
+    op.add_column(
+        "backfield_project",
+        sa.Column("stylebook_id", sa.Integer(), nullable=True),
+    )
+    op.create_foreign_key(
+        "backfield_project_stylebook_id_fkey",
+        "backfield_project",
+        "stylebook",
+        ["stylebook_id"],
+        ["id"],
+        ondelete="RESTRICT",
+    )
+    op.create_index(
+        "ix_backfield_project_stylebook_id",
+        "backfield_project",
+        ["stylebook_id"],
+    )
+    _backfill_project_stylebooks(op.get_bind())
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_backfield_project_stylebook_id",
+        table_name="backfield_project",
+    )
+    op.drop_constraint(
+        "backfield_project_stylebook_id_fkey",
+        "backfield_project",
+        type_="foreignkey",
+    )
+    op.drop_column("backfield_project", "stylebook_id")

--- a/packages/backfield-db/pyproject.toml
+++ b/packages/backfield-db/pyproject.toml
@@ -8,6 +8,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
+    "pydantic>=2.0.0",
     "sqlmodel>=0.0.14",
     "sqlalchemy>=2.0.0",
     "psycopg[binary]>=3.1.0",

--- a/packages/backfield-db/src/backfield_db/models.py
+++ b/packages/backfield-db/src/backfield_db/models.py
@@ -131,6 +131,11 @@ class BackfieldProject(SQLModel, table=True):
         foreign_key="backfield_workspace.id",
         index=True,
     )
+    stylebook_id: int | None = Field(
+        default=None,
+        foreign_key="stylebook.id",
+        index=True,
+    )
     name: str = Field(sa_column=Column(Text, nullable=False))
     slug: str = Field(sa_column=Column(Text, unique=True, nullable=False, index=True))
     settings_json: str | None = Field(default=None, sa_column=Column(Text, nullable=True))

--- a/packages/backfield-db/src/backfield_db/tenancy_audit.py
+++ b/packages/backfield-db/src/backfield_db/tenancy_audit.py
@@ -1,0 +1,544 @@
+"""Read-only preflight audit for project workspace and Stylebook ownership."""
+
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from enum import StrEnum
+
+from pydantic import BaseModel, Field
+from sqlalchemy import inspect, text
+from sqlmodel import Session, select
+
+from backfield_db.models import (
+    AgateGraph,
+    BackfieldWorkspace,
+    Stylebook,
+    StylebookLocationCanonical,
+    StylebookOrganizationCanonical,
+    StylebookPersonCanonical,
+    SubstrateLocation,
+    SubstrateOrganization,
+    SubstratePerson,
+)
+
+
+class TenancyBlockerCode(StrEnum):
+    ORPHAN_PROJECT = "orphan_project"
+    PROJECT_WORKSPACE_ORGANIZATION_MISMATCH = "project_workspace_organization_mismatch"
+    WORKSPACE_STYLEBOOK_ORGANIZATION_MISMATCH = "workspace_stylebook_organization_mismatch"
+    PROJECT_STYLEBOOK_ORGANIZATION_MISMATCH = "project_stylebook_organization_mismatch"
+    PROJECT_STYLEBOOK_UNRESOLVED = "project_stylebook_unresolved"
+    GRAPH_SPEC_INVALID = "graph_spec_invalid"
+    GRAPH_STYLEBOOK_CONFLICT = "graph_stylebook_conflict"
+    GRAPH_MULTIPLE_STYLEBOOKS = "graph_multiple_stylebooks"
+    LINKED_CANONICAL_STYLEBOOK_MISMATCH = "linked_canonical_stylebook_mismatch"
+    DUPLICATE_PROJECT_SLUG = "duplicate_project_slug"
+
+
+class TenancyEntityType(StrEnum):
+    LOCATION = "location"
+    PERSON = "person"
+    ORGANIZATION = "organization"
+
+
+_ENTITY_ID_SAMPLE_LIMIT = 5
+
+
+class TenancyAuditBlocker(BaseModel):
+    code: TenancyBlockerCode
+    message: str
+    organization_id: int | None = None
+    project_id: int | None = None
+    related_project_ids: list[int] = Field(default_factory=list)
+    project_slug: str | None = None
+    workspace_id: int | None = None
+    stylebook_id: int | None = None
+    expected_stylebook_id: int | None = None
+    actual_stylebook_ids: list[int] = Field(default_factory=list)
+    graph_id: str | None = None
+    node_ids: list[str] = Field(default_factory=list)
+    entity_type: TenancyEntityType | None = None
+    entity_id: str | None = None
+    affected_count: int | None = None
+    sample_entity_ids: list[str] = Field(default_factory=list)
+
+
+class TenancyAuditReport(BaseModel):
+    ok: bool
+    blocker_count: int
+    blockers: list[TenancyAuditBlocker] = Field(default_factory=list)
+
+    def to_json(self) -> str:
+        return self.model_dump_json(indent=2)
+
+
+class ProjectAuditRow(BaseModel):
+    id: int
+    organization_id: int
+    workspace_id: int | None
+    stylebook_id: int | None
+    name: str
+    slug: str
+
+
+def _load_projects(session: Session) -> list[ProjectAuditRow]:
+    """Load projects from either side of the additive ``stylebook_id`` migration."""
+    connection = session.connection()
+    column_names = {
+        str(column["name"]) for column in inspect(connection).get_columns("backfield_project")
+    }
+    stylebook_projection = (
+        "stylebook_id" if "stylebook_id" in column_names else "NULL AS stylebook_id"
+    )
+    rows = session.execute(
+        text(
+            f"""
+            SELECT id, organization_id, workspace_id, {stylebook_projection}, name, slug
+            FROM backfield_project
+            ORDER BY id
+            """
+        )
+    ).mappings()
+    return [ProjectAuditRow.model_validate(dict(row)) for row in rows]
+
+
+def _project_label(project: ProjectAuditRow) -> str:
+    return f"project {project.id} ({project.slug})"
+
+
+def _organization_fallbacks(stylebooks: list[Stylebook]) -> dict[int, int]:
+    by_organization: dict[int, list[Stylebook]] = defaultdict(list)
+    for stylebook in stylebooks:
+        by_organization[int(stylebook.organization_id)].append(stylebook)
+
+    fallbacks: dict[int, int] = {}
+    for organization_id, rows in by_organization.items():
+        defaults = [row for row in rows if bool(row.is_default)]
+        chosen: Stylebook | None = defaults[0] if len(defaults) == 1 else None
+        if chosen is None and not defaults and len(rows) == 1:
+            chosen = rows[0]
+        if chosen is not None and chosen.id is not None:
+            fallbacks[organization_id] = int(chosen.id)
+    return fallbacks
+
+
+def _proposed_project_stylebooks(
+    projects: list[ProjectAuditRow],
+    workspaces: dict[int, BackfieldWorkspace],
+    stylebooks: dict[int, Stylebook],
+    organization_fallbacks: dict[int, int],
+) -> dict[int, int | None]:
+    proposed: dict[int, int | None] = {}
+    for project in projects:
+        project_id = project.id
+        if project.stylebook_id is not None:
+            proposed[project_id] = int(project.stylebook_id)
+            continue
+        workspace = (
+            workspaces.get(int(project.workspace_id))
+            if project.workspace_id is not None
+            else None
+        )
+        if workspace is not None and int(workspace.organization_id) == int(project.organization_id):
+            stylebook = stylebooks.get(int(workspace.stylebook_id))
+            if stylebook is not None and int(stylebook.organization_id) == int(
+                project.organization_id
+            ):
+                proposed[project_id] = int(workspace.stylebook_id)
+                continue
+            proposed[project_id] = None
+            continue
+        proposed[project_id] = organization_fallbacks.get(int(project.organization_id))
+    return proposed
+
+
+def _duplicate_project_slug_blockers(
+    projects: list[ProjectAuditRow],
+) -> list[TenancyAuditBlocker]:
+    grouped: dict[tuple[int, str], list[ProjectAuditRow]] = defaultdict(list)
+    for project in projects:
+        grouped[(int(project.organization_id), str(project.slug))].append(project)
+
+    blockers: list[TenancyAuditBlocker] = []
+    for (organization_id, slug), rows in grouped.items():
+        if len(rows) < 2:
+            continue
+        project_ids = sorted(row.id for row in rows)
+        blockers.append(
+            TenancyAuditBlocker(
+                code=TenancyBlockerCode.DUPLICATE_PROJECT_SLUG,
+                message=(
+                    f"organization {organization_id} has duplicate project slug {slug!r} "
+                    f"on projects {project_ids}"
+                ),
+                organization_id=organization_id,
+                related_project_ids=project_ids,
+                project_slug=slug,
+            )
+        )
+    return blockers
+
+
+def _coerce_stylebook_id(raw: object) -> int | None:
+    if raw is None or isinstance(raw, bool):
+        return None
+    if isinstance(raw, int):
+        return raw
+    if isinstance(raw, float):
+        if raw != raw or raw % 1 != 0:
+            return None
+        return int(raw)
+    if isinstance(raw, str):
+        value = raw.strip()
+        if value.isdigit():
+            return int(value)
+    return None
+
+
+def _node_stylebook_refs(spec_json: str) -> tuple[list[tuple[str, int]], bool]:
+    try:
+        raw = json.loads(spec_json)
+    except (TypeError, json.JSONDecodeError):
+        return [], False
+    if not isinstance(raw, dict):
+        return [], False
+    nodes = raw.get("nodes")
+    if not isinstance(nodes, list):
+        return [], True
+
+    references: list[tuple[str, int]] = []
+    for node in nodes:
+        if not isinstance(node, dict):
+            continue
+        node_id = node.get("id")
+        params = node.get("params")
+        if not isinstance(node_id, str) or not isinstance(params, dict):
+            continue
+        stylebook_id = _coerce_stylebook_id(params.get("stylebook_id"))
+        if stylebook_id is None:
+            stylebook_id = _coerce_stylebook_id(params.get("stylebookId"))
+        if stylebook_id is None:
+            continue
+        references.append((node_id, stylebook_id))
+    return references, True
+
+
+def _graph_blockers(
+    graphs: list[AgateGraph],
+    projects: dict[int, ProjectAuditRow],
+    proposed_stylebooks: dict[int, int | None],
+) -> list[TenancyAuditBlocker]:
+    blockers: list[TenancyAuditBlocker] = []
+    for graph in graphs:
+        project = projects.get(int(graph.project_id))
+        if project is None:
+            continue
+        refs, valid_spec = _node_stylebook_refs(graph.spec_json)
+        if not valid_spec:
+            blockers.append(
+                TenancyAuditBlocker(
+                    code=TenancyBlockerCode.GRAPH_SPEC_INVALID,
+                    message=f"graph {graph.id} has invalid JSON and cannot be audited",
+                    organization_id=int(project.organization_id),
+                    project_id=project.id,
+                    project_slug=str(project.slug),
+                    graph_id=str(graph.id),
+                )
+            )
+            continue
+
+        stylebook_ids = sorted({stylebook_id for _, stylebook_id in refs})
+        if len(stylebook_ids) > 1:
+            blockers.append(
+                TenancyAuditBlocker(
+                    code=TenancyBlockerCode.GRAPH_MULTIPLE_STYLEBOOKS,
+                    message=f"graph {graph.id} references several Stylebooks: {stylebook_ids}",
+                    organization_id=int(project.organization_id),
+                    project_id=project.id,
+                    project_slug=str(project.slug),
+                    expected_stylebook_id=proposed_stylebooks.get(project.id),
+                    actual_stylebook_ids=stylebook_ids,
+                    graph_id=str(graph.id),
+                    node_ids=[node_id for node_id, _ in refs],
+                )
+            )
+
+        expected = proposed_stylebooks.get(project.id)
+        conflicts = [(node_id, sid) for node_id, sid in refs if sid != expected]
+        if conflicts:
+            actual = sorted({sid for _, sid in conflicts})
+            blockers.append(
+                TenancyAuditBlocker(
+                    code=TenancyBlockerCode.GRAPH_STYLEBOOK_CONFLICT,
+                    message=(
+                        f"graph {graph.id} references Stylebooks {actual}, "
+                        f"not project Stylebook {expected}"
+                    ),
+                    organization_id=int(project.organization_id),
+                    project_id=project.id,
+                    project_slug=str(project.slug),
+                    expected_stylebook_id=expected,
+                    actual_stylebook_ids=actual,
+                    graph_id=str(graph.id),
+                    node_ids=[node_id for node_id, _ in conflicts],
+                )
+            )
+    return blockers
+
+
+def _linked_canonical_blocker(
+    *,
+    project: ProjectAuditRow,
+    proposed_stylebook_id: int | None,
+    actual_stylebook_id: int,
+    entity_type: TenancyEntityType,
+    entity_ids: set[int],
+) -> TenancyAuditBlocker:
+    ordered_entity_ids = sorted(entity_ids)
+    affected_count = len(ordered_entity_ids)
+    return TenancyAuditBlocker(
+        code=TenancyBlockerCode.LINKED_CANONICAL_STYLEBOOK_MISMATCH,
+        message=(
+            f"{affected_count} linked {entity_type.value} row(s) use Stylebook "
+            f"{actual_stylebook_id}, not project Stylebook {proposed_stylebook_id}"
+        ),
+        organization_id=int(project.organization_id),
+        project_id=project.id,
+        project_slug=str(project.slug),
+        stylebook_id=actual_stylebook_id,
+        expected_stylebook_id=proposed_stylebook_id,
+        actual_stylebook_ids=[actual_stylebook_id],
+        entity_type=entity_type,
+        affected_count=affected_count,
+        sample_entity_ids=[
+            str(entity_id) for entity_id in ordered_entity_ids[:_ENTITY_ID_SAMPLE_LIMIT]
+        ],
+    )
+
+
+def _record_linked_canonical_mismatch(
+    groups: dict[tuple[int, TenancyEntityType, int, int | None], set[int]],
+    *,
+    projects: dict[int, ProjectAuditRow],
+    proposed_stylebooks: dict[int, int | None],
+    project_id: int,
+    actual_stylebook_id: int,
+    entity_type: TenancyEntityType,
+    entity_id: int,
+) -> None:
+    project = projects.get(project_id)
+    if project is None:
+        return
+    expected_stylebook_id = proposed_stylebooks.get(project.id)
+    if expected_stylebook_id == actual_stylebook_id:
+        return
+    key = (project_id, entity_type, actual_stylebook_id, expected_stylebook_id)
+    groups.setdefault(key, set()).add(entity_id)
+
+
+def _linked_canonical_blockers(
+    session: Session,
+    projects: dict[int, ProjectAuditRow],
+    proposed_stylebooks: dict[int, int | None],
+) -> list[TenancyAuditBlocker]:
+    groups: dict[tuple[int, TenancyEntityType, int, int | None], set[int]] = {}
+    location_rows = session.exec(
+        select(SubstrateLocation, StylebookLocationCanonical)
+        .join(
+            StylebookLocationCanonical,
+            StylebookLocationCanonical.id
+            == SubstrateLocation.stylebook_location_canonical_id,
+        )
+        .where(SubstrateLocation.canonical_link_status == "linked")
+    ).all()
+    person_rows = session.exec(
+        select(SubstratePerson, StylebookPersonCanonical)
+        .join(
+            StylebookPersonCanonical,
+            StylebookPersonCanonical.id == SubstratePerson.stylebook_person_canonical_id,
+        )
+        .where(SubstratePerson.canonical_link_status == "linked")
+    ).all()
+    organization_rows = session.exec(
+        select(SubstrateOrganization, StylebookOrganizationCanonical)
+        .join(
+            StylebookOrganizationCanonical,
+            StylebookOrganizationCanonical.id
+            == SubstrateOrganization.stylebook_organization_canonical_id,
+        )
+        .where(SubstrateOrganization.canonical_link_status == "linked")
+    ).all()
+
+    for row, canonical in location_rows:
+        if row.id is None:
+            continue
+        _record_linked_canonical_mismatch(
+            groups,
+            projects=projects,
+            proposed_stylebooks=proposed_stylebooks,
+            project_id=int(row.project_id),
+            actual_stylebook_id=int(canonical.stylebook_id),
+            entity_type=TenancyEntityType.LOCATION,
+            entity_id=int(row.id),
+        )
+    for row, canonical in person_rows:
+        if row.id is None:
+            continue
+        _record_linked_canonical_mismatch(
+            groups,
+            projects=projects,
+            proposed_stylebooks=proposed_stylebooks,
+            project_id=int(row.project_id),
+            actual_stylebook_id=int(canonical.stylebook_id),
+            entity_type=TenancyEntityType.PERSON,
+            entity_id=int(row.id),
+        )
+    for row, canonical in organization_rows:
+        if row.id is None:
+            continue
+        _record_linked_canonical_mismatch(
+            groups,
+            projects=projects,
+            proposed_stylebooks=proposed_stylebooks,
+            project_id=int(row.project_id),
+            actual_stylebook_id=int(canonical.stylebook_id),
+            entity_type=TenancyEntityType.ORGANIZATION,
+            entity_id=int(row.id),
+        )
+    blockers: list[TenancyAuditBlocker] = []
+    ordered_groups = sorted(
+        groups.items(),
+        key=lambda item: (
+            item[0][0],
+            item[0][1].value,
+            item[0][2],
+            item[0][3] if item[0][3] is not None else -1,
+        ),
+    )
+    for (project_id, entity_type, actual, expected), entity_ids in ordered_groups:
+        blockers.append(
+            _linked_canonical_blocker(
+                project=projects[project_id],
+                proposed_stylebook_id=expected,
+                actual_stylebook_id=actual,
+                entity_type=entity_type,
+                entity_ids=entity_ids,
+            )
+        )
+    return blockers
+
+
+def audit_tenancy(session: Session) -> TenancyAuditReport:
+    """Inspect tenancy migration blockers without changing database state."""
+    projects = _load_projects(session)
+    workspaces = list(session.exec(select(BackfieldWorkspace)).all())
+    stylebooks = list(session.exec(select(Stylebook)).all())
+    graphs = list(session.exec(select(AgateGraph)).all())
+
+    projects_by_id = {project.id: project for project in projects}
+    workspaces_by_id = {
+        int(workspace.id): workspace for workspace in workspaces if workspace.id is not None
+    }
+    stylebooks_by_id = {
+        int(stylebook.id): stylebook for stylebook in stylebooks if stylebook.id is not None
+    }
+    proposed_stylebooks = _proposed_project_stylebooks(
+        projects,
+        workspaces_by_id,
+        stylebooks_by_id,
+        _organization_fallbacks(stylebooks),
+    )
+
+    blockers: list[TenancyAuditBlocker] = []
+    for workspace in workspaces:
+        stylebook = stylebooks_by_id.get(int(workspace.stylebook_id))
+        if stylebook is None or int(stylebook.organization_id) != int(workspace.organization_id):
+            blockers.append(
+                TenancyAuditBlocker(
+                    code=TenancyBlockerCode.WORKSPACE_STYLEBOOK_ORGANIZATION_MISMATCH,
+                    message=(
+                        f"workspace {workspace.id} belongs to organization "
+                        f"{workspace.organization_id} but Stylebook "
+                        f"{workspace.stylebook_id} does not"
+                    ),
+                    organization_id=int(workspace.organization_id),
+                    workspace_id=int(workspace.id) if workspace.id is not None else None,
+                    stylebook_id=int(workspace.stylebook_id),
+                )
+            )
+
+    for project in projects:
+        project_id = project.id
+        if project.workspace_id is None:
+            blockers.append(
+                TenancyAuditBlocker(
+                    code=TenancyBlockerCode.ORPHAN_PROJECT,
+                    message=f"{_project_label(project)} has no workspace",
+                    organization_id=int(project.organization_id),
+                    project_id=project_id,
+                    project_slug=str(project.slug),
+                )
+            )
+        else:
+            workspace = workspaces_by_id.get(int(project.workspace_id))
+            if workspace is None or int(workspace.organization_id) != int(project.organization_id):
+                blockers.append(
+                    TenancyAuditBlocker(
+                        code=TenancyBlockerCode.PROJECT_WORKSPACE_ORGANIZATION_MISMATCH,
+                        message=(
+                            f"{_project_label(project)} does not share an organization with "
+                            f"workspace {project.workspace_id}"
+                        ),
+                        organization_id=int(project.organization_id),
+                        project_id=project_id,
+                        project_slug=str(project.slug),
+                        workspace_id=int(project.workspace_id),
+                    )
+                )
+
+        if project.stylebook_id is not None:
+            stylebook = stylebooks_by_id.get(int(project.stylebook_id))
+            if stylebook is None or int(stylebook.organization_id) != int(project.organization_id):
+                blockers.append(
+                    TenancyAuditBlocker(
+                        code=TenancyBlockerCode.PROJECT_STYLEBOOK_ORGANIZATION_MISMATCH,
+                        message=(
+                            f"{_project_label(project)} does not share an organization with "
+                            f"Stylebook {project.stylebook_id}"
+                        ),
+                        organization_id=int(project.organization_id),
+                        project_id=project_id,
+                        project_slug=str(project.slug),
+                        stylebook_id=int(project.stylebook_id),
+                    )
+                )
+        if proposed_stylebooks.get(project_id) is None:
+            blockers.append(
+                TenancyAuditBlocker(
+                    code=TenancyBlockerCode.PROJECT_STYLEBOOK_UNRESOLVED,
+                    message=f"{_project_label(project)} has no unambiguous Stylebook assignment",
+                    organization_id=int(project.organization_id),
+                    project_id=project_id,
+                    project_slug=str(project.slug),
+                )
+            )
+
+    blockers.extend(_duplicate_project_slug_blockers(projects))
+    blockers.extend(_graph_blockers(graphs, projects_by_id, proposed_stylebooks))
+    blockers.extend(_linked_canonical_blockers(session, projects_by_id, proposed_stylebooks))
+    blockers.sort(
+        key=lambda blocker: (
+            blocker.code.value,
+            blocker.organization_id or 0,
+            blocker.project_id or 0,
+            blocker.workspace_id or 0,
+            blocker.graph_id or "",
+            blocker.entity_id or "",
+        )
+    )
+    return TenancyAuditReport(
+        ok=not blockers,
+        blocker_count=len(blockers),
+        blockers=blockers,
+    )

--- a/packages/backfield-db/tests/test_project_stylebook_migration.py
+++ b/packages/backfield-db/tests/test_project_stylebook_migration.py
@@ -1,0 +1,215 @@
+"""Backfill behavior for direct project Stylebook ownership."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+from sqlalchemy import Connection, create_engine, text
+
+
+def _migration_module() -> ModuleType:
+    path = (
+        Path(__file__).resolve().parents[1]
+        / "alembic"
+        / "versions"
+        / "069_project_stylebook_ownership.py"
+    )
+    spec = importlib.util.spec_from_file_location("migration_069", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _create_pre_backfill_schema(conn: Connection) -> None:
+    conn.execute(
+        text(
+            """
+            CREATE TABLE backfield_organization (
+                id INTEGER PRIMARY KEY,
+                name TEXT NOT NULL,
+                slug TEXT NOT NULL
+            )
+            """
+        )
+    )
+    conn.execute(
+        text(
+            """
+            CREATE TABLE stylebook (
+                id INTEGER PRIMARY KEY,
+                organization_id INTEGER NOT NULL,
+                slug TEXT NOT NULL,
+                name TEXT NOT NULL,
+                is_default BOOLEAN NOT NULL DEFAULT false
+            )
+            """
+        )
+    )
+    conn.execute(
+        text(
+            """
+            CREATE TABLE backfield_workspace (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                organization_id INTEGER NOT NULL,
+                stylebook_id INTEGER NOT NULL,
+                name TEXT NOT NULL,
+                slug TEXT NOT NULL,
+                created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE (organization_id, slug)
+            )
+            """
+        )
+    )
+    conn.execute(
+        text(
+            """
+            CREATE TABLE backfield_project (
+                id INTEGER PRIMARY KEY,
+                organization_id INTEGER NOT NULL,
+                workspace_id INTEGER,
+                stylebook_id INTEGER,
+                name TEXT NOT NULL,
+                slug TEXT NOT NULL
+            )
+            """
+        )
+    )
+
+
+def test_backfill_copies_workspace_stylebook_and_assigns_orphans() -> None:
+    migration = _migration_module()
+    engine = create_engine("sqlite://")
+    with engine.begin() as conn:
+        _create_pre_backfill_schema(conn)
+        conn.execute(
+            text(
+                """
+                INSERT INTO backfield_organization (id, name, slug)
+                VALUES (1, 'One', 'one'), (2, 'Two', 'two')
+                """
+            )
+        )
+        conn.execute(
+            text(
+                """
+                INSERT INTO stylebook (id, organization_id, slug, name, is_default)
+                VALUES
+                    (10, 1, 'news', 'News', false),
+                    (11, 1, 'default', 'Default', true),
+                    (20, 2, 'only', 'Only', false)
+                """
+            )
+        )
+        conn.execute(
+            text(
+                """
+                INSERT INTO backfield_workspace
+                    (id, organization_id, stylebook_id, name, slug)
+                VALUES (100, 1, 10, 'Desk', 'desk')
+                """
+            )
+        )
+        conn.execute(
+            text(
+                """
+                INSERT INTO backfield_project
+                    (id, organization_id, workspace_id, stylebook_id, name, slug)
+                VALUES
+                    (1000, 1, 100, NULL, 'Assigned', 'assigned'),
+                    (2000, 2, NULL, NULL, 'Orphan', 'orphan')
+                """
+            )
+        )
+
+        migration._backfill_project_stylebooks(conn)
+
+        assigned = conn.execute(
+            text(
+                """
+                SELECT workspace_id, stylebook_id
+                FROM backfield_project
+                WHERE id = 1000
+                """
+            )
+        ).one()
+        orphan = conn.execute(
+            text(
+                """
+                SELECT p.workspace_id, p.stylebook_id, w.name, w.slug
+                FROM backfield_project AS p
+                JOIN backfield_workspace AS w ON w.id = p.workspace_id
+                WHERE p.id = 2000
+                """
+            )
+        ).one()
+
+        assert tuple(assigned) == (100, 10)
+        assert orphan[0] is not None
+        assert tuple(orphan[1:]) == (20, "General", "general")
+
+
+@pytest.mark.parametrize("failure", ["cross_org", "no_stylebook", "ambiguous_stylebooks"])
+def test_backfill_fails_instead_of_guessing(failure: str) -> None:
+    migration = _migration_module()
+    engine = create_engine("sqlite://")
+    with engine.begin() as conn:
+        _create_pre_backfill_schema(conn)
+        conn.execute(
+            text(
+                """
+                INSERT INTO backfield_organization (id, name, slug)
+                VALUES (1, 'One', 'one'), (2, 'Two', 'two')
+                """
+            )
+        )
+        if failure == "cross_org":
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO stylebook (id, organization_id, slug, name, is_default)
+                    VALUES (20, 2, 'two', 'Two', true)
+                    """
+                )
+            )
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO backfield_workspace
+                        (id, organization_id, stylebook_id, name, slug)
+                    VALUES (100, 2, 20, 'Foreign', 'foreign')
+                    """
+                )
+            )
+            workspace_id = 100
+        elif failure == "ambiguous_stylebooks":
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO stylebook (id, organization_id, slug, name, is_default)
+                    VALUES
+                        (10, 1, 'one', 'One', false),
+                        (11, 1, 'two', 'Two', false)
+                    """
+                )
+            )
+            workspace_id = None
+        else:
+            workspace_id = None
+        conn.execute(
+            text(
+                """
+                INSERT INTO backfield_project
+                    (id, organization_id, workspace_id, stylebook_id, name, slug)
+                VALUES (1000, 1, :workspace_id, NULL, 'Project', 'project')
+                """
+            ),
+            {"workspace_id": workspace_id},
+        )
+
+        with pytest.raises(RuntimeError, match="cross-organization|no Stylebook|no default"):
+            migration._backfill_project_stylebooks(conn)

--- a/packages/backfield-db/tests/test_project_stylebook_model.py
+++ b/packages/backfield-db/tests/test_project_stylebook_model.py
@@ -1,0 +1,13 @@
+"""Structural contract for additive project Stylebook ownership."""
+
+from __future__ import annotations
+
+from backfield_db import BackfieldProject
+
+
+def test_project_stylebook_column_is_nullable_indexed_foreign_key() -> None:
+    column = BackfieldProject.__table__.c.stylebook_id
+
+    assert column.nullable is True
+    assert column.index is True
+    assert {foreign_key.target_fullname for foreign_key in column.foreign_keys} == {"stylebook.id"}

--- a/packages/backfield-db/tests/test_tenancy_audit.py
+++ b/packages/backfield-db/tests/test_tenancy_audit.py
@@ -1,0 +1,384 @@
+"""Read-only tenancy preflight audit coverage."""
+
+from __future__ import annotations
+
+import json
+
+from backfield_db import (
+    AgateGraph,
+    BackfieldOrganization,
+    BackfieldProject,
+    BackfieldWorkspace,
+    Stylebook,
+    StylebookLocationCanonical,
+    StylebookOrganizationCanonical,
+    StylebookPersonCanonical,
+    SubstrateLocation,
+    SubstrateOrganization,
+    SubstratePerson,
+)
+from backfield_db.tenancy_audit import (
+    ProjectAuditRow,
+    TenancyBlockerCode,
+    _duplicate_project_slug_blockers,
+    _load_projects,
+    audit_tenancy,
+)
+from sqlalchemy import text
+from sqlmodel import Session, SQLModel, create_engine
+
+
+def _engine():
+    engine = create_engine("sqlite://")
+    SQLModel.metadata.create_all(engine)
+    return engine
+
+
+def test_project_audit_rows_load_before_stylebook_column_exists() -> None:
+    engine = create_engine("sqlite://")
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                CREATE TABLE backfield_project (
+                    id INTEGER PRIMARY KEY,
+                    organization_id INTEGER NOT NULL,
+                    workspace_id INTEGER,
+                    name TEXT NOT NULL,
+                    slug TEXT NOT NULL
+                )
+                """
+            )
+        )
+        connection.execute(
+            text(
+                """
+                INSERT INTO backfield_project
+                    (id, organization_id, workspace_id, name, slug)
+                VALUES (1, 10, NULL, 'Legacy', 'legacy')
+                """
+            )
+        )
+
+    with Session(engine) as session:
+        projects = _load_projects(session)
+
+    assert len(projects) == 1
+    assert projects[0].id == 1
+    assert projects[0].stylebook_id is None
+
+
+def test_tenancy_audit_clean_report_is_read_only() -> None:
+    engine = _engine()
+    with Session(engine) as session:
+        organization = BackfieldOrganization(name="One", slug="audit-clean")
+        session.add(organization)
+        session.flush()
+        stylebook = Stylebook(
+            organization_id=int(organization.id),
+            name="Default",
+            slug="default",
+            is_default=True,
+        )
+        session.add(stylebook)
+        session.flush()
+        workspace = BackfieldWorkspace(
+            organization_id=int(organization.id),
+            stylebook_id=int(stylebook.id),
+            name="Workspace",
+            slug="workspace",
+        )
+        session.add(workspace)
+        session.flush()
+        project = BackfieldProject(
+            organization_id=int(organization.id),
+            workspace_id=int(workspace.id),
+            stylebook_id=int(stylebook.id),
+            name="Project",
+            slug="audit-clean-project",
+        )
+        session.add(project)
+        session.flush()
+        session.add(
+            AgateGraph(
+                project_id=int(project.id),
+                name="Graph",
+                spec_json=json.dumps(
+                    {
+                        "nodes": [
+                            {
+                                "id": "output",
+                                "params": {"stylebook_id": int(stylebook.id)},
+                            }
+                        ]
+                    }
+                ),
+            )
+        )
+        session.commit()
+
+        report = audit_tenancy(session)
+
+        assert report.ok is True
+        assert report.blocker_count == 0
+        assert report.blockers == []
+        assert not session.new
+        assert not session.dirty
+        assert not session.deleted
+
+
+def test_tenancy_audit_reports_cross_layer_blockers() -> None:
+    engine = _engine()
+    with Session(engine) as session:
+        organization_one = BackfieldOrganization(name="One", slug="audit-one")
+        organization_two = BackfieldOrganization(name="Two", slug="audit-two")
+        organization_three = BackfieldOrganization(name="Three", slug="audit-three")
+        session.add_all([organization_one, organization_two, organization_three])
+        session.flush()
+        stylebook_one = Stylebook(
+            organization_id=int(organization_one.id),
+            name="One",
+            slug="one",
+            is_default=True,
+        )
+        stylebook_one_extra = Stylebook(
+            organization_id=int(organization_one.id),
+            name="One Extra",
+            slug="one-extra",
+            is_default=False,
+        )
+        stylebook_two = Stylebook(
+            organization_id=int(organization_two.id),
+            name="Two",
+            slug="two",
+            is_default=True,
+        )
+        session.add_all([stylebook_one, stylebook_one_extra, stylebook_two])
+        session.flush()
+        workspace_one = BackfieldWorkspace(
+            organization_id=int(organization_one.id),
+            stylebook_id=int(stylebook_one.id),
+            name="One",
+            slug="one",
+        )
+        workspace_cross_stylebook = BackfieldWorkspace(
+            organization_id=int(organization_one.id),
+            stylebook_id=int(stylebook_two.id),
+            name="Cross Stylebook",
+            slug="cross-stylebook",
+        )
+        workspace_two = BackfieldWorkspace(
+            organization_id=int(organization_two.id),
+            stylebook_id=int(stylebook_two.id),
+            name="Two",
+            slug="two",
+        )
+        session.add_all([workspace_one, workspace_cross_stylebook, workspace_two])
+        session.flush()
+        orphan = BackfieldProject(
+            organization_id=int(organization_one.id),
+            workspace_id=None,
+            stylebook_id=None,
+            name="Orphan",
+            slug="audit-orphan",
+        )
+        cross_workspace = BackfieldProject(
+            organization_id=int(organization_one.id),
+            workspace_id=int(workspace_two.id),
+            stylebook_id=int(stylebook_one.id),
+            name="Cross Workspace",
+            slug="audit-cross-workspace",
+        )
+        cross_stylebook = BackfieldProject(
+            organization_id=int(organization_one.id),
+            workspace_id=int(workspace_one.id),
+            stylebook_id=int(stylebook_two.id),
+            name="Cross Stylebook",
+            slug="audit-cross-stylebook",
+        )
+        graph_project = BackfieldProject(
+            organization_id=int(organization_one.id),
+            workspace_id=int(workspace_one.id),
+            stylebook_id=int(stylebook_one.id),
+            name="Graph Project",
+            slug="audit-graph-project",
+        )
+        unresolved = BackfieldProject(
+            organization_id=int(organization_three.id),
+            workspace_id=None,
+            stylebook_id=None,
+            name="Unresolved",
+            slug="audit-unresolved",
+        )
+        session.add_all([orphan, cross_workspace, cross_stylebook, graph_project, unresolved])
+        session.flush()
+        session.add(
+            AgateGraph(
+                project_id=int(graph_project.id),
+                name="Mixed Graph",
+                spec_json=json.dumps(
+                    {
+                        "nodes": [
+                            {
+                                "id": "one-extra",
+                                "params": {"stylebook_id": int(stylebook_one_extra.id)},
+                            },
+                            {
+                                "id": "two",
+                                "params": {"stylebookId": int(stylebook_two.id)},
+                            },
+                        ]
+                    }
+                ),
+            )
+        )
+        location_canonical = StylebookLocationCanonical(
+            stylebook_id=int(stylebook_two.id),
+            label="Location",
+            slug="location",
+        )
+        other_location_canonical = StylebookLocationCanonical(
+            stylebook_id=int(stylebook_one_extra.id),
+            label="Other Location",
+            slug="other-location",
+        )
+        person_canonical = StylebookPersonCanonical(
+            stylebook_id=int(stylebook_two.id),
+            label="Person",
+            slug="person",
+        )
+        organization_canonical = StylebookOrganizationCanonical(
+            stylebook_id=int(stylebook_two.id),
+            label="Organization",
+            slug="organization",
+        )
+        session.add_all(
+            [
+                location_canonical,
+                other_location_canonical,
+                person_canonical,
+                organization_canonical,
+            ]
+        )
+        session.flush()
+        session.add_all(
+            [
+                SubstrateLocation(
+                    project_id=int(graph_project.id),
+                    name=f"Location {index}",
+                    normalized_name=f"location {index}",
+                    canonical_link_status="linked",
+                    stylebook_location_canonical_id=location_canonical.id,
+                )
+                for index in range(12)
+            ]
+        )
+        session.add(
+            SubstrateLocation(
+                project_id=int(graph_project.id),
+                name="Other Location",
+                normalized_name="other location",
+                canonical_link_status="linked",
+                stylebook_location_canonical_id=other_location_canonical.id,
+            )
+        )
+        session.add(
+            SubstratePerson(
+                project_id=int(graph_project.id),
+                name="Person",
+                normalized_name="person",
+                canonical_link_status="linked",
+                stylebook_person_canonical_id=person_canonical.id,
+            )
+        )
+        session.add(
+            SubstrateOrganization(
+                project_id=int(graph_project.id),
+                name="Organization",
+                normalized_name="organization",
+                canonical_link_status="linked",
+                stylebook_organization_canonical_id=organization_canonical.id,
+            )
+        )
+        session.commit()
+
+        report = audit_tenancy(session)
+
+        codes = {blocker.code for blocker in report.blockers}
+        assert report.ok is False
+        assert {
+            TenancyBlockerCode.ORPHAN_PROJECT,
+            TenancyBlockerCode.PROJECT_WORKSPACE_ORGANIZATION_MISMATCH,
+            TenancyBlockerCode.WORKSPACE_STYLEBOOK_ORGANIZATION_MISMATCH,
+            TenancyBlockerCode.PROJECT_STYLEBOOK_ORGANIZATION_MISMATCH,
+            TenancyBlockerCode.PROJECT_STYLEBOOK_UNRESOLVED,
+            TenancyBlockerCode.GRAPH_STYLEBOOK_CONFLICT,
+            TenancyBlockerCode.GRAPH_MULTIPLE_STYLEBOOKS,
+            TenancyBlockerCode.LINKED_CANONICAL_STYLEBOOK_MISMATCH,
+        } <= codes
+        linked = [
+            blocker
+            for blocker in report.blockers
+            if blocker.code == TenancyBlockerCode.LINKED_CANONICAL_STYLEBOOK_MISMATCH
+        ]
+        assert {blocker.entity_type for blocker in linked} == {
+            "location",
+            "person",
+            "organization",
+        }
+        assert len(linked) == 4
+        location_blocker = next(
+            blocker
+            for blocker in linked
+            if blocker.entity_type == "location"
+            and blocker.stylebook_id == int(stylebook_two.id)
+        )
+        assert location_blocker.affected_count == 12
+        assert len(location_blocker.sample_entity_ids) == 5
+        assert location_blocker.sample_entity_ids == sorted(
+            location_blocker.sample_entity_ids,
+            key=int,
+        )
+        assert location_blocker.entity_id is None
+        other_location_blocker = next(
+            blocker
+            for blocker in linked
+            if blocker.entity_type == "location"
+            and blocker.stylebook_id == int(stylebook_one_extra.id)
+        )
+        assert other_location_blocker.affected_count == 1
+
+
+def test_duplicate_project_slug_audit_is_scoped_to_organization() -> None:
+    rows = [
+        ProjectAuditRow(
+            id=1,
+            organization_id=10,
+            workspace_id=None,
+            stylebook_id=None,
+            name="A",
+            slug="duplicate",
+        ),
+        ProjectAuditRow(
+            id=2,
+            organization_id=10,
+            workspace_id=None,
+            stylebook_id=None,
+            name="B",
+            slug="duplicate",
+        ),
+        ProjectAuditRow(
+            id=3,
+            organization_id=20,
+            workspace_id=None,
+            stylebook_id=None,
+            name="C",
+            slug="duplicate",
+        ),
+    ]
+
+    blockers = _duplicate_project_slug_blockers(rows)
+
+    assert len(blockers) == 1
+    assert blockers[0].code == TenancyBlockerCode.DUPLICATE_PROJECT_SLUG
+    assert blockers[0].organization_id == 10

--- a/packages/backfield-entities/src/backfield_entities/catalog/resolve.py
+++ b/packages/backfield-entities/src/backfield_entities/catalog/resolve.py
@@ -4,40 +4,54 @@ Catalog resolution:
 
 1. **Explicit catalog id** — ``catalog_stylebook_id`` from caller; row must exist in project's org.
 2. **Slug** — non-empty ``stylebook_slug`` in that org (rename redirects apply).
-3. **Organization default** — default Stylebook, then first Stylebook by id.
+3. **Project ownership** — direct project Stylebook, then its workspace Stylebook during rollout.
+4. **Organization default** — default Stylebook, then first Stylebook by id.
 
 **Surfaces**
 
-* Stylebook HTTP: slug query → organization default (**2 → 3**).
+* Stylebook HTTP: slug query → project ownership → organization default (**2 → 3 → 4**).
 
 * Worker **DBOutput**: ``resolve_effective_stylebook_id`` delegates here; node ``stylebook_id``
-  maps to ``catalog_stylebook_id`` (**1 → 3**).
+  maps to ``catalog_stylebook_id`` (**1 → 3 → 4**).
 
 * Worker **GeocodeAgent** DB cache: project-scoped fingerprint lookup works without a catalog id;
   canonical lookup, adjudication, and materialization use only the node's catalog id, with no
   organization-default fallback.
 
-If step **3** fails, ``LookupError`` is raised; DBOutput persistence may catch it and skip
-catalog-backed canonicalization.
+If the fallback chain finds no Stylebook, ``LookupError`` is raised; DBOutput persistence may
+catch it and skip catalog-backed canonicalization.
 """
 
 from __future__ import annotations
 
-from backfield_db import BackfieldProject, Stylebook
+from backfield_db import BackfieldProject, BackfieldWorkspace, Stylebook
 from sqlmodel import Session, col, select
 
 STYLEBOOK_SLUG_NOT_IN_ORG = "STYLEBOOK_SLUG_NOT_IN_ORG"
 
 
 def resolve_stylebook_id_for_project_id(session: Session, project_id: int) -> int:
-    """Return the organization's default Stylebook for the project.
-
-    Workspaces are no longer used to select a default Stylebook.
-    """
+    """Return the project's owned Stylebook with rolling-upgrade fallbacks."""
     proj = session.get(BackfieldProject, project_id)
     if proj is None:
         raise LookupError(f"project {project_id} not found")
     oid = int(proj.organization_id)
+
+    if proj.stylebook_id is not None:
+        project_stylebook = session.get(Stylebook, int(proj.stylebook_id))
+        if project_stylebook is None or int(project_stylebook.organization_id) != oid:
+            raise ValueError("project Stylebook does not belong to the project's organization")
+        return int(project_stylebook.id)
+
+    if proj.workspace_id is not None:
+        workspace = session.get(BackfieldWorkspace, int(proj.workspace_id))
+        if workspace is None or int(workspace.organization_id) != oid:
+            raise ValueError("project workspace does not belong to the project's organization")
+        workspace_stylebook = session.get(Stylebook, int(workspace.stylebook_id))
+        if workspace_stylebook is None or int(workspace_stylebook.organization_id) != oid:
+            raise ValueError("workspace Stylebook does not belong to the project's organization")
+        return int(workspace_stylebook.id)
+
     sb = session.exec(
         select(Stylebook)
         .where(Stylebook.organization_id == oid)
@@ -57,7 +71,7 @@ def resolve_effective_stylebook_id_for_project(
 ) -> int:
     """Effective catalog row id for the project.
 
-    Precedence: ``catalog_stylebook_id`` → ``stylebook_slug`` → organization default.
+    Precedence: explicit id → slug → project → workspace → organization default.
 
     Raises ``ValueError`` when ``catalog_stylebook_id`` is invalid or wrong organization.
 

--- a/packages/backfield-entities/src/backfield_entities/catalog/stylebook_library.py
+++ b/packages/backfield-entities/src/backfield_entities/catalog/stylebook_library.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from backfield_db import (
+    BackfieldProject,
     BackfieldWorkspace,
     Stylebook,
     StylebookActivity,
@@ -431,8 +432,8 @@ def delete_stylebook(
 ) -> None:
     """Delete a stylebook when guards pass (see StylebookLibraryError).
 
-    Workspaces still referencing this stylebook are repointed to the org default (or the
-    replacement default when deleting the current default). Deleting the current default
+    Projects and workspaces still referencing this stylebook are repointed to the org default
+    (or the replacement default when deleting the current default). Deleting the current default
     requires ``replacement_default_id`` for another book in the same org.
 
     Non-cascading dependents (activity, bundle jobs, cleanup/candidate review rows) are
@@ -477,6 +478,14 @@ def delete_stylebook(
         organization_id=org_id,
         from_stylebook_id=int(stylebook_id),
         to_stylebook_id=int(reassign_target_id),
+    )
+    session.exec(
+        update(BackfieldProject)
+        .where(
+            BackfieldProject.organization_id == org_id,
+            BackfieldProject.stylebook_id == int(stylebook_id),
+        )
+        .values(stylebook_id=int(reassign_target_id))
     )
     reassign_stylebook_refs_in_org_graphs(
         session,

--- a/tests/agate_api/test_agate_api.py
+++ b/tests/agate_api/test_agate_api.py
@@ -30,9 +30,45 @@ from backfield_db import (
 )
 from backfield_entities.catalog.bootstrap import ensure_default_stylebook_for_organization
 from fastapi.testclient import TestClient
-from sqlmodel import Session, SQLModel, create_engine
+from httpx import Response
+from sqlmodel import Session, SQLModel, create_engine, select
 
 from tests.integration_helpers import patch_test_engine
+
+
+def _post_project(client: TestClient, *, name: str, slug: str) -> Response:
+    """Create a workspace explicitly for tests whose focus is downstream of project creation."""
+    dependency = app.dependency_overrides.get(get_session)
+    assert dependency is not None
+    session_generator = dependency()
+    session = next(session_generator)
+    try:
+        workspace = session.exec(
+            select(BackfieldWorkspace).order_by(BackfieldWorkspace.id)
+        ).first()
+        if workspace is None:
+            organization = session.exec(
+                select(BackfieldOrganization).order_by(BackfieldOrganization.id)
+            ).first()
+            assert organization is not None and organization.id is not None
+            stylebook = ensure_default_stylebook_for_organization(session, int(organization.id))
+            workspace = BackfieldWorkspace(
+                organization_id=int(organization.id),
+                stylebook_id=int(stylebook.id),
+                name="Test Workspace",
+                slug="test-workspace",
+            )
+            session.add(workspace)
+            session.commit()
+            session.refresh(workspace)
+        assert workspace.id is not None
+        workspace_id = int(workspace.id)
+    finally:
+        session_generator.close()
+    return client.post(
+        "/projects",
+        json={"name": name, "slug": slug, "workspace_id": workspace_id},
+    )
 
 
 def _minimal_text_input_spec(
@@ -146,9 +182,8 @@ def test_project_estimated_ai_cost_includes_model_breakdown(tmp_path):
             app,
             headers={"Authorization": "Bearer backfield-dev"},
         )
-        project = client.post(
-            "/projects",
-            json={"name": "AI Cost Project", "slug": "ai-cost-project"},
+        project = _post_project(
+            client, name="AI Cost Project", slug="ai-cost-project"
         ).json()
 
         with Session(engine) as s:
@@ -232,10 +267,7 @@ def test_run_estimated_ai_cost_node_breakdown_includes_node_type(tmp_path):
             app,
             headers={"Authorization": "Bearer backfield-dev"},
         )
-        project = client.post(
-            "/projects",
-            json={"name": "Run AI Cost", "slug": "run-ai-cost"},
-        ).json()
+        project = _post_project(client, name="Run AI Cost", slug="run-ai-cost").json()
         graph = client.post(
             "/graphs",
             json={
@@ -319,7 +351,7 @@ def test_projects_require_auth(tmp_path):
 
 
 def test_create_run_rejects_graph_without_ingress(client: TestClient):
-    project = client.post("/projects", json={"name": "No ingress", "slug": "no-ingress"}).json()
+    project = _post_project(client, name="No ingress", slug="no-ingress").json()
     graph = client.post(
         "/graphs",
         json={
@@ -347,7 +379,7 @@ def test_project_graph_and_run_creation(monkeypatch, client: TestClient):
 
     monkeypatch.setattr(runs.celery_app, "send_task", fake_send_task)
 
-    project_response = client.post("/projects", json={"name": "Smoke Project", "slug": "smoke"})
+    project_response = _post_project(client, name="Smoke Project", slug="smoke")
     assert project_response.status_code == 200
     project = project_response.json()
 
@@ -431,7 +463,7 @@ def test_project_graph_and_run_creation(monkeypatch, client: TestClient):
 
 
 def test_list_graphs_summary_and_project_filter(client: TestClient):
-    project = client.post("/projects", json={"name": "General", "slug": "general-perf"}).json()
+    project = _post_project(client, name="General", slug="general-perf").json()
     client.post(
         "/graphs",
         json={
@@ -454,7 +486,7 @@ def test_list_graphs_summary_and_project_filter(client: TestClient):
 def test_list_runs_supports_lightweight_list(monkeypatch, client: TestClient):
     monkeypatch.setattr(runs.celery_app, "send_task", lambda *_a, **_k: None)
 
-    project = client.post("/projects", json={"name": "Runs", "slug": "runs-perf"}).json()
+    project = _post_project(client, name="Runs", slug="runs-perf").json()
     graph = client.post(
         "/graphs",
         json={
@@ -477,7 +509,7 @@ def test_list_runs_supports_lightweight_list(monkeypatch, client: TestClient):
 def test_run_graph_spec_snapshot_and_flow_changed(monkeypatch, client: TestClient):
     monkeypatch.setattr(runs.celery_app, "send_task", lambda *args, **kwargs: None)
 
-    project = client.post("/projects", json={"name": "Snap Project", "slug": "snap-proj"}).json()
+    project = _post_project(client, name="Snap Project", slug="snap-proj").json()
     base_spec = {
         "name": "snap_flow",
         "nodes": [
@@ -548,10 +580,7 @@ def test_replay_run_uses_source_snapshot_not_live_graph(monkeypatch, client: Tes
 
     monkeypatch.setattr(runs.celery_app, "send_task", capture_send_task)
 
-    project = client.post(
-        "/projects",
-        json={"name": "Replay Project", "slug": "replay-proj"},
-    ).json()
+    project = _post_project(client, name="Replay Project", slug="replay-proj").json()
     base_spec = {
         "name": "replay_flow",
         "nodes": [
@@ -613,7 +642,7 @@ def test_replay_run_uses_source_snapshot_not_live_graph(monkeypatch, client: Tes
 
 
 def test_graph_description_round_trip(client: TestClient):
-    project_response = client.post("/projects", json={"name": "Desc Project", "slug": "desc-proj"})
+    project_response = _post_project(client, name="Desc Project", slug="desc-proj")
     assert project_response.status_code == 200
     project = project_response.json()
 
@@ -700,14 +729,8 @@ def test_project_api_key_scopes_agate_api_access(tmp_path):
             app,
             headers={"Authorization": "Bearer backfield-dev"},
         )
-        project_one = tc.post(
-            "/projects",
-            json={"name": "Project One", "slug": "project-one"},
-        ).json()
-        project_two = tc.post(
-            "/projects",
-            json={"name": "Project Two", "slug": "project-two"},
-        ).json()
+        project_one = _post_project(tc, name="Project One", slug="project-one").json()
+        project_two = _post_project(tc, name="Project Two", slug="project-two").json()
 
         raw_key = "bfk_project_scope_test_key_1234567890abcdef"
         with Session(engine) as s:
@@ -763,7 +786,7 @@ def test_list_runs_includes_processed_item_counts(monkeypatch, tmp_path):
             app,
             headers={"Authorization": "Bearer backfield-dev"},
         )
-        project = tc.post("/projects", json={"name": "Run Counts", "slug": "run-counts"}).json()
+        project = _post_project(tc, name="Run Counts", slug="run-counts").json()
         graph = tc.post(
             "/graphs",
             json={
@@ -862,7 +885,7 @@ def test_delete_graph_cleans_up_run_dependencies(monkeypatch, tmp_path):
             app,
             headers={"Authorization": "Bearer backfield-dev"},
         )
-        project = tc.post("/projects", json={"name": "Delete Graph", "slug": "delete-graph"}).json()
+        project = _post_project(tc, name="Delete Graph", slug="delete-graph").json()
         graph = tc.post(
             "/graphs",
             json={
@@ -947,7 +970,7 @@ def test_s3_graph_run_enqueues_batch_setup(monkeypatch, client: TestClient):
 
     monkeypatch.setattr(runs.celery_app, "send_task", fake_send_task)
 
-    project = client.post("/projects", json={"name": "S3 Project", "slug": "s3-proj"}).json()
+    project = _post_project(client, name="S3 Project", slug="s3-proj").json()
     graph = client.post(
         "/graphs",
         json={
@@ -995,7 +1018,7 @@ def test_get_run_includes_processed_items_array(monkeypatch, client: TestClient)
 
     monkeypatch.setattr(runs.celery_app, "send_task", fake_send_task)
 
-    project = client.post("/projects", json={"name": "Runs API", "slug": "runs-api"}).json()
+    project = _post_project(client, name="Runs API", slug="runs-api").json()
     graph = client.post(
         "/graphs",
         json={
@@ -1029,7 +1052,7 @@ def test_get_run_processed_item_not_found(monkeypatch, client: TestClient):
 
     monkeypatch.setattr(runs.celery_app, "send_task", fake_send_task)
 
-    project = client.post("/projects", json={"name": "Item 404", "slug": "item-404"}).json()
+    project = _post_project(client, name="Item 404", slug="item-404").json()
     graph = client.post(
         "/graphs",
         json={
@@ -1075,7 +1098,7 @@ def test_get_run_processed_item_synthetic_whole_run_pending(monkeypatch, tmp_pat
 
     try:
         tc = TestClient(app, headers={"Authorization": "Bearer backfield-dev"})
-        project = tc.post("/projects", json={"name": "Synth Item", "slug": "synth-item"}).json()
+        project = _post_project(tc, name="Synth Item", slug="synth-item").json()
         graph = tc.post(
             "/graphs",
             json={
@@ -1110,7 +1133,7 @@ def test_get_run_processed_item_synthetic_whole_run_pending(monkeypatch, tmp_pat
 def test_get_run_processed_item_synthetic_second_item_404(monkeypatch, client: TestClient):
     monkeypatch.setattr(runs.celery_app, "send_task", lambda *_a, **_k: None)
 
-    project = client.post("/projects", json={"name": "Synth 404", "slug": "synth-404"}).json()
+    project = _post_project(client, name="Synth 404", slug="synth-404").json()
     graph = client.post(
         "/graphs",
         json={
@@ -1155,7 +1178,7 @@ def test_rerun_processed_item_resets_row_and_enqueues_task(monkeypatch, tmp_path
             app,
             headers={"Authorization": "Bearer backfield-dev"},
         )
-        project = tc.post("/projects", json={"name": "Rerun API", "slug": "rerun-api"}).json()
+        project = _post_project(tc, name="Rerun API", slug="rerun-api").json()
         graph = tc.post(
             "/graphs",
             json={
@@ -1247,9 +1270,7 @@ def test_rerun_synthetic_whole_graph_run_resets_run_and_enqueues_task(
             app,
             headers={"Authorization": "Bearer backfield-dev"},
         )
-        project = tc.post(
-            "/projects", json={"name": "Rerun Synth", "slug": "rerun-synth"}
-        ).json()
+        project = _post_project(tc, name="Rerun Synth", slug="rerun-synth").json()
         graph = tc.post(
             "/graphs",
             json={
@@ -1308,9 +1329,7 @@ def test_create_run_with_replace_article_geography_flag(monkeypatch, tmp_path):
     app.dependency_overrides[get_session] = get_test_session
     try:
         tc = TestClient(app, headers={"Authorization": "Bearer backfield-dev"})
-        project = tc.post(
-            "/projects", json={"name": "Replace flag", "slug": "replace-flag"}
-        ).json()
+        project = _post_project(tc, name="Replace flag", slug="replace-flag").json()
         graph = tc.post(
             "/graphs",
             json={
@@ -1337,7 +1356,7 @@ def test_create_run_with_replace_article_geography_flag(monkeypatch, tmp_path):
 def test_rerun_processed_item_404_when_no_such_row(monkeypatch, client: TestClient):
     monkeypatch.setattr(runs.celery_app, "send_task", lambda *_a, **_k: None)
 
-    project = client.post("/projects", json={"name": "Rerun 404", "slug": "rerun-404"}).json()
+    project = _post_project(client, name="Rerun 404", slug="rerun-404").json()
     graph = client.post(
         "/graphs",
         json={
@@ -1374,7 +1393,7 @@ def test_get_run_processed_item_synthetic_with_run_result_json(tmp_path, monkeyp
             app,
             headers={"Authorization": "Bearer backfield-dev"},
         )
-        project = client.post("/projects", json={"name": "Synth OK", "slug": "synth-ok"}).json()
+        project = _post_project(client, name="Synth OK", slug="synth-ok").json()
         graph = client.post(
             "/graphs",
             json={
@@ -1428,7 +1447,7 @@ def test_patch_processed_item_overlay_success_and_409(tmp_path, monkeypatch):
 
     try:
         tc = TestClient(app, headers={"Authorization": "Bearer backfield-dev"})
-        project = tc.post("/projects", json={"name": "Overlay API", "slug": "overlay-api"}).json()
+        project = _post_project(tc, name="Overlay API", slug="overlay-api").json()
         graph = tc.post(
             "/graphs",
             json={
@@ -1542,7 +1561,7 @@ def test_patch_processed_item_overlay_materializes_reviewed_output(tmp_path, mon
 
     try:
         tc = TestClient(app, headers={"Authorization": "Bearer backfield-dev"})
-        project = tc.post("/projects", json={"name": "Reviewed Out", "slug": "reviewed-out"}).json()
+        project = _post_project(tc, name="Reviewed Out", slug="reviewed-out").json()
         graph = tc.post(
             "/graphs",
             json={
@@ -1611,7 +1630,7 @@ def test_patch_processed_item_overlay_geometry_400(tmp_path, monkeypatch):
 
     try:
         tc = TestClient(app, headers={"Authorization": "Bearer backfield-dev"})
-        project = tc.post("/projects", json={"name": "Geom API", "slug": "geom-api"}).json()
+        project = _post_project(tc, name="Geom API", slug="geom-api").json()
         graph = tc.post(
             "/graphs",
             json={
@@ -1684,7 +1703,7 @@ def test_patch_processed_item_overlay_requires_if_match(tmp_path, monkeypatch):
 
     try:
         tc = TestClient(app, headers={"Authorization": "Bearer backfield-dev"})
-        project = tc.post("/projects", json={"name": "IfMatch", "slug": "ifmatch"}).json()
+        project = _post_project(tc, name="IfMatch", slug="ifmatch").json()
         graph = tc.post(
             "/graphs",
             json={
@@ -1738,7 +1757,7 @@ def test_patch_processed_item_overlay_synthetic_404(monkeypatch, tmp_path):
     app.dependency_overrides[get_session] = get_test_session
     try:
         tc = TestClient(app, headers={"Authorization": "Bearer backfield-dev"})
-        project = tc.post("/projects", json={"name": "Synth PATCH", "slug": "synth-patch"}).json()
+        project = _post_project(tc, name="Synth PATCH", slug="synth-patch").json()
         graph = tc.post(
             "/graphs",
             json={
@@ -1781,7 +1800,7 @@ def test_get_run_processed_item_merged_locations_and_stale(tmp_path, monkeypatch
 
     try:
         tc = TestClient(app, headers={"Authorization": "Bearer backfield-dev"})
-        project = tc.post("/projects", json={"name": "Merge lane", "slug": "merge-lane"}).json()
+        project = _post_project(tc, name="Merge lane", slug="merge-lane").json()
         graph = tc.post(
             "/graphs",
             json={
@@ -1898,7 +1917,7 @@ def test_get_run_processed_item_failed_does_not_bleed_batch_substrate(tmp_path, 
 
     try:
         tc = TestClient(app, headers={"Authorization": "Bearer backfield-dev"})
-        project = tc.post("/projects", json={"name": "Batch bleed", "slug": "batch-bleed"}).json()
+        project = _post_project(tc, name="Batch bleed", slug="batch-bleed").json()
         graph = tc.post(
             "/graphs",
             json={
@@ -2012,7 +2031,7 @@ def test_get_run_processed_item_article_context_substrate(tmp_path, monkeypatch)
 
     try:
         tc = TestClient(app, headers={"Authorization": "Bearer backfield-dev"})
-        project = tc.post("/projects", json={"name": "Art Ctx", "slug": "art-ctx-sub"}).json()
+        project = _post_project(tc, name="Art Ctx", slug="art-ctx-sub").json()
         graph = tc.post(
             "/graphs",
             json={
@@ -2094,7 +2113,7 @@ def test_get_run_processed_item_article_context_inline_only(tmp_path, monkeypatc
 
     try:
         tc = TestClient(app, headers={"Authorization": "Bearer backfield-dev"})
-        project = tc.post("/projects", json={"name": "Art Inline", "slug": "art-inline"}).json()
+        project = _post_project(tc, name="Art Inline", slug="art-inline").json()
         graph = tc.post(
             "/graphs",
             json={

--- a/tests/agate_api/test_processed_item_article_meta.py
+++ b/tests/agate_api/test_processed_item_article_meta.py
@@ -17,7 +17,11 @@ from backfield_db import (
 from fastapi.testclient import TestClient
 from sqlmodel import Session, SQLModel, create_engine
 
-from tests.agate_api.test_agate_api import _insert_pending_run, _minimal_text_input_spec
+from tests.agate_api.test_agate_api import (
+    _insert_pending_run,
+    _minimal_text_input_spec,
+    _post_project,
+)
 
 
 def _seed_article_with_meta(session: Session, *, project_id: int) -> tuple[int, int]:
@@ -66,7 +70,7 @@ def test_get_processed_item_includes_article_meta_rows(tmp_path, monkeypatch) ->
 
     try:
         tc = TestClient(app, headers={"Authorization": "Bearer backfield-dev"})
-        project = tc.post("/projects", json={"name": "Meta Get", "slug": "meta-get-api"}).json()
+        project = _post_project(tc, name="Meta Get", slug="meta-get-api").json()
         graph = tc.post(
             "/graphs",
             json={
@@ -132,7 +136,7 @@ def test_patch_article_meta_category_updates_substrate_and_overlay(tmp_path, mon
 
     try:
         tc = TestClient(app, headers={"Authorization": "Bearer backfield-dev"})
-        project = tc.post("/projects", json={"name": "Meta Patch", "slug": "meta-patch-api"}).json()
+        project = _post_project(tc, name="Meta Patch", slug="meta-patch-api").json()
         graph = tc.post(
             "/graphs",
             json={
@@ -209,10 +213,7 @@ def test_patch_article_meta_category_overlay_only_json_output(tmp_path, monkeypa
 
     try:
         tc = TestClient(app, headers={"Authorization": "Bearer backfield-dev"})
-        project = tc.post(
-            "/projects",
-            json={"name": "Meta Overlay", "slug": "meta-overlay-api"},
-        ).json()
+        project = _post_project(tc, name="Meta Overlay", slug="meta-overlay-api").json()
         graph = tc.post(
             "/graphs",
             json={
@@ -282,10 +283,7 @@ def test_delete_article_meta_overlay_only_json_output(tmp_path, monkeypatch) -> 
 
     try:
         tc = TestClient(app, headers={"Authorization": "Bearer backfield-dev"})
-        project = tc.post(
-            "/projects",
-            json={"name": "Meta Delete", "slug": "meta-delete-api"},
-        ).json()
+        project = _post_project(tc, name="Meta Delete", slug="meta-delete-api").json()
         graph = tc.post(
             "/graphs",
             json={
@@ -352,9 +350,10 @@ def test_delete_article_meta_removes_substrate_row(tmp_path, monkeypatch) -> Non
 
     try:
         tc = TestClient(app, headers={"Authorization": "Bearer backfield-dev"})
-        project = tc.post(
-            "/projects",
-            json={"name": "Meta Delete Substrate", "slug": "meta-delete-substrate-api"},
+        project = _post_project(
+            tc,
+            name="Meta Delete Substrate",
+            slug="meta-delete-substrate-api",
         ).json()
         graph = tc.post(
             "/graphs",
@@ -426,10 +425,7 @@ def test_create_article_meta_overlay_only_json_output(tmp_path, monkeypatch) -> 
 
     try:
         tc = TestClient(app, headers={"Authorization": "Bearer backfield-dev"})
-        project = tc.post(
-            "/projects",
-            json={"name": "Meta Create", "slug": "meta-create-api"},
-        ).json()
+        project = _post_project(tc, name="Meta Create", slug="meta-create-api").json()
         graph = tc.post(
             "/graphs",
             json={
@@ -496,9 +492,10 @@ def test_create_article_meta_persists_substrate_row(tmp_path, monkeypatch) -> No
 
     try:
         tc = TestClient(app, headers={"Authorization": "Bearer backfield-dev"})
-        project = tc.post(
-            "/projects",
-            json={"name": "Meta Create Substrate", "slug": "meta-create-substrate-api"},
+        project = _post_project(
+            tc,
+            name="Meta Create Substrate",
+            slug="meta-create-substrate-api",
         ).json()
         graph = tc.post(
             "/graphs",

--- a/tests/agate_api/test_processed_item_s3_sync.py
+++ b/tests/agate_api/test_processed_item_s3_sync.py
@@ -13,7 +13,11 @@ from backfield_db import AgateProcessedItem, BackfieldOrganization
 from fastapi.testclient import TestClient
 from sqlmodel import Session, SQLModel, create_engine
 
-from tests.agate_api.test_agate_api import _insert_pending_run, _minimal_text_input_spec
+from tests.agate_api.test_agate_api import (
+    _insert_pending_run,
+    _minimal_text_input_spec,
+    _post_project,
+)
 
 
 def _s3_output_result_json() -> str:
@@ -62,7 +66,7 @@ def _insert_succeeded_item(
     result_json: str | None,
     status: str = "succeeded",
 ) -> tuple[str, int]:
-    project = tc.post("/projects", json={"name": "S3 Sync", "slug": "s3-sync-api"}).json()
+    project = _post_project(tc, name="S3 Sync", slug="s3-sync-api").json()
     graph = tc.post(
         "/graphs",
         json={

--- a/tests/agate_api/test_project_stylebook_ownership.py
+++ b/tests/agate_api/test_project_stylebook_ownership.py
@@ -1,0 +1,207 @@
+"""Project creation pins the selected workspace's Stylebook."""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from dataclasses import dataclass
+
+import pytest
+from api.deps import get_session
+from api.main import app
+from backfield_db import (
+    BackfieldOrganization,
+    BackfieldProject,
+    BackfieldWorkspace,
+    Stylebook,
+)
+from fastapi.testclient import TestClient
+from sqlalchemy.engine import Engine
+from sqlmodel import Session, SQLModel, create_engine
+
+
+@dataclass(frozen=True)
+class ProjectOwnershipFixture:
+    client: TestClient
+    engine: Engine
+    organization_id: int
+    workspace_id: int
+    original_stylebook_id: int
+    replacement_stylebook_id: int
+
+
+@pytest.fixture
+def ownership_fixture(tmp_path) -> Generator[ProjectOwnershipFixture, None, None]:
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'project-stylebook.db'}",
+        connect_args={"check_same_thread": False},
+    )
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as session:
+        organization = BackfieldOrganization(name="News Org", slug="news-org")
+        session.add(organization)
+        session.flush()
+        original = Stylebook(
+            organization_id=int(organization.id),
+            name="Original",
+            slug="original",
+            is_default=True,
+        )
+        replacement = Stylebook(
+            organization_id=int(organization.id),
+            name="Replacement",
+            slug="replacement",
+            is_default=False,
+        )
+        session.add(original)
+        session.add(replacement)
+        session.flush()
+        workspace = BackfieldWorkspace(
+            organization_id=int(organization.id),
+            stylebook_id=int(original.id),
+            name="Newsroom",
+            slug="newsroom",
+        )
+        session.add(workspace)
+        session.commit()
+        session.refresh(organization)
+        session.refresh(original)
+        session.refresh(replacement)
+        session.refresh(workspace)
+        organization_id = int(organization.id)
+        workspace_id = int(workspace.id)
+        original_stylebook_id = int(original.id)
+        replacement_stylebook_id = int(replacement.id)
+
+    def get_test_session() -> Generator[Session, None, None]:
+        with Session(engine) as session:
+            yield session
+
+    app.dependency_overrides[get_session] = get_test_session
+    try:
+        yield ProjectOwnershipFixture(
+            client=TestClient(app, headers={"Authorization": "Bearer backfield-dev"}),
+            engine=engine,
+            organization_id=organization_id,
+            workspace_id=workspace_id,
+            original_stylebook_id=original_stylebook_id,
+            replacement_stylebook_id=replacement_stylebook_id,
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_project_create_requires_workspace(
+    ownership_fixture: ProjectOwnershipFixture,
+) -> None:
+    missing_workspace = ownership_fixture.client.post(
+        "/projects",
+        json={
+            "name": "Missing workspace",
+        },
+    )
+    assert missing_workspace.status_code == 422
+
+
+def test_project_create_copies_workspace_stylebook_and_exposes_direct_fields(
+    ownership_fixture: ProjectOwnershipFixture,
+) -> None:
+    response = ownership_fixture.client.post(
+        "/projects",
+        json={
+            "name": "Pinned project",
+            "slug": "pinned-project",
+            "workspace_id": ownership_fixture.workspace_id,
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["stylebook_id"] == ownership_fixture.original_stylebook_id
+    assert body["stylebook_name"] == "Original"
+    assert body["stylebook_slug"] == "original"
+    assert body["workspace_stylebook_id"] == ownership_fixture.original_stylebook_id
+    with Session(ownership_fixture.engine) as session:
+        project = session.get(BackfieldProject, int(body["id"]))
+        assert project is not None
+        assert project.stylebook_id == ownership_fixture.original_stylebook_id
+
+
+def test_workspace_stylebook_change_does_not_mutate_existing_project(
+    ownership_fixture: ProjectOwnershipFixture,
+) -> None:
+    created = ownership_fixture.client.post(
+        "/projects",
+        json={
+            "name": "Stable project",
+            "slug": "stable-project",
+            "workspace_id": ownership_fixture.workspace_id,
+        },
+    )
+    assert created.status_code == 200
+    project_id = int(created.json()["id"])
+
+    with Session(ownership_fixture.engine) as session:
+        workspace = session.get(BackfieldWorkspace, ownership_fixture.workspace_id)
+        assert workspace is not None
+        workspace.stylebook_id = ownership_fixture.replacement_stylebook_id
+        session.add(workspace)
+        session.commit()
+
+    response = ownership_fixture.client.get(f"/projects/{project_id}")
+    assert response.status_code == 200
+    assert response.json()["stylebook_id"] == ownership_fixture.original_stylebook_id
+    assert response.json()["workspace_stylebook_id"] == ownership_fixture.original_stylebook_id
+    with Session(ownership_fixture.engine) as session:
+        project = session.get(BackfieldProject, project_id)
+        assert project is not None
+        assert project.stylebook_id == ownership_fixture.original_stylebook_id
+
+
+def test_project_response_falls_back_to_workspace_stylebook(
+    ownership_fixture: ProjectOwnershipFixture,
+) -> None:
+    with Session(ownership_fixture.engine) as session:
+        workspace = session.get(BackfieldWorkspace, ownership_fixture.workspace_id)
+        assert workspace is not None
+        workspace.stylebook_id = ownership_fixture.replacement_stylebook_id
+        project = BackfieldProject(
+            organization_id=ownership_fixture.organization_id,
+            workspace_id=ownership_fixture.workspace_id,
+            stylebook_id=None,
+            name="Legacy workspace project",
+            slug="legacy-workspace-project",
+        )
+        session.add(workspace)
+        session.add(project)
+        session.commit()
+        session.refresh(project)
+        project_id = int(project.id)
+
+    response = ownership_fixture.client.get(f"/projects/{project_id}")
+
+    assert response.status_code == 200
+    assert response.json()["stylebook_id"] == ownership_fixture.replacement_stylebook_id
+    assert response.json()["stylebook_name"] == "Replacement"
+
+
+def test_project_response_falls_back_to_organization_default(
+    ownership_fixture: ProjectOwnershipFixture,
+) -> None:
+    with Session(ownership_fixture.engine) as session:
+        project = BackfieldProject(
+            organization_id=ownership_fixture.organization_id,
+            workspace_id=None,
+            stylebook_id=None,
+            name="Legacy orphan project",
+            slug="legacy-orphan-project",
+        )
+        session.add(project)
+        session.commit()
+        session.refresh(project)
+        project_id = int(project.id)
+
+    response = ownership_fixture.client.get(f"/projects/{project_id}")
+
+    assert response.status_code == 200
+    assert response.json()["stylebook_id"] == ownership_fixture.original_stylebook_id
+    assert response.json()["stylebook_name"] == "Original"

--- a/tests/entities/test_resolve_effective_stylebook.py
+++ b/tests/entities/test_resolve_effective_stylebook.py
@@ -22,7 +22,7 @@ def _engine():
     return engine
 
 
-def test_effective_uses_org_default_when_slug_missing() -> None:
+def test_effective_uses_workspace_stylebook_when_project_is_unpinned() -> None:
     engine = _engine()
     with Session(engine) as session:
         org = BackfieldOrganization(slug="org-eff", name="Org Eff")
@@ -39,7 +39,7 @@ def test_effective_uses_org_default_when_slug_missing() -> None:
             organization_id=int(org.id),
             name="WS",
             slug="ws-eff",
-            stylebook_id=int(sb_b.id),
+            stylebook_id=int(sb_a.id),
         )
         session.add(ws)
         session.flush()
@@ -54,8 +54,54 @@ def test_effective_uses_org_default_when_slug_missing() -> None:
         session.commit()
 
         got = resolve_effective_stylebook_id_for_project(session, proj, stylebook_slug=None)
-        assert got == int(sb_b.id)
-        assert resolve_stylebook_id_for_project_id(session, int(proj.id)) == int(sb_b.id)
+        assert got == int(sb_a.id)
+        assert resolve_stylebook_id_for_project_id(session, int(proj.id)) == int(sb_a.id)
+
+
+def test_effective_project_stylebook_wins_after_workspace_default_changes() -> None:
+    engine = _engine()
+    with Session(engine) as session:
+        org = BackfieldOrganization(slug="org-pinned", name="Org Pinned")
+        session.add(org)
+        session.flush()
+        pinned = Stylebook(
+            organization_id=int(org.id),
+            slug="pinned",
+            name="Pinned",
+            is_default=True,
+        )
+        replacement = Stylebook(
+            organization_id=int(org.id),
+            slug="replacement",
+            name="Replacement",
+            is_default=False,
+        )
+        session.add(pinned)
+        session.add(replacement)
+        session.flush()
+        workspace = BackfieldWorkspace(
+            organization_id=int(org.id),
+            name="WS",
+            slug="ws-pinned",
+            stylebook_id=int(pinned.id),
+        )
+        session.add(workspace)
+        session.flush()
+        project = BackfieldProject(
+            organization_id=int(org.id),
+            workspace_id=int(workspace.id),
+            stylebook_id=int(pinned.id),
+            name="Project",
+            slug="project-pinned",
+        )
+        session.add(project)
+        session.flush()
+
+        workspace.stylebook_id = int(replacement.id)
+        session.add(workspace)
+        session.commit()
+
+        assert resolve_stylebook_id_for_project_id(session, int(project.id)) == int(pinned.id)
 
 
 def test_effective_override_by_slug_same_org() -> None:

--- a/tests/entities/test_stylebook_library.py
+++ b/tests/entities/test_stylebook_library.py
@@ -377,6 +377,25 @@ def test_delete_default_with_replacement() -> None:
         session.refresh(b)
         aid = int(a.id)  # type: ignore[arg-type]
         bid = int(b.id)  # type: ignore[arg-type]
+        workspace = BackfieldWorkspace(
+            organization_id=oid,
+            stylebook_id=aid,
+            name="Workspace",
+            slug="workspace-delete-reassign",
+        )
+        session.add(workspace)
+        session.flush()
+        project = BackfieldProject(
+            organization_id=oid,
+            workspace_id=int(workspace.id),
+            stylebook_id=aid,
+            name="Project",
+            slug="project-delete-reassign",
+        )
+        session.add(project)
+        session.commit()
+        project_id = int(project.id)
+        workspace_id = int(workspace.id)
 
         delete_stylebook(session, aid, replacement_default_id=bid)
         session.commit()
@@ -385,6 +404,12 @@ def test_delete_default_with_replacement() -> None:
         assert len(rest) == 1
         assert rest[0].id == bid
         assert rest[0].is_default is True
+        reassigned_project = session.get(BackfieldProject, project_id)
+        reassigned_workspace = session.get(BackfieldWorkspace, workspace_id)
+        assert reassigned_project is not None
+        assert reassigned_project.stylebook_id == bid
+        assert reassigned_workspace is not None
+        assert reassigned_workspace.stylebook_id == bid
 
 
 def test_ensure_default_still_idempotent() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -414,6 +414,7 @@ dependencies = [
     { name = "passlib", extra = ["bcrypt"] },
     { name = "pgvector" },
     { name = "psycopg", extra = ["binary"] },
+    { name = "pydantic" },
     { name = "sqlalchemy" },
     { name = "sqlmodel" },
 ]
@@ -427,6 +428,7 @@ requires-dist = [
     { name = "passlib", extras = ["bcrypt"], specifier = ">=1.7.4" },
     { name = "pgvector", specifier = ">=0.3.0" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.1.0" },
+    { name = "pydantic", specifier = ">=2.0.0" },
     { name = "sqlalchemy", specifier = ">=2.0.0" },
     { name = "sqlmodel", specifier = ">=0.0.14" },
 ]


### PR DESCRIPTION
## Summary
- add direct project Stylebook ownership with guarded workspace/default backfill
- require workspaces for new projects and pin their workspace Stylebook at creation
- add a typed, read-only tenancy preflight for graph, canonical, and ownership conflicts
- preserve rolling fallbacks and compatibility response fields

This PR is stacked on #116 while the tenancy slices are under development.

## Test plan
- [x] `make lint`
- [x] `make test`
- [x] `make smoke`
- [x] Agate UI production build
- [x] `backfield tenancy-audit --json` against local retained data
- [x] migration 069 applied through `make migrate-host`

Made with [Cursor](https://cursor.com)