### PR TITLE
Make project Stylebooks authoritative

### DIFF
--- a/apps/agate-api/src/api/routers/graphs.py
+++ b/apps/agate-api/src/api/routers/graphs.py
@@ -18,7 +18,8 @@ from backfield_db import (
 )
 from backfield_entities.catalog.graph_stylebook_refs import (
     StylebookGraphRefsError,
-    sanitize_stylebook_refs_for_organization,
+    normalize_runtime_stylebook_refs,
+    validate_runtime_stylebook_refs_for_project,
     validate_stylebook_refs_for_organization,
 )
 from fastapi import APIRouter, Depends, HTTPException
@@ -39,12 +40,11 @@ def _prepare_spec_stylebook_refs(
         return spec
     org_id = int(proj.organization_id)
     spec_dict = spec.model_dump()
-    sanitize_stylebook_refs_for_organization(
-        session,
-        organization_id=org_id,
-        spec=spec_dict,
-    )
     try:
+        validate_runtime_stylebook_refs_for_project(
+            spec_dict,
+            project_stylebook_id=int(proj.stylebook_id),
+        )
         validate_stylebook_refs_for_organization(
             session,
             organization_id=org_id,
@@ -52,6 +52,10 @@ def _prepare_spec_stylebook_refs(
         )
     except StylebookGraphRefsError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
+    normalize_runtime_stylebook_refs(
+        spec_dict,
+        project_stylebook_id=int(proj.stylebook_id),
+    )
     return GraphSpec.model_validate(spec_dict)
 
 

--- a/apps/agate-api/src/api/routers/projects.py
+++ b/apps/agate-api/src/api/routers/projects.py
@@ -92,13 +92,13 @@ class ProjectOut(BaseModel):
     system_prompt: str | None = None
     created_at: datetime
     updated_at: datetime
-    workspace_id: int | None = None
-    stylebook_id: int | None = None
-    stylebook_name: str | None = None
-    stylebook_slug: str | None = None
-    workspace_stylebook_id: int | None = None
-    workspace_stylebook_name: str | None = None
-    workspace_stylebook_slug: str | None = None
+    workspace_id: int
+    stylebook_id: int
+    stylebook_name: str
+    stylebook_slug: str
+    workspace_stylebook_id: int
+    workspace_stylebook_name: str
+    workspace_stylebook_slug: str
 
 
 def _project_to_out(session: Session, p: BackfieldProject) -> ProjectOut:
@@ -106,14 +106,14 @@ def _project_to_out(session: Session, p: BackfieldProject) -> ProjectOut:
         raise HTTPException(500, "Project row missing id")
     try:
         sid = resolve_stylebook_id_for_project_id(session, int(p.id))
-    except LookupError:
-        sid = None
-    except ValueError as error:
+    except (LookupError, ValueError) as error:
         raise HTTPException(500, "Invalid project Stylebook ownership") from error
-    stylebook = session.get(Stylebook, sid) if sid is not None else None
-    sname = str(stylebook.name) if stylebook is not None else None
-    sslug = str(stylebook.slug) if stylebook is not None else None
-    wid = int(p.workspace_id) if p.workspace_id is not None else None
+    stylebook = session.get(Stylebook, sid)
+    if stylebook is None:
+        raise HTTPException(500, "Invalid project Stylebook ownership")
+    sname = str(stylebook.name)
+    sslug = str(stylebook.slug)
+    wid = int(p.workspace_id)
     d = _settings_dict(p)
     return ProjectOut(
         id=int(p.id),
@@ -173,6 +173,9 @@ def create_project(
         raise HTTPException(400, "Workspace not found")
     workspace_id = int(ws.id)
     organization_id = int(ws.organization_id)
+    stylebook = session.get(Stylebook, int(ws.stylebook_id))
+    if stylebook is None or int(stylebook.organization_id) != organization_id:
+        raise HTTPException(400, "Workspace has an invalid Stylebook assignment")
     require_session_may_assign_project_to_workspace(
         session,
         auth,

--- a/apps/agate-ui/src/lib/flowBuilderDefaults.test.ts
+++ b/apps/agate-ui/src/lib/flowBuilderDefaults.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  getMiddleNodeDefaultData,
+  getOutputBookendDefaultData,
+} from '@/lib/flowBuilderDefaults'
+
+describe('project Stylebook inheritance', () => {
+  it('does not add a Stylebook choice to new runtime nodes', () => {
+    expect(getMiddleNodeDefaultData('GeocodeAgent')).not.toHaveProperty('stylebook_id')
+    expect(getMiddleNodeDefaultData('GeocodeAgent')).not.toHaveProperty('stylebookId')
+    expect(getOutputBookendDefaultData('DBOutput')).not.toHaveProperty('stylebook_id')
+    expect(getOutputBookendDefaultData('DBOutput')).not.toHaveProperty('stylebookId')
+  })
+})

--- a/apps/agate-ui/src/lib/flowBuilderDefaults.ts
+++ b/apps/agate-ui/src/lib/flowBuilderDefaults.ts
@@ -24,10 +24,7 @@ export function getInputBookendDefaultData(type: string): Record<string, unknown
   }
 }
 
-export function getOutputBookendDefaultData(
-  type: string,
-  workspaceStylebookId?: number | null,
-): Record<string, unknown> {
+export function getOutputBookendDefaultData(type: string): Record<string, unknown> {
   switch (type) {
     case 'Output':
       return {}
@@ -42,10 +39,7 @@ export function getOutputBookendDefaultData(
   }
 }
 
-export function getMiddleNodeDefaultData(
-  type: string,
-  workspaceStylebookId?: number | null,
-): Record<string, unknown> {
+export function getMiddleNodeDefaultData(type: string): Record<string, unknown> {
   switch (type) {
     case 'PlaceExtract':
     case 'PersonExtract':
@@ -60,11 +54,7 @@ export function getMiddleNodeDefaultData(
     }
     case 'GeocodeAgent': {
       const meta = nodeMetadata.find((m) => m.type === 'GeocodeAgent')
-      const base = { ...(meta?.defaultParams ?? {}) } as Record<string, unknown>
-      if (typeof workspaceStylebookId === 'number') {
-        base.stylebook_id = workspaceStylebookId
-      }
-      return base
+      return { ...(meta?.defaultParams ?? {}) } as Record<string, unknown>
     }
     default: {
       const meta = nodeMetadata.find((m) => m.type === type)

--- a/apps/agate-ui/src/nodes/db_output/NodeComponent.tsx
+++ b/apps/agate-ui/src/nodes/db_output/NodeComponent.tsx
@@ -34,7 +34,6 @@ const nodeMetadata = {
   ],
   "defaultParams": {
     "stylebook_matching_enabled": true,
-    "stylebook_id": null,
     "canonicalization_mode": "ai_assisted",
     "reconciliation_policy": "smart_merge",
     "auto_apply_canonicalization": true,

--- a/apps/agate-ui/src/nodes/db_output/PanelComponent.tsx
+++ b/apps/agate-ui/src/nodes/db_output/PanelComponent.tsx
@@ -34,7 +34,6 @@ const nodeMetadata = {
   ],
   "defaultParams": {
     "stylebook_matching_enabled": true,
-    "stylebook_id": null,
     "canonicalization_mode": "ai_assisted",
     "reconciliation_policy": "smart_merge",
     "auto_apply_canonicalization": true,
@@ -56,7 +55,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
-import { listOrgStylebooks, type OrgStylebook } from '@/lib/core-api'
 import {
   autoConnectionsEligibility,
   autoConnectionsIneligibleCopy,
@@ -79,7 +77,6 @@ import {
   catalogToSelectOptions,
   hasExplicitAiModelChoice,
   resolvedAiModelSelectValue,
-  resolvedStylebookId,
 } from '@/lib/nodePanelAiModel'
 
 interface DBOutputPanelProps {
@@ -91,7 +88,6 @@ interface DBOutputPanelProps {
 
 const DEFAULTS = {
   stylebook_matching_enabled: true,
-  stylebook_id: null as number | null,
   canonicalization_mode: 'ai_assisted' as 'rules' | 'ai_assisted',
   reconciliation_policy: 'smart_merge' as 'add_only' | 'smart_merge' | 'replace',
   auto_apply_canonicalization: true,
@@ -100,8 +96,6 @@ const DEFAULTS = {
   semantic_indexing_enabled: false,
   auto_connections_enabled: true,
 }
-
-const ORG_DEFAULT_STYLEBOOK_SELECT = '__org_default_stylebook__'
 
 const ADJUDICATION_MODEL_KEYS = {
   configIdKey: 'adjudication_ai_model_config_id',
@@ -130,48 +124,16 @@ export default function DBOutputPanel({
   graphContext,
 }: DBOutputPanelProps) {
   const merged = { ...DEFAULTS, ...(node.data || {}) }
-  const legacyCamel = (node.data as Record<string, unknown> | undefined)?.stylebookId
-  if (merged.stylebook_id == null && legacyCamel != null && legacyCamel !== '') {
-    ;(merged as Record<string, unknown>).stylebook_id = legacyCamel
-  }
-
-  const paramStylebookId = resolvedStylebookId(merged as Record<string, unknown>)
 
   const disabled = !(editMode && setNodes)
-  const orgId = graphContext?.organizationId ?? null
   const projectId = graphContext?.projectId ?? null
 
-  const [stylebooks, setStylebooks] = useState<OrgStylebook[]>([])
-  const [stylebooksError, setStylebooksError] = useState<string | null>(null)
   const [catalogRows, setCatalogRows] = useState<ProjectAiModelOption[]>([])
   const [catalogLoading, setCatalogLoading] = useState(false)
   const [catalogError, setCatalogError] = useState<string | null>(null)
   const [semanticIndexingConfigured, setSemanticIndexingConfigured] = useState<boolean | null>(
     null,
   )
-
-  useEffect(() => {
-    if (!orgId) {
-      setStylebooks([])
-      setStylebooksError(null)
-      return
-    }
-    let cancelled = false
-    setStylebooksError(null)
-    listOrgStylebooks(orgId)
-      .then((rows) => {
-        if (!cancelled) setStylebooks(rows)
-      })
-      .catch((e: unknown) => {
-        if (!cancelled) {
-          setStylebooks([])
-          setStylebooksError(e instanceof Error ? e.message : 'Could not load catalogs.')
-        }
-      })
-    return () => {
-      cancelled = true
-    }
-  }, [orgId])
 
   useEffect(() => {
     const fetcher = graphContext?.fetchProjectAiModels
@@ -314,47 +276,6 @@ export default function DBOutputPanel({
     })
   }
 
-  const missingFromList = paramStylebookId != null && !stylebooks.some((s) => s.id === paramStylebookId)
-
-  useEffect(() => {
-    if (!editMode || !setNodes || !missingFromList || paramStylebookId == null) return
-    if (stylebooks.length === 0) return
-    setNodes((nodes: any[]) =>
-      nodes.map((n) =>
-        n.id === node.id
-          ? { ...n, data: mergeData({ ...(n.data || {}), stylebook_id: null }) }
-          : n,
-      ),
-    )
-  }, [editMode, setNodes, missingFromList, paramStylebookId, stylebooks.length, node.id])
-
-  const orgDefaultStylebook = stylebooks.find((sb) => sb.is_default)
-  const usesOrgDefault =
-    paramStylebookId == null ||
-    (orgDefaultStylebook != null && paramStylebookId === orgDefaultStylebook.id)
-
-  const stylebookSelectValue = usesOrgDefault
-    ? ORG_DEFAULT_STYLEBOOK_SELECT
-    : String(paramStylebookId)
-
-  const handleStylebookSelect = (value: string) => {
-    if (!setNodes) return
-    const nextId = value === ORG_DEFAULT_STYLEBOOK_SELECT ? null : Number(value)
-    setNodes((nodes: any[]) =>
-      nodes.map((n) =>
-        n.id === node.id ? { ...n, data: mergeData({ ...(n.data || {}), stylebook_id: nextId }) } : n,
-      ),
-    )
-  }
-
-  const defaultOptionLabel = orgDefaultStylebook?.name
-    ? `${orgDefaultStylebook.name} (Default)`
-    : 'Default'
-
-  const selectableStylebooks = orgDefaultStylebook
-    ? stylebooks.filter((sb) => sb.id !== orgDefaultStylebook.id)
-    : stylebooks
-
   const data = merged
   const stylebookMatchingEnabled = Boolean(data.stylebook_matching_enabled)
   const semanticIndexingEnabled = Boolean(data.semantic_indexing_enabled)
@@ -493,48 +414,6 @@ export default function DBOutputPanel({
           </p>
         ) : (
           <div className="space-y-4">
-            <div className="space-y-2">
-              <Label htmlFor="dbout-stylebook">Stylebook</Label>
-              <Select
-                value={stylebookSelectValue}
-                onValueChange={handleStylebookSelect}
-                disabled={disabled || orgId == null}
-              >
-                <SelectTrigger id="dbout-stylebook" className="text-xs">
-                  <SelectValue placeholder="Choose a Stylebook" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value={ORG_DEFAULT_STYLEBOOK_SELECT}>{defaultOptionLabel}</SelectItem>
-                  {missingFromList && paramStylebookId != null ? (
-                    <SelectItem value={String(paramStylebookId)}>
-                      {stylebooks.length === 0 && !stylebooksError
-                        ? `Saved selection (ID ${paramStylebookId})`
-                        : `Saved Stylebook unavailable (ID ${paramStylebookId})`}
-                    </SelectItem>
-                  ) : null}
-                  {selectableStylebooks.map((sb) => (
-                    <SelectItem key={sb.id} value={String(sb.id)}>
-                      {sb.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              {orgId == null && (
-                <p className="text-xs text-muted-foreground">
-                  Save the flow to a project (or open an existing project flow) to choose a Stylebook
-                  for your organization.
-                </p>
-              )}
-              {orgId != null && stylebooks.length === 0 && !stylebooksError && (
-                <p className="text-xs text-muted-foreground">Loading Stylebooks…</p>
-              )}
-              {stylebooksError && <p className="text-xs text-destructive">{stylebooksError}</p>}
-              <p className="text-xs text-muted-foreground">
-                Default uses your organization&apos;s default Stylebook. Choose another to match and
-                write against a different catalog.
-              </p>
-            </div>
-
             <div className="space-y-2">
               <Label htmlFor="dbout-mode">Matching strategy</Label>
               <Select

--- a/apps/agate-ui/src/nodes/geocode_agent/NodeComponent.tsx
+++ b/apps/agate-ui/src/nodes/geocode_agent/NodeComponent.tsx
@@ -34,7 +34,6 @@ const nodeMetadata = {
     "maxLocations": 200,
     "perLocationTimeout": 300,
     "useCache": true,
-    "stylebook_id": null,
     "stylebookApiUrl": "",
     "projectSlug": "",
     "evaluationModel": "",

--- a/apps/agate-ui/src/nodes/geocode_agent/PanelComponent.tsx
+++ b/apps/agate-ui/src/nodes/geocode_agent/PanelComponent.tsx
@@ -34,7 +34,6 @@ const nodeMetadata = {
     "maxLocations": 200,
     "perLocationTimeout": 300,
     "useCache": true,
-    "stylebook_id": null,
     "stylebookApiUrl": "",
     "projectSlug": "",
     "evaluationModel": "",
@@ -54,7 +53,6 @@ import { useEffect, useMemo, useState } from 'react'
 import { NodePanelTabGate } from '@/components/node-panel/NodePanelTabContext'
 import type { GraphPanelContext, ProjectAiModelOption } from '@/components/NodePanel'
 import { Label } from '@/components/ui/label'
-import { listOrgStylebooks, type OrgStylebook } from '@/lib/core-api'
 import {
   Select,
   SelectContent,
@@ -67,16 +65,12 @@ import {
   catalogToSelectOptions,
   hasExplicitAiModelChoice,
   resolvedAiModelSelectValue,
-  resolvedStylebookId,
 } from '@/lib/nodePanelAiModel'
-
-const NO_STYLEBOOK_VALUE = '__bf_no_stylebook__'
 
 const DEFAULTS = {
   maxLocations: 200,
   perLocationTimeout: 300,
   useCache: true,
-  stylebook_id: null as number | null,
   stylebookApiUrl: '',
   projectSlug: '',
   evaluationModel: '',
@@ -169,43 +163,13 @@ export default function GeocodeAgentPanel({
   graphContext,
 }: GeocodeAgentPanelProps) {
   const merged = { ...DEFAULTS, ...(node.data || {}) }
-  const legacyCamel = (node.data as Record<string, unknown> | undefined)?.stylebookId
-  if (merged.stylebook_id == null && legacyCamel != null && legacyCamel !== '') {
-    ;(merged as Record<string, unknown>).stylebook_id = legacyCamel
-  }
   const params = merged
 
   const isDisabled = !(editMode && setNodes)
-  const orgId = graphContext?.organizationId ?? null
   const projectId = graphContext?.projectId ?? null
-  const [stylebooks, setStylebooks] = useState<OrgStylebook[]>([])
-  const [stylebooksError, setStylebooksError] = useState<string | null>(null)
   const [catalogRows, setCatalogRows] = useState<ProjectAiModelOption[]>([])
   const [catalogLoading, setCatalogLoading] = useState(false)
   const [catalogError, setCatalogError] = useState<string | null>(null)
-
-  useEffect(() => {
-    if (!orgId || !params.useCache) {
-      setStylebooks([])
-      setStylebooksError(null)
-      return
-    }
-    let cancelled = false
-    setStylebooksError(null)
-    listOrgStylebooks(orgId)
-      .then((rows) => {
-        if (!cancelled) setStylebooks(rows)
-      })
-      .catch((e: unknown) => {
-        if (!cancelled) {
-          setStylebooks([])
-          setStylebooksError(e instanceof Error ? e.message : 'Could not load Stylebooks.')
-        }
-      })
-    return () => {
-      cancelled = true
-    }
-  }, [orgId, params.useCache])
 
   useEffect(() => {
     const fetcher = graphContext?.fetchProjectAiModels
@@ -361,70 +325,13 @@ export default function GeocodeAgentPanel({
   const handleUseCacheChange = (checked: boolean) => {
     if (setNodes) {
       setNodes((nodes: any[]) =>
-        nodes.map((n) => {
-          if (n.id !== node.id) return n
-          const data = mergeData({ ...(n.data || {}), useCache: checked })
-          if (!checked) {
-            data.stylebook_id = null
-          }
-          return { ...n, data }
-        }),
-      )
-    }
-  }
-
-  const paramStylebookId = resolvedStylebookId(params as Record<string, unknown>)
-  const orgDefaultStylebook = stylebooks.find((sb) => sb.is_default)
-  const missingStylebookFromList =
-    params.useCache &&
-    paramStylebookId != null &&
-    !stylebooks.some((s) => s.id === paramStylebookId)
-
-  useEffect(() => {
-    if (!editMode || !setNodes || !missingStylebookFromList || paramStylebookId == null) return
-    if (stylebooks.length === 0) return
-    const nextId = orgDefaultStylebook?.id ?? null
-    if (nextId == null) return
-    setNodes((nodes: any[]) =>
-      nodes.map((n) =>
-        n.id === node.id
-          ? { ...n, data: mergeData({ ...(n.data || {}), stylebook_id: nextId }) }
-          : n,
-      ),
-    )
-  }, [
-    editMode,
-    setNodes,
-    missingStylebookFromList,
-    paramStylebookId,
-    stylebooks.length,
-    orgDefaultStylebook?.id,
-    node.id,
-  ])
-
-  const stylebookSelectValue =
-    paramStylebookId != null ? String(paramStylebookId) : NO_STYLEBOOK_VALUE
-
-  const handleStylebookSelect = (value: string) => {
-    if (!setNodes) return
-    if (value === NO_STYLEBOOK_VALUE) {
-      setNodes((nodes: any[]) =>
         nodes.map((n) =>
           n.id === node.id
-            ? { ...n, data: mergeData({ ...(n.data || {}), stylebook_id: null }) }
+            ? { ...n, data: mergeData({ ...(n.data || {}), useCache: checked }) }
             : n,
         ),
       )
-      return
     }
-    const nextId = Number(value)
-    setNodes((nodes: any[]) =>
-      nodes.map((n) =>
-        n.id === node.id
-          ? { ...n, data: mergeData({ ...(n.data || {}), stylebook_id: nextId }) }
-          : n,
-      ),
-    )
   }
 
   const handleEvaluationModel = (selectValue: string) => {
@@ -556,39 +463,6 @@ export default function GeocodeAgentPanel({
             </p>
           </div>
 
-          {params.useCache && (
-            <div className="space-y-2">
-              <Label htmlFor="geocode-stylebook" className="text-sm font-medium">
-                Stylebook
-              </Label>
-              <Select
-                value={stylebookSelectValue}
-                onValueChange={handleStylebookSelect}
-                disabled={isDisabled}
-              >
-                <SelectTrigger id="geocode-stylebook" className="text-xs">
-                  <SelectValue placeholder="Choose a Stylebook" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value={NO_STYLEBOOK_VALUE}>None</SelectItem>
-                  {stylebooks.map((sb) => (
-                    <SelectItem key={sb.id} value={String(sb.id)}>
-                      {sb.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              {orgId == null && (
-                <p className="text-xs text-muted-foreground">
-                  Save the flow to a project to load Stylebooks for your organization.
-                </p>
-              )}
-              {orgId != null && params.useCache && stylebooks.length === 0 && !stylebooksError && (
-                <p className="text-xs text-muted-foreground">Loading Stylebooks…</p>
-              )}
-              {stylebooksError && <p className="text-xs text-destructive">{stylebooksError}</p>}
-            </div>
-          )}
         </div>
       </NodePanelTabGate>
 

--- a/apps/agate-ui/src/nodes/geocode_agent/VisualizationComponent.tsx
+++ b/apps/agate-ui/src/nodes/geocode_agent/VisualizationComponent.tsx
@@ -34,7 +34,6 @@ const nodeMetadata = {
     "maxLocations": 200,
     "perLocationTimeout": 300,
     "useCache": true,
-    "stylebook_id": null,
     "stylebookApiUrl": "",
     "projectSlug": "",
     "evaluationModel": "",

--- a/apps/agate-ui/src/pages/GuidedFlowBuilder.tsx
+++ b/apps/agate-ui/src/pages/GuidedFlowBuilder.tsx
@@ -460,7 +460,6 @@ const GuidedFlowBuilder = forwardRef<GuidedFlowBuilderHandle, GuidedFlowBuilderP
   }, [isRunVariant, scaffoldModel])
 
   const flowProjectId = resolvedFlowProject?.id ?? null
-  const workspaceStylebookId = resolvedFlowProject?.workspace_stylebook_id ?? null
 
   useEffect(() => {
     if (resolvedFlowProject?.workspace_id == null) {
@@ -712,7 +711,7 @@ const GuidedFlowBuilder = forwardRef<GuidedFlowBuilderHandle, GuidedFlowBuilderP
       const data = (
         isInput
           ? getInputBookendDefaultData(type)
-          : getOutputBookendDefaultData(type, workspaceStylebookId)
+          : getOutputBookendDefaultData(type)
       ) as Record<string, unknown>
       const node: Node = { id, type, data, position: currentBookend?.position ?? { x: 0, y: 0 } }
 
@@ -789,7 +788,6 @@ const GuidedFlowBuilder = forwardRef<GuidedFlowBuilderHandle, GuidedFlowBuilderP
       inputNode,
       outputNode,
       scaffoldModel,
-      workspaceStylebookId,
       resetStepsAfterInput,
       resetStepsAfterOutput,
       clearScaffold,
@@ -1538,7 +1536,7 @@ const GuidedFlowBuilder = forwardRef<GuidedFlowBuilderHandle, GuidedFlowBuilderP
       const newNode = {
         id: nextNodeId(),
         type,
-        data: getMiddleNodeDefaultData(type, workspaceStylebookId),
+        data: getMiddleNodeDefaultData(type),
       }
       setScaffoldModel((model) => {
         if (!model) return model
@@ -1559,7 +1557,7 @@ const GuidedFlowBuilder = forwardRef<GuidedFlowBuilderHandle, GuidedFlowBuilderP
       setAddFromParentId(null)
       setAddIntoEdge(null)
     },
-    [addFromParentId, addIntoEdge, scaffoldModel, workspaceStylebookId],
+    [addFromParentId, addIntoEdge, scaffoldModel],
   )
 
   /**

--- a/apps/core-api/src/core_api/routers/public/entities/locations/helpers.py
+++ b/apps/core-api/src/core_api/routers/public/entities/locations/helpers.py
@@ -43,6 +43,11 @@ def resolve_public_locations_scope(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=detail,
         ) from exc
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Stylebook does not match the project's assigned Stylebook",
+        ) from exc
     return stylebook_id, int(project.id)  # type: ignore[arg-type]
 
 

--- a/apps/core-api/src/core_api/routers/public/entities/organizations/helpers.py
+++ b/apps/core-api/src/core_api/routers/public/entities/organizations/helpers.py
@@ -46,6 +46,11 @@ def resolve_public_organizations_scope(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=detail,
         ) from exc
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Stylebook does not match the project's assigned Stylebook",
+        ) from exc
     return stylebook_id, int(project.id)  # type: ignore[arg-type]
 
 

--- a/apps/core-api/src/core_api/routers/public/entities/people/helpers.py
+++ b/apps/core-api/src/core_api/routers/public/entities/people/helpers.py
@@ -43,6 +43,11 @@ def resolve_public_people_scope(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=detail,
         ) from exc
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Stylebook does not match the project's assigned Stylebook",
+        ) from exc
     return stylebook_id, int(project.id)  # type: ignore[arg-type]
 
 

--- a/apps/stylebook-api/src/stylebook_api/entities/location/candidates.py
+++ b/apps/stylebook-api/src/stylebook_api/entities/location/candidates.py
@@ -52,6 +52,7 @@ from stylebook_api.helpers.project_scope import (
     require_stylebook_id as _require_stylebook_id,
 )
 from stylebook_api.mention_serialization import article_fields_for_linked_mention
+from stylebook_api.stylebook_permissions import require_stylebook_edit_access_by_id
 
 router = APIRouter(prefix="/v1", tags=["location-candidates"])
 
@@ -533,7 +534,8 @@ def candidate_update_note(
     """Attach a short editor note to a review queue item (stored on the location row)."""
     proj = _project_by_slug(session, project_slug)
     require_project_access(session, auth, int(proj.id))
-    _ = _require_stylebook_id(session, proj, stylebook_slug)
+    stylebook_id = _require_stylebook_id(session, proj, stylebook_slug)
+    require_stylebook_edit_access_by_id(session, auth=auth, stylebook_id=stylebook_id)
 
     loc = session.get(SubstrateLocation, substrate_location_id)
     if loc is None or int(loc.project_id) != int(proj.id):
@@ -662,7 +664,8 @@ def defer_candidate(
     """Defer canonical linking for a substrate row (remove from open queue without linking)."""
     proj = _project_by_slug(session, project_slug)
     require_project_access(session, auth, int(proj.id))
-    _ = _require_stylebook_id(session, proj, stylebook_slug)
+    stylebook_id = _require_stylebook_id(session, proj, stylebook_slug)
+    require_stylebook_edit_access_by_id(session, auth=auth, stylebook_id=stylebook_id)
 
     loc = session.get(SubstrateLocation, substrate_location_id)
     if loc is None or int(loc.project_id) != int(proj.id):
@@ -694,7 +697,8 @@ def clear_candidate_recommendation(
 ) -> dict[str, str]:
     proj = _project_by_slug(session, project_slug)
     require_project_access(session, auth, int(proj.id))
-    _ = _require_stylebook_id(session, proj, stylebook_slug)
+    stylebook_id = _require_stylebook_id(session, proj, stylebook_slug)
+    require_stylebook_edit_access_by_id(session, auth=auth, stylebook_id=stylebook_id)
 
     loc = session.get(SubstrateLocation, substrate_location_id)
     if loc is None or int(loc.project_id) != int(proj.id):
@@ -727,6 +731,7 @@ def accept_candidate(
     proj = _project_by_slug(session, project_slug)
     require_project_access(session, auth, int(proj.id))
     stylebook_id = _require_stylebook_id(session, proj, stylebook_slug)
+    require_stylebook_edit_access_by_id(session, auth=auth, stylebook_id=stylebook_id)
 
     loc = session.get(SubstrateLocation, substrate_location_id)
     if loc is None or int(loc.project_id) != int(proj.id):

--- a/apps/stylebook-api/src/stylebook_api/entities/organization/candidates.py
+++ b/apps/stylebook-api/src/stylebook_api/entities/organization/candidates.py
@@ -47,6 +47,7 @@ from stylebook_api.helpers.project_scope import (
     require_stylebook_id as _require_stylebook_id,
 )
 from stylebook_api.mention_serialization import article_fields_for_linked_mention
+from stylebook_api.stylebook_permissions import require_stylebook_edit_access_by_id
 
 router = APIRouter(prefix="/v1/organizations", tags=["organization-candidates"])
 
@@ -487,7 +488,8 @@ def candidate_update_note(
     """Attach a short editor note to a review queue item (stored on the organization row)."""
     proj = _project_by_slug(session, project_slug)
     require_project_access(session, auth, int(proj.id))
-    _ = _require_stylebook_id(session, proj, stylebook_slug)
+    stylebook_id = _require_stylebook_id(session, proj, stylebook_slug)
+    require_stylebook_edit_access_by_id(session, auth=auth, stylebook_id=stylebook_id)
 
     organization = session.get(SubstrateOrganization, substrate_organization_id)
     if organization is None or int(organization.project_id) != int(proj.id):
@@ -616,7 +618,8 @@ def defer_candidate(
     """Defer canonical linking for a substrate row (remove from open queue without linking)."""
     proj = _project_by_slug(session, project_slug)
     require_project_access(session, auth, int(proj.id))
-    _ = _require_stylebook_id(session, proj, stylebook_slug)
+    stylebook_id = _require_stylebook_id(session, proj, stylebook_slug)
+    require_stylebook_edit_access_by_id(session, auth=auth, stylebook_id=stylebook_id)
 
     organization = session.get(SubstrateOrganization, substrate_organization_id)
     if organization is None or int(organization.project_id) != int(proj.id):
@@ -648,7 +651,8 @@ def clear_candidate_recommendation(
 ) -> dict[str, str]:
     proj = _project_by_slug(session, project_slug)
     require_project_access(session, auth, int(proj.id))
-    _ = _require_stylebook_id(session, proj, stylebook_slug)
+    stylebook_id = _require_stylebook_id(session, proj, stylebook_slug)
+    require_stylebook_edit_access_by_id(session, auth=auth, stylebook_id=stylebook_id)
 
     organization = session.get(SubstrateOrganization, substrate_organization_id)
     if organization is None or int(organization.project_id) != int(proj.id):
@@ -681,6 +685,7 @@ def accept_candidate(
     proj = _project_by_slug(session, project_slug)
     require_project_access(session, auth, int(proj.id))
     stylebook_id = _require_stylebook_id(session, proj, stylebook_slug)
+    require_stylebook_edit_access_by_id(session, auth=auth, stylebook_id=stylebook_id)
 
     organization = session.get(SubstrateOrganization, substrate_organization_id)
     if organization is None or int(organization.project_id) != int(proj.id):

--- a/apps/stylebook-api/src/stylebook_api/entities/person/candidates.py
+++ b/apps/stylebook-api/src/stylebook_api/entities/person/candidates.py
@@ -46,6 +46,7 @@ from stylebook_api.helpers.project_scope import (
     require_stylebook_id as _require_stylebook_id,
 )
 from stylebook_api.mention_serialization import article_fields_for_linked_mention
+from stylebook_api.stylebook_permissions import require_stylebook_edit_access_by_id
 
 router = APIRouter(prefix="/v1/people", tags=["person-candidates"])
 
@@ -471,7 +472,8 @@ def candidate_update_note(
     """Attach a short editor note to a review queue item (stored on the person row)."""
     proj = _project_by_slug(session, project_slug)
     require_project_access(session, auth, int(proj.id))
-    _ = _require_stylebook_id(session, proj, stylebook_slug)
+    stylebook_id = _require_stylebook_id(session, proj, stylebook_slug)
+    require_stylebook_edit_access_by_id(session, auth=auth, stylebook_id=stylebook_id)
 
     person = session.get(SubstratePerson, substrate_person_id)
     if person is None or int(person.project_id) != int(proj.id):
@@ -600,7 +602,8 @@ def defer_candidate(
     """Defer canonical linking for a substrate row (remove from open queue without linking)."""
     proj = _project_by_slug(session, project_slug)
     require_project_access(session, auth, int(proj.id))
-    _ = _require_stylebook_id(session, proj, stylebook_slug)
+    stylebook_id = _require_stylebook_id(session, proj, stylebook_slug)
+    require_stylebook_edit_access_by_id(session, auth=auth, stylebook_id=stylebook_id)
 
     person = session.get(SubstratePerson, substrate_person_id)
     if person is None or int(person.project_id) != int(proj.id):
@@ -632,7 +635,8 @@ def clear_candidate_recommendation(
 ) -> dict[str, str]:
     proj = _project_by_slug(session, project_slug)
     require_project_access(session, auth, int(proj.id))
-    _ = _require_stylebook_id(session, proj, stylebook_slug)
+    stylebook_id = _require_stylebook_id(session, proj, stylebook_slug)
+    require_stylebook_edit_access_by_id(session, auth=auth, stylebook_id=stylebook_id)
 
     person = session.get(SubstratePerson, substrate_person_id)
     if person is None or int(person.project_id) != int(proj.id):
@@ -665,6 +669,7 @@ def accept_candidate(
     proj = _project_by_slug(session, project_slug)
     require_project_access(session, auth, int(proj.id))
     stylebook_id = _require_stylebook_id(session, proj, stylebook_slug)
+    require_stylebook_edit_access_by_id(session, auth=auth, stylebook_id=stylebook_id)
 
     person = session.get(SubstratePerson, substrate_person_id)
     if person is None or int(person.project_id) != int(proj.id):

--- a/apps/stylebook-api/src/stylebook_api/routers/stylebook_candidate_ai_review.py
+++ b/apps/stylebook-api/src/stylebook_api/routers/stylebook_candidate_ai_review.py
@@ -118,12 +118,18 @@ def _require_project_in_stylebook_org(
     *,
     project_slug: str,
     organization_id: int,
+    stylebook_id: int,
     auth: dict[str, Any],
 ) -> BackfieldProject:
     proj = _project_by_slug(session, project_slug)
     if int(proj.organization_id) != organization_id:
         raise HTTPException(status_code=400, detail="Project is not in this organization")
     require_project_access(session, auth, int(proj.id))
+    if int(proj.stylebook_id) != stylebook_id:
+        raise HTTPException(
+            status_code=400,
+            detail="Stylebook does not match the project's assigned Stylebook",
+        )
     return proj
 
 
@@ -175,6 +181,7 @@ def start_candidate_ai_review(
         session,
         project_slug=body.project_slug.strip(),
         organization_id=int(sb.organization_id),
+        stylebook_id=int(sb.id),
         auth=auth,
     )
     _validate_model_selection(
@@ -226,6 +233,7 @@ def cancel_candidate_ai_review(
     review = session.get(StylebookCandidateAiReview, review_id)
     if review is None or int(review.stylebook_id) != int(sb.id):
         raise HTTPException(status_code=404, detail="Review not found")
+    require_project_access(session, auth, int(review.project_id))
     if review.status not in ("queued", "running"):
         raise HTTPException(
             status_code=400,
@@ -261,6 +269,7 @@ def get_latest_candidate_ai_review(
         session,
         project_slug=project_slug.strip(),
         organization_id=int(sb.organization_id),
+        stylebook_id=int(sb.id),
         auth=auth,
     )
     row = session.exec(
@@ -294,4 +303,5 @@ def get_candidate_ai_review(
     review = session.get(StylebookCandidateAiReview, review_id)
     if review is None or int(review.stylebook_id) != int(sb.id):
         raise HTTPException(status_code=404, detail="Review not found")
+    require_project_access(session, auth, int(review.project_id))
     return CandidateAiReviewOut.from_row(review)

--- a/apps/stylebook-api/src/stylebook_api/stylebook_permissions.py
+++ b/apps/stylebook-api/src/stylebook_api/stylebook_permissions.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from backfield_auth.gate import require_org_admin
-from backfield_db import StylebookMembership
+from backfield_db import Stylebook, StylebookMembership
 from fastapi import HTTPException
 from sqlmodel import Session, select
 
@@ -55,5 +55,38 @@ def require_stylebook_edit_access(
 ) -> None:
     if can_edit_stylebook(session, auth=auth, stylebook_slug=stylebook_slug):
         return
+    raise HTTPException(status_code=403, detail="No permission to edit this stylebook")
+
+
+def require_stylebook_edit_access_by_id(
+    session: Session,
+    *,
+    auth: dict[str, Any],
+    stylebook_id: int,
+) -> None:
+    """Require edit access for a project-derived Stylebook id."""
+    if auth.get("type") == "service":
+        return
+    if auth.get("type") == "api_key":
+        raise HTTPException(status_code=403, detail="No permission to edit this stylebook")
+    stylebook = session.get(Stylebook, stylebook_id)
+    if stylebook is None:
+        raise HTTPException(status_code=404, detail="Stylebook not found")
+    try:
+        require_org_admin(session, auth, int(stylebook.organization_id))
+        return
+    except HTTPException:
+        pass
+    user = auth.get("user")
+    if user is not None and user.id is not None:
+        membership = session.exec(
+            select(StylebookMembership).where(
+                StylebookMembership.stylebook_id == stylebook_id,
+                StylebookMembership.user_id == int(user.id),
+                StylebookMembership.role == "editor",
+            )
+        ).first()
+        if membership is not None:
+            return
     raise HTTPException(status_code=403, detail="No permission to edit this stylebook")
 

--- a/docs/api/agate.md
+++ b/docs/api/agate.md
@@ -30,14 +30,16 @@ Project, flow, and run access is checked against the resource's project. Organiz
   endpoint never falls back to a default organization. API keys cannot create projects.
 - Secret responses contain metadata, never secret values.
 - Project responses expose direct `stylebook_id`, `stylebook_name`, and `stylebook_slug` fields
-  while retaining the `workspace_stylebook_*` response fields for compatibility. During rollout,
-  reads resolve the direct project Stylebook first, then the workspace Stylebook, then the
-  organization default (or first catalog by id for a legacy organization with no marked default).
-  A later workspace Stylebook change does not alter existing projects.
+  while retaining the `workspace_stylebook_*` response fields for compatibility. The direct
+  project Stylebook is authoritative. A later workspace Stylebook change does not alter existing
+  projects.
 
 ### Flows and templates
 
-`/graphs` creates, lists, validates, updates, and deletes saved `GraphSpec` flows. Referenced node Stylebook identifiers must exist in the flow project's organization. Graph responses include descriptive and public-run settings used by Agate UI and Core API.
+`/graphs` creates, lists, validates, updates, and deletes saved `GraphSpec` flows. Graph create and
+update normalize Backfield Output and GeocodeAgent compatibility parameters to the project's
+Stylebook. Completed run snapshots are not rewritten. Graph responses include descriptive and
+public-run settings used by Agate UI and Core API.
 
 `/templates` lists flow templates and instantiates a template into a project after project-access checks.
 
@@ -97,6 +99,9 @@ Backfield Output persists consolidated article content and the domains present i
 - semantic mention documents when enabled;
 - automatic entity connections when configured.
 
-Entity reconciliation supports `add_only`, `smart_merge`, and `replace`. The policy applies to each current entity domain represented in the consolidated payload, and the node returns per-domain reconciliation summaries. Catalog matching resolves an explicit node Stylebook when configured, otherwise the organization's default Stylebook (or its first Stylebook by id).
+Entity reconciliation supports `add_only`, `smart_merge`, and `replace`. The policy applies to
+each current entity domain represented in the consolidated payload, and the node returns
+per-domain reconciliation summaries. Catalog matching always uses the project's Stylebook; a
+legacy node value is accepted only when it matches.
 
 Backfield Output persistence runs in the worker. The package-level runner is a no-op outside that worker context so local graph execution can still return the node's output shape.

--- a/docs/api/stylebook.md
+++ b/docs/api/stylebook.md
@@ -10,7 +10,9 @@ Routes accept the signed browser `session` cookie, `SERVICE_API_TOKEN` Bearer au
 
 Two scopes are used:
 
-- Project-scoped routes take `project_slug`, resolve it to a project, and require project access. An optional `stylebook_slug` selects another Stylebook in the same organization; when omitted, the organization's default Stylebook is used (or its first Stylebook by id when none is marked default).
+- Project-scoped routes take `project_slug`, resolve it to a project, and require project access.
+  They always use the project's assigned Stylebook. A temporary `stylebook_slug` parameter remains
+  accepted only when it matches that assignment; conflicting values are rejected.
 - Stylebook-scoped routes take `stylebook_slug` and require the Stylebook to belong to the authenticated organization. Reads follow the caller's catalog access. Writes require an organization admin, a Stylebook editor membership, or the service token. Project API keys cannot edit a Stylebook.
 
 Organization library routes compare `org_id` with the session organization. The service token is allowed for automation across organizations.
@@ -40,6 +42,10 @@ Location geometry uses GeoJSON `Point`, `Polygon`, or `MultiPolygon` with longit
 Canonical metadata is Stylebook-wide editorial data. Its rows retain a project association for storage and bundle transfer, but reads are not filtered to that project. Writes use the organization's first project as that association, so the organization must contain at least one project.
 
 ## Saved entities and candidate review
+
+Candidate reads require project access. Location, person, and organization candidate mutations
+(notes, deferral, recommendation clearing, and acceptance/linking or canonical creation) also
+require edit permission for the project's Stylebook.
 
 Project-scoped saved entity routes manage article evidence before or after a canonical decision:
 

--- a/docs/architecture/canonicalization.md
+++ b/docs/architecture/canonicalization.md
@@ -121,16 +121,8 @@ occurrence evidence; canonical identity is resolved through the substrate link a
 
 ## Catalog selection
 
-Catalog selection follows one current rule:
-
-1. An explicit Stylebook row id, validated against the project's organization.
-2. A supplied Stylebook slug, including slug redirects.
-3. The project's direct Stylebook ownership.
-4. The project's workspace Stylebook during the rolling-compatibility window.
-5. The organization's default Stylebook, falling back to the first catalog by id when no row is
-   marked default.
-
-Backfield Output uses an explicit id or the project ownership chain. Stylebook routes can use a
-slug or that same ownership chain. GeocodeAgent does not use this fallback: its project-scoped
-substrate cache works without a Stylebook id, while canonical lookup, adjudication, and
-materialization require the node's explicit Stylebook id.
+The project's direct Stylebook ownership is authoritative. Temporary explicit-id and slug
+parameters remain compatible only when they identify that same Stylebook; conflicting values are
+rejected. Backfield Output and GeocodeAgent inherit the project assignment. Graph writes persist
+that id on those nodes for rolling worker compatibility, while completed run snapshots remain
+unchanged.

--- a/docs/architecture/database.md
+++ b/docs/architecture/database.md
@@ -23,8 +23,9 @@ All schema changes use the single Alembic chain under `packages/backfield-db/ale
 - Organizations, workspaces, projects, and users:
   `backfield_organization`, `backfield_workspace`, `backfield_project`, `backfield_user`.
   Projects store both their workspace and a direct Stylebook ownership reference. The direct
-  reference is nullable during rollout, indexed for project-to-catalog joins, and is copied from
-  the selected workspace when a project is created.
+  reference and workspace are required, indexed, and copied from the selected workspace when a
+  project is created. Composite foreign keys prevent projects and workspaces from retaining
+  cross-organization ownership references.
 - Access grants and API keys: `backfield_organization_membership`,
   `backfield_workspace_membership`, `backfield_project_membership`,
   `backfield_api_credential`.
@@ -92,10 +93,10 @@ shared entity rows are not trusted because sibling batch items may reuse the sam
   `stylebook_candidate_ai_review`.
 
 Canonical ids are UUID strings. Canonical slugs are unique within a Stylebook, and aliases are
-unique by canonical plus normalized alias. A Stylebook belongs to one organization. Catalog reads
-prefer the project's direct Stylebook, then its workspace Stylebook for rolling compatibility,
-then the organization's default. Changing a workspace's Stylebook affects future project creation
-but does not rewrite existing project ownership.
+unique by canonical plus normalized alias. A Stylebook belongs to one organization. The project's
+direct `stylebook_id` is authoritative for project-scoped reads and runtime writes. Compatibility
+slug or node parameters are accepted only when they match that assignment. Changing a workspace's
+Stylebook affects future project creation but does not rewrite existing project ownership.
 
 Deleting a Stylebook reassigns projects, workspaces, and graph Stylebook refs, resets linked
 substrate rows to pending, removes non-cascading dependents (activity, bundle jobs, cleanup and

--- a/docs/operations/migrations.md
+++ b/docs/operations/migrations.md
@@ -21,6 +21,11 @@ projects or graphs, or change canonical links. Canonical-link mismatches are agg
 project, entity type, expected Stylebook, and actual Stylebook, with an affected count and a
 five-id sample so large datasets still produce practical reports.
 
+The strict project runtime migration validates retained projects before making `workspace_id` and
+`stylebook_id` required. It stops with the first project or workspace that has a null, missing, or
+cross-organization assignment. Repair those rows and rerun the migration; it does not guess a
+replacement catalog.
+
 ## Local workflow
 
 With the Compose stack configuration:

--- a/packages/backfield-agate/src/agate_nodes/db_output/metadata.json
+++ b/packages/backfield-agate/src/agate_nodes/db_output/metadata.json
@@ -33,7 +33,6 @@
   ],
   "defaultParams": {
     "stylebook_matching_enabled": true,
-    "stylebook_id": null,
     "canonicalization_mode": "ai_assisted",
     "reconciliation_policy": "smart_merge",
     "auto_apply_canonicalization": true,

--- a/packages/backfield-agate/src/agate_nodes/db_output/ui/PanelComponent.tsx
+++ b/packages/backfield-agate/src/agate_nodes/db_output/ui/PanelComponent.tsx
@@ -9,7 +9,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
-import { listOrgStylebooks, type OrgStylebook } from '@/lib/core-api'
 import {
   autoConnectionsEligibility,
   autoConnectionsIneligibleCopy,
@@ -32,7 +31,6 @@ import {
   catalogToSelectOptions,
   hasExplicitAiModelChoice,
   resolvedAiModelSelectValue,
-  resolvedStylebookId,
 } from '@/lib/nodePanelAiModel'
 
 interface DBOutputPanelProps {
@@ -44,7 +42,6 @@ interface DBOutputPanelProps {
 
 const DEFAULTS = {
   stylebook_matching_enabled: true,
-  stylebook_id: null as number | null,
   canonicalization_mode: 'ai_assisted' as 'rules' | 'ai_assisted',
   reconciliation_policy: 'smart_merge' as 'add_only' | 'smart_merge' | 'replace',
   auto_apply_canonicalization: true,
@@ -53,8 +50,6 @@ const DEFAULTS = {
   semantic_indexing_enabled: false,
   auto_connections_enabled: true,
 }
-
-const ORG_DEFAULT_STYLEBOOK_SELECT = '__org_default_stylebook__'
 
 const ADJUDICATION_MODEL_KEYS = {
   configIdKey: 'adjudication_ai_model_config_id',
@@ -83,48 +78,16 @@ export default function DBOutputPanel({
   graphContext,
 }: DBOutputPanelProps) {
   const merged = { ...DEFAULTS, ...(node.data || {}) }
-  const legacyCamel = (node.data as Record<string, unknown> | undefined)?.stylebookId
-  if (merged.stylebook_id == null && legacyCamel != null && legacyCamel !== '') {
-    ;(merged as Record<string, unknown>).stylebook_id = legacyCamel
-  }
-
-  const paramStylebookId = resolvedStylebookId(merged as Record<string, unknown>)
 
   const disabled = !(editMode && setNodes)
-  const orgId = graphContext?.organizationId ?? null
   const projectId = graphContext?.projectId ?? null
 
-  const [stylebooks, setStylebooks] = useState<OrgStylebook[]>([])
-  const [stylebooksError, setStylebooksError] = useState<string | null>(null)
   const [catalogRows, setCatalogRows] = useState<ProjectAiModelOption[]>([])
   const [catalogLoading, setCatalogLoading] = useState(false)
   const [catalogError, setCatalogError] = useState<string | null>(null)
   const [semanticIndexingConfigured, setSemanticIndexingConfigured] = useState<boolean | null>(
     null,
   )
-
-  useEffect(() => {
-    if (!orgId) {
-      setStylebooks([])
-      setStylebooksError(null)
-      return
-    }
-    let cancelled = false
-    setStylebooksError(null)
-    listOrgStylebooks(orgId)
-      .then((rows) => {
-        if (!cancelled) setStylebooks(rows)
-      })
-      .catch((e: unknown) => {
-        if (!cancelled) {
-          setStylebooks([])
-          setStylebooksError(e instanceof Error ? e.message : 'Could not load catalogs.')
-        }
-      })
-    return () => {
-      cancelled = true
-    }
-  }, [orgId])
 
   useEffect(() => {
     const fetcher = graphContext?.fetchProjectAiModels
@@ -267,47 +230,6 @@ export default function DBOutputPanel({
     })
   }
 
-  const missingFromList = paramStylebookId != null && !stylebooks.some((s) => s.id === paramStylebookId)
-
-  useEffect(() => {
-    if (!editMode || !setNodes || !missingFromList || paramStylebookId == null) return
-    if (stylebooks.length === 0) return
-    setNodes((nodes: any[]) =>
-      nodes.map((n) =>
-        n.id === node.id
-          ? { ...n, data: mergeData({ ...(n.data || {}), stylebook_id: null }) }
-          : n,
-      ),
-    )
-  }, [editMode, setNodes, missingFromList, paramStylebookId, stylebooks.length, node.id])
-
-  const orgDefaultStylebook = stylebooks.find((sb) => sb.is_default)
-  const usesOrgDefault =
-    paramStylebookId == null ||
-    (orgDefaultStylebook != null && paramStylebookId === orgDefaultStylebook.id)
-
-  const stylebookSelectValue = usesOrgDefault
-    ? ORG_DEFAULT_STYLEBOOK_SELECT
-    : String(paramStylebookId)
-
-  const handleStylebookSelect = (value: string) => {
-    if (!setNodes) return
-    const nextId = value === ORG_DEFAULT_STYLEBOOK_SELECT ? null : Number(value)
-    setNodes((nodes: any[]) =>
-      nodes.map((n) =>
-        n.id === node.id ? { ...n, data: mergeData({ ...(n.data || {}), stylebook_id: nextId }) } : n,
-      ),
-    )
-  }
-
-  const defaultOptionLabel = orgDefaultStylebook?.name
-    ? `${orgDefaultStylebook.name} (Default)`
-    : 'Default'
-
-  const selectableStylebooks = orgDefaultStylebook
-    ? stylebooks.filter((sb) => sb.id !== orgDefaultStylebook.id)
-    : stylebooks
-
   const data = merged
   const stylebookMatchingEnabled = Boolean(data.stylebook_matching_enabled)
   const semanticIndexingEnabled = Boolean(data.semantic_indexing_enabled)
@@ -446,48 +368,6 @@ export default function DBOutputPanel({
           </p>
         ) : (
           <div className="space-y-4">
-            <div className="space-y-2">
-              <Label htmlFor="dbout-stylebook">Stylebook</Label>
-              <Select
-                value={stylebookSelectValue}
-                onValueChange={handleStylebookSelect}
-                disabled={disabled || orgId == null}
-              >
-                <SelectTrigger id="dbout-stylebook" className="text-xs">
-                  <SelectValue placeholder="Choose a Stylebook" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value={ORG_DEFAULT_STYLEBOOK_SELECT}>{defaultOptionLabel}</SelectItem>
-                  {missingFromList && paramStylebookId != null ? (
-                    <SelectItem value={String(paramStylebookId)}>
-                      {stylebooks.length === 0 && !stylebooksError
-                        ? `Saved selection (ID ${paramStylebookId})`
-                        : `Saved Stylebook unavailable (ID ${paramStylebookId})`}
-                    </SelectItem>
-                  ) : null}
-                  {selectableStylebooks.map((sb) => (
-                    <SelectItem key={sb.id} value={String(sb.id)}>
-                      {sb.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              {orgId == null && (
-                <p className="text-xs text-muted-foreground">
-                  Save the flow to a project (or open an existing project flow) to choose a Stylebook
-                  for your organization.
-                </p>
-              )}
-              {orgId != null && stylebooks.length === 0 && !stylebooksError && (
-                <p className="text-xs text-muted-foreground">Loading Stylebooks…</p>
-              )}
-              {stylebooksError && <p className="text-xs text-destructive">{stylebooksError}</p>}
-              <p className="text-xs text-muted-foreground">
-                Default uses your organization&apos;s default Stylebook. Choose another to match and
-                write against a different catalog.
-              </p>
-            </div>
-
             <div className="space-y-2">
               <Label htmlFor="dbout-mode">Matching strategy</Label>
               <Select

--- a/packages/backfield-agate/src/agate_nodes/geocode_agent/metadata.json
+++ b/packages/backfield-agate/src/agate_nodes/geocode_agent/metadata.json
@@ -16,7 +16,6 @@
     "maxLocations": 200,
     "perLocationTimeout": 300,
     "useCache": true,
-    "stylebook_id": null,
     "stylebookApiUrl": "",
     "projectSlug": "",
     "evaluationModel": "",

--- a/packages/backfield-agate/src/agate_nodes/geocode_agent/runner.py
+++ b/packages/backfield-agate/src/agate_nodes/geocode_agent/runner.py
@@ -104,7 +104,6 @@ def attach_geocode_cache_bundle(
         return
     try:
         pid = int(raw_pid)
-        sid = stylebook_id
     except (TypeError, ValueError):
         logger.debug(
             "Geocode DB cache skipped: invalid BACKFIELD_PROJECT_ID or stylebook id (%r, %r)",
@@ -113,18 +112,16 @@ def attach_geocode_cache_bundle(
         )
         return
 
-    if sid is not None:
-        from backfield_db import Stylebook
-        from backfield_db.session import get_engine
-        from sqlmodel import Session
+    from backfield_db.session import get_engine
+    from backfield_entities.catalog.resolve import resolve_stylebook_id_for_project_id
+    from sqlmodel import Session
 
-        with Session(get_engine()) as session:
-            sb = session.get(Stylebook, sid)
-        if sb is None:
-            raise ValueError(
-                "This flow uses a Stylebook that no longer exists. "
-                "Open the Geocode step and choose a Stylebook that is still available."
-            )
+    with Session(get_engine()) as session:
+        sid = resolve_stylebook_id_for_project_id(session, pid)
+    if stylebook_id is not None and int(stylebook_id) != sid:
+        raise ValueError(
+            "GeocodeAgent Stylebook does not match the project's assigned Stylebook"
+        )
 
     ctx.metadata["geocode_cache_bundle"] = _build_geocode_cache_bundle(pid, sid)
 

--- a/packages/backfield-agate/src/agate_nodes/geocode_agent/ui/PanelComponent.tsx
+++ b/packages/backfield-agate/src/agate_nodes/geocode_agent/ui/PanelComponent.tsx
@@ -2,7 +2,6 @@ import { useEffect, useMemo, useState } from 'react'
 import { NodePanelTabGate } from '@/components/node-panel/NodePanelTabContext'
 import type { GraphPanelContext, ProjectAiModelOption } from '@/components/NodePanel'
 import { Label } from '@/components/ui/label'
-import { listOrgStylebooks, type OrgStylebook } from '@/lib/core-api'
 import {
   Select,
   SelectContent,
@@ -15,16 +14,12 @@ import {
   catalogToSelectOptions,
   hasExplicitAiModelChoice,
   resolvedAiModelSelectValue,
-  resolvedStylebookId,
 } from '@/lib/nodePanelAiModel'
-
-const NO_STYLEBOOK_VALUE = '__bf_no_stylebook__'
 
 const DEFAULTS = {
   maxLocations: 200,
   perLocationTimeout: 300,
   useCache: true,
-  stylebook_id: null as number | null,
   stylebookApiUrl: '',
   projectSlug: '',
   evaluationModel: '',
@@ -117,43 +112,13 @@ export default function GeocodeAgentPanel({
   graphContext,
 }: GeocodeAgentPanelProps) {
   const merged = { ...DEFAULTS, ...(node.data || {}) }
-  const legacyCamel = (node.data as Record<string, unknown> | undefined)?.stylebookId
-  if (merged.stylebook_id == null && legacyCamel != null && legacyCamel !== '') {
-    ;(merged as Record<string, unknown>).stylebook_id = legacyCamel
-  }
   const params = merged
 
   const isDisabled = !(editMode && setNodes)
-  const orgId = graphContext?.organizationId ?? null
   const projectId = graphContext?.projectId ?? null
-  const [stylebooks, setStylebooks] = useState<OrgStylebook[]>([])
-  const [stylebooksError, setStylebooksError] = useState<string | null>(null)
   const [catalogRows, setCatalogRows] = useState<ProjectAiModelOption[]>([])
   const [catalogLoading, setCatalogLoading] = useState(false)
   const [catalogError, setCatalogError] = useState<string | null>(null)
-
-  useEffect(() => {
-    if (!orgId || !params.useCache) {
-      setStylebooks([])
-      setStylebooksError(null)
-      return
-    }
-    let cancelled = false
-    setStylebooksError(null)
-    listOrgStylebooks(orgId)
-      .then((rows) => {
-        if (!cancelled) setStylebooks(rows)
-      })
-      .catch((e: unknown) => {
-        if (!cancelled) {
-          setStylebooks([])
-          setStylebooksError(e instanceof Error ? e.message : 'Could not load Stylebooks.')
-        }
-      })
-    return () => {
-      cancelled = true
-    }
-  }, [orgId, params.useCache])
 
   useEffect(() => {
     const fetcher = graphContext?.fetchProjectAiModels
@@ -309,70 +274,13 @@ export default function GeocodeAgentPanel({
   const handleUseCacheChange = (checked: boolean) => {
     if (setNodes) {
       setNodes((nodes: any[]) =>
-        nodes.map((n) => {
-          if (n.id !== node.id) return n
-          const data = mergeData({ ...(n.data || {}), useCache: checked })
-          if (!checked) {
-            data.stylebook_id = null
-          }
-          return { ...n, data }
-        }),
-      )
-    }
-  }
-
-  const paramStylebookId = resolvedStylebookId(params as Record<string, unknown>)
-  const orgDefaultStylebook = stylebooks.find((sb) => sb.is_default)
-  const missingStylebookFromList =
-    params.useCache &&
-    paramStylebookId != null &&
-    !stylebooks.some((s) => s.id === paramStylebookId)
-
-  useEffect(() => {
-    if (!editMode || !setNodes || !missingStylebookFromList || paramStylebookId == null) return
-    if (stylebooks.length === 0) return
-    const nextId = orgDefaultStylebook?.id ?? null
-    if (nextId == null) return
-    setNodes((nodes: any[]) =>
-      nodes.map((n) =>
-        n.id === node.id
-          ? { ...n, data: mergeData({ ...(n.data || {}), stylebook_id: nextId }) }
-          : n,
-      ),
-    )
-  }, [
-    editMode,
-    setNodes,
-    missingStylebookFromList,
-    paramStylebookId,
-    stylebooks.length,
-    orgDefaultStylebook?.id,
-    node.id,
-  ])
-
-  const stylebookSelectValue =
-    paramStylebookId != null ? String(paramStylebookId) : NO_STYLEBOOK_VALUE
-
-  const handleStylebookSelect = (value: string) => {
-    if (!setNodes) return
-    if (value === NO_STYLEBOOK_VALUE) {
-      setNodes((nodes: any[]) =>
         nodes.map((n) =>
           n.id === node.id
-            ? { ...n, data: mergeData({ ...(n.data || {}), stylebook_id: null }) }
+            ? { ...n, data: mergeData({ ...(n.data || {}), useCache: checked }) }
             : n,
         ),
       )
-      return
     }
-    const nextId = Number(value)
-    setNodes((nodes: any[]) =>
-      nodes.map((n) =>
-        n.id === node.id
-          ? { ...n, data: mergeData({ ...(n.data || {}), stylebook_id: nextId }) }
-          : n,
-      ),
-    )
   }
 
   const handleEvaluationModel = (selectValue: string) => {
@@ -504,39 +412,6 @@ export default function GeocodeAgentPanel({
             </p>
           </div>
 
-          {params.useCache && (
-            <div className="space-y-2">
-              <Label htmlFor="geocode-stylebook" className="text-sm font-medium">
-                Stylebook
-              </Label>
-              <Select
-                value={stylebookSelectValue}
-                onValueChange={handleStylebookSelect}
-                disabled={isDisabled}
-              >
-                <SelectTrigger id="geocode-stylebook" className="text-xs">
-                  <SelectValue placeholder="Choose a Stylebook" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value={NO_STYLEBOOK_VALUE}>None</SelectItem>
-                  {stylebooks.map((sb) => (
-                    <SelectItem key={sb.id} value={String(sb.id)}>
-                      {sb.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              {orgId == null && (
-                <p className="text-xs text-muted-foreground">
-                  Save the flow to a project to load Stylebooks for your organization.
-                </p>
-              )}
-              {orgId != null && params.useCache && stylebooks.length === 0 && !stylebooksError && (
-                <p className="text-xs text-muted-foreground">Loading Stylebooks…</p>
-              )}
-              {stylebooksError && <p className="text-xs text-destructive">{stylebooksError}</p>}
-            </div>
-          )}
         </div>
       </NodePanelTabGate>
 

--- a/packages/backfield-agate/src/agate_runtime/starter_flow.py
+++ b/packages/backfield-agate/src/agate_runtime/starter_flow.py
@@ -77,7 +77,6 @@ def starter_geocode_flow_graph_spec() -> GraphSpec:
                 type="DBOutput",
                 params={
                     "stylebook_matching_enabled": True,
-                    "stylebook_id": None,
                     "canonicalization_mode": "ai_assisted",
                     "auto_apply_canonicalization": True,
                     "adjudication_model": "gpt-5-nano",

--- a/packages/backfield-agate/tests/test_geocode_agent_stylebook.py
+++ b/packages/backfield-agate/tests/test_geocode_agent_stylebook.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -36,18 +36,17 @@ def test_geocode_params_accepts_stylebook_id_snake_case() -> None:
     assert params.stylebookId == 2
 
 
-def test_geocode_raises_when_stylebook_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_geocode_raises_when_project_stylebook_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     from agate_runtime.nodes.geocode_agent import run_geocode_agent
 
     monkeypatch.setenv("BACKFIELD_PROJECT_ID", "1")
-    mock_cm = MagicMock()
-    mock_sess = MagicMock()
-    mock_sess.get.return_value = None
-    mock_cm.__enter__.return_value = mock_sess
-    mock_cm.__exit__.return_value = None
-
-    with patch("sqlmodel.Session", return_value=mock_cm):
-        with pytest.raises(ValueError, match="Stylebook that no longer exists"):
+    with patch(
+        "backfield_entities.catalog.resolve.resolve_stylebook_id_for_project_id",
+        side_effect=ValueError("project Stylebook does not belong to the project's organization"),
+    ):
+        with pytest.raises(ValueError, match="does not belong"):
             run_geocode_agent({"useCache": True, "stylebook_id": 99999}, {})
 
 
@@ -65,14 +64,11 @@ def test_geocode_agent_run_attaches_cache_bundle(monkeypatch: pytest.MonkeyPatch
     ctx = AgateEnvContext()
     params = GeocodeAgentParams.model_validate({"useCache": True, "stylebook_id": 2})
 
-    mock_cm = MagicMock()
-    mock_sess = MagicMock()
-    mock_sess.get.return_value = MagicMock()
-    mock_cm.__enter__.return_value = mock_sess
-    mock_cm.__exit__.return_value = None
-
     async def run_agent() -> None:
-        with patch("sqlmodel.Session", return_value=mock_cm):
+        with patch(
+            "backfield_entities.catalog.resolve.resolve_stylebook_id_for_project_id",
+            return_value=2,
+        ):
             with patch(
                 "agate_nodes.geocode_agent.node.run_geocode_agent_pipeline",
                 new_callable=AsyncMock,
@@ -100,12 +96,6 @@ def test_geocode_agent_async_runner_attaches_cache_bundle(
     from agate_runtime.runners import run_geocode_agent_async
 
     monkeypatch.setenv("BACKFIELD_PROJECT_ID", "1")
-    mock_cm = MagicMock()
-    mock_sess = MagicMock()
-    mock_sess.get.return_value = MagicMock()
-    mock_cm.__enter__.return_value = mock_sess
-    mock_cm.__exit__.return_value = None
-
     captured_ctx: AgateEnvContext | None = None
 
     async def capture_pipeline(
@@ -118,7 +108,10 @@ def test_geocode_agent_async_runner_attaches_cache_bundle(
         return GeocodeAgentOutput(places=_EMPTY_PLACES)
 
     async def run_runner() -> None:
-        with patch("sqlmodel.Session", return_value=mock_cm):
+        with patch(
+            "backfield_entities.catalog.resolve.resolve_stylebook_id_for_project_id",
+            return_value=2,
+        ):
             with patch(
                 "agate_nodes.geocode_agent.node.run_geocode_agent_pipeline",
                 side_effect=capture_pipeline,

--- a/packages/backfield-db/alembic/versions/070_project_stylebook_runtime.py
+++ b/packages/backfield-db/alembic/versions/070_project_stylebook_runtime.py
@@ -1,0 +1,148 @@
+"""Make project workspace and Stylebook ownership strict."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.engine import Connection
+
+revision: str = "070_project_stylebook_runtime"
+down_revision: str | None = "069_project_stylebook_ownership"
+branch_labels: Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _validate_project_ownership(conn: Connection) -> None:
+    null_row = conn.execute(
+        sa.text(
+            """
+            SELECT id, workspace_id, stylebook_id
+            FROM backfield_project
+            WHERE workspace_id IS NULL OR stylebook_id IS NULL
+            ORDER BY id
+            LIMIT 1
+            """
+        )
+    ).fetchone()
+    if null_row is not None:
+        raise RuntimeError(
+            "cannot enforce project tenancy: "
+            f"project {int(null_row[0])} has a null workspace_id or stylebook_id"
+        )
+
+    invalid_project = conn.execute(
+        sa.text(
+            """
+            SELECT p.id
+            FROM backfield_project AS p
+            LEFT JOIN backfield_workspace AS w ON w.id = p.workspace_id
+            LEFT JOIN stylebook AS s ON s.id = p.stylebook_id
+            WHERE w.id IS NULL
+               OR s.id IS NULL
+               OR w.organization_id <> p.organization_id
+               OR s.organization_id <> p.organization_id
+            ORDER BY p.id
+            LIMIT 1
+            """
+        )
+    ).fetchone()
+    if invalid_project is not None:
+        raise RuntimeError(
+            "cannot enforce project tenancy: "
+            f"project {int(invalid_project[0])} has a missing or cross-organization "
+            "workspace/Stylebook assignment"
+        )
+
+    invalid_workspace = conn.execute(
+        sa.text(
+            """
+            SELECT w.id
+            FROM backfield_workspace AS w
+            LEFT JOIN stylebook AS s ON s.id = w.stylebook_id
+            WHERE s.id IS NULL OR s.organization_id <> w.organization_id
+            ORDER BY w.id
+            LIMIT 1
+            """
+        )
+    ).fetchone()
+    if invalid_workspace is not None:
+        raise RuntimeError(
+            "cannot enforce project tenancy: "
+            f"workspace {int(invalid_workspace[0])} has a missing or "
+            "cross-organization Stylebook assignment"
+        )
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    _validate_project_ownership(conn)
+
+    op.alter_column("backfield_project", "workspace_id", existing_type=sa.Integer(), nullable=False)
+    op.alter_column("backfield_project", "stylebook_id", existing_type=sa.Integer(), nullable=False)
+
+    op.create_unique_constraint(
+        "uq_stylebook_organization_id",
+        "stylebook",
+        ["organization_id", "id"],
+    )
+    op.create_unique_constraint(
+        "uq_backfield_workspace_org_id",
+        "backfield_workspace",
+        ["organization_id", "id"],
+    )
+    op.create_foreign_key(
+        "fk_backfield_workspace_org_stylebook",
+        "backfield_workspace",
+        "stylebook",
+        ["organization_id", "stylebook_id"],
+        ["organization_id", "id"],
+        ondelete="RESTRICT",
+    )
+    op.create_foreign_key(
+        "fk_backfield_project_org_workspace",
+        "backfield_project",
+        "backfield_workspace",
+        ["organization_id", "workspace_id"],
+        ["organization_id", "id"],
+        ondelete="RESTRICT",
+    )
+    op.create_foreign_key(
+        "fk_backfield_project_org_stylebook",
+        "backfield_project",
+        "stylebook",
+        ["organization_id", "stylebook_id"],
+        ["organization_id", "id"],
+        ondelete="RESTRICT",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "fk_backfield_project_org_stylebook",
+        "backfield_project",
+        type_="foreignkey",
+    )
+    op.drop_constraint(
+        "fk_backfield_project_org_workspace",
+        "backfield_project",
+        type_="foreignkey",
+    )
+    op.drop_constraint(
+        "fk_backfield_workspace_org_stylebook",
+        "backfield_workspace",
+        type_="foreignkey",
+    )
+    op.drop_constraint(
+        "uq_backfield_workspace_org_id",
+        "backfield_workspace",
+        type_="unique",
+    )
+    op.drop_constraint(
+        "uq_stylebook_organization_id",
+        "stylebook",
+        type_="unique",
+    )
+    op.alter_column("backfield_project", "stylebook_id", existing_type=sa.Integer(), nullable=True)
+    op.alter_column("backfield_project", "workspace_id", existing_type=sa.Integer(), nullable=True)

--- a/packages/backfield-db/src/backfield_db/models.py
+++ b/packages/backfield-db/src/backfield_db/models.py
@@ -17,6 +17,7 @@ from sqlalchemy import (
     DateTime,
     Float,
     ForeignKey,
+    ForeignKeyConstraint,
     Index,
     Integer,
     Numeric,
@@ -70,6 +71,12 @@ class BackfieldWorkspace(SQLModel, table=True):
     __tablename__ = "backfield_workspace"
     __table_args__ = (
         UniqueConstraint("organization_id", "slug", name="uq_backfield_workspace_org_slug"),
+        UniqueConstraint("organization_id", "id", name="uq_backfield_workspace_org_id"),
+        ForeignKeyConstraint(
+            ["organization_id", "stylebook_id"],
+            ["stylebook.organization_id", "stylebook.id"],
+            name="fk_backfield_workspace_org_stylebook",
+        ),
     )
 
     id: int | None = Field(default=None, primary_key=True)
@@ -123,16 +130,26 @@ class BackfieldProject(SQLModel, table=True):
     """Canonical project for Agate, Stylebook vault, and future Core import APIs."""
 
     __tablename__ = "backfield_project"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["organization_id", "workspace_id"],
+            ["backfield_workspace.organization_id", "backfield_workspace.id"],
+            name="fk_backfield_project_org_workspace",
+        ),
+        ForeignKeyConstraint(
+            ["organization_id", "stylebook_id"],
+            ["stylebook.organization_id", "stylebook.id"],
+            name="fk_backfield_project_org_stylebook",
+        ),
+    )
 
     id: int | None = Field(default=None, primary_key=True)
     organization_id: int = Field(foreign_key="backfield_organization.id", index=True)
-    workspace_id: int | None = Field(
-        default=None,
+    workspace_id: int = Field(
         foreign_key="backfield_workspace.id",
         index=True,
     )
-    stylebook_id: int | None = Field(
-        default=None,
+    stylebook_id: int = Field(
         foreign_key="stylebook.id",
         index=True,
     )
@@ -232,6 +249,7 @@ class Stylebook(SQLModel, table=True):
     __table_args__ = (
         UniqueConstraint("organization_id", "slug", name="uq_stylebook_organization_slug"),
         UniqueConstraint("organization_id", "name", name="uq_stylebook_organization_name"),
+        UniqueConstraint("organization_id", "id", name="uq_stylebook_organization_id"),
         Index(
             "uq_stylebook_org_one_default",
             "organization_id",

--- a/packages/backfield-db/tests/test_project_stylebook_model.py
+++ b/packages/backfield-db/tests/test_project_stylebook_model.py
@@ -1,13 +1,27 @@
-"""Structural contract for additive project Stylebook ownership."""
+"""Structural contract for strict project Stylebook ownership."""
 
 from __future__ import annotations
 
 from backfield_db import BackfieldProject
 
 
-def test_project_stylebook_column_is_nullable_indexed_foreign_key() -> None:
-    column = BackfieldProject.__table__.c.stylebook_id
+def test_project_workspace_and_stylebook_columns_are_required() -> None:
+    workspace_column = BackfieldProject.__table__.c.workspace_id
+    stylebook_column = BackfieldProject.__table__.c.stylebook_id
 
-    assert column.nullable is True
-    assert column.index is True
-    assert {foreign_key.target_fullname for foreign_key in column.foreign_keys} == {"stylebook.id"}
+    assert workspace_column.nullable is False
+    assert stylebook_column.nullable is False
+    assert workspace_column.index is True
+    assert stylebook_column.index is True
+    assert {foreign_key.target_fullname for foreign_key in workspace_column.foreign_keys} == {
+        "backfield_workspace.id"
+    }
+    assert {foreign_key.target_fullname for foreign_key in stylebook_column.foreign_keys} == {
+        "stylebook.id"
+    }
+
+    constraint_names = {
+        constraint.name for constraint in BackfieldProject.__table__.constraints
+    }
+    assert "fk_backfield_project_org_workspace" in constraint_names
+    assert "fk_backfield_project_org_stylebook" in constraint_names

--- a/packages/backfield-db/tests/test_project_stylebook_runtime_migration.py
+++ b/packages/backfield-db/tests/test_project_stylebook_runtime_migration.py
@@ -1,0 +1,93 @@
+"""Guard behavior for strict project runtime ownership."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+from sqlalchemy import Connection, create_engine, text
+
+
+def _migration_module() -> ModuleType:
+    path = (
+        Path(__file__).resolve().parents[1]
+        / "alembic"
+        / "versions"
+        / "070_project_stylebook_runtime.py"
+    )
+    spec = importlib.util.spec_from_file_location("migration_070", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _create_schema(conn: Connection) -> None:
+    conn.execute(
+        text("CREATE TABLE stylebook (id INTEGER PRIMARY KEY, organization_id INTEGER NOT NULL)")
+    )
+    conn.execute(
+        text(
+            "CREATE TABLE backfield_workspace ("
+            "id INTEGER PRIMARY KEY, organization_id INTEGER NOT NULL, "
+            "stylebook_id INTEGER NOT NULL)"
+        )
+    )
+    conn.execute(
+        text(
+            "CREATE TABLE backfield_project ("
+            "id INTEGER PRIMARY KEY, organization_id INTEGER NOT NULL, "
+            "workspace_id INTEGER, stylebook_id INTEGER)"
+        )
+    )
+
+
+def test_validation_accepts_complete_same_organization_assignments() -> None:
+    migration = _migration_module()
+    with create_engine("sqlite://").begin() as conn:
+        _create_schema(conn)
+        conn.execute(text("INSERT INTO stylebook VALUES (10, 1)"))
+        conn.execute(text("INSERT INTO backfield_workspace VALUES (20, 1, 10)"))
+        conn.execute(text("INSERT INTO backfield_project VALUES (30, 1, 20, 10)"))
+
+        migration._validate_project_ownership(conn)
+
+
+@pytest.mark.parametrize(
+    ("workspace_id", "stylebook_id", "match"),
+    [
+        (None, 10, "null workspace_id or stylebook_id"),
+        (20, None, "null workspace_id or stylebook_id"),
+        (20, 11, "missing or cross-organization"),
+    ],
+)
+def test_validation_rejects_invalid_retained_projects(
+    workspace_id: int | None,
+    stylebook_id: int | None,
+    match: str,
+) -> None:
+    migration = _migration_module()
+    with create_engine("sqlite://").begin() as conn:
+        _create_schema(conn)
+        conn.execute(text("INSERT INTO stylebook VALUES (10, 1), (11, 2)"))
+        conn.execute(text("INSERT INTO backfield_workspace VALUES (20, 1, 10)"))
+        conn.execute(
+            text("INSERT INTO backfield_project VALUES (30, 1, :workspace_id, :stylebook_id)"),
+            {"workspace_id": workspace_id, "stylebook_id": stylebook_id},
+        )
+
+        with pytest.raises(RuntimeError, match=match):
+            migration._validate_project_ownership(conn)
+
+
+def test_validation_rejects_cross_organization_workspace_catalog() -> None:
+    migration = _migration_module()
+    with create_engine("sqlite://").begin() as conn:
+        _create_schema(conn)
+        conn.execute(text("INSERT INTO stylebook VALUES (10, 2)"))
+        conn.execute(text("INSERT INTO backfield_workspace VALUES (20, 1, 10)"))
+
+        with pytest.raises(RuntimeError, match="workspace 20"):
+            migration._validate_project_ownership(conn)

--- a/packages/backfield-db/tests/test_tenancy_audit.py
+++ b/packages/backfield-db/tests/test_tenancy_audit.py
@@ -28,9 +28,18 @@ from sqlalchemy import text
 from sqlmodel import Session, SQLModel, create_engine
 
 
-def _engine():
+def _engine(*, legacy_nullable_project_ownership: bool = False):
     engine = create_engine("sqlite://")
-    SQLModel.metadata.create_all(engine)
+    workspace_column = BackfieldProject.__table__.c.workspace_id
+    stylebook_column = BackfieldProject.__table__.c.stylebook_id
+    if legacy_nullable_project_ownership:
+        workspace_column.nullable = True
+        stylebook_column.nullable = True
+    try:
+        SQLModel.metadata.create_all(engine)
+    finally:
+        workspace_column.nullable = False
+        stylebook_column.nullable = False
     return engine
 
 
@@ -128,7 +137,7 @@ def test_tenancy_audit_clean_report_is_read_only() -> None:
 
 
 def test_tenancy_audit_reports_cross_layer_blockers() -> None:
-    engine = _engine()
+    engine = _engine(legacy_nullable_project_ownership=True)
     with Session(engine) as session:
         organization_one = BackfieldOrganization(name="One", slug="audit-one")
         organization_two = BackfieldOrganization(name="Two", slug="audit-two")

--- a/packages/backfield-entities/src/backfield_entities/catalog/graph_stylebook_refs.py
+++ b/packages/backfield-entities/src/backfield_entities/catalog/graph_stylebook_refs.py
@@ -139,6 +139,65 @@ def _is_geocode_agent_node_type(node_type: Any) -> bool:
     return normalized in ("geocodeagent", "geocode_agent")
 
 
+def validate_runtime_stylebook_refs_for_project(
+    spec: Mapping[str, Any],
+    *,
+    project_stylebook_id: int,
+) -> None:
+    """Reject explicit runtime-node Stylebook refs that differ from project ownership."""
+    nodes = spec.get("nodes")
+    if not isinstance(nodes, list):
+        return
+    for node in nodes:
+        if not isinstance(node, dict):
+            continue
+        node_type = node.get("type")
+        if not (_is_db_output_node_type(node_type) or _is_geocode_agent_node_type(node_type)):
+            continue
+        params = node.get("params")
+        if not isinstance(params, dict):
+            continue
+        for param_key in (STYLEBOOK_NODE_PARAM_KEY, _LEGACY_STYLEBOOK_PARAM_KEY):
+            if param_key not in params or params[param_key] is None:
+                continue
+            explicit_stylebook_id = _coerce_stylebook_param(params[param_key])
+            if explicit_stylebook_id != project_stylebook_id:
+                node_id = str(node.get("id") or "unknown")
+                raise StylebookGraphRefsError(
+                    f"Node {node_id} references a Stylebook that does not match the "
+                    "project's assigned Stylebook."
+                )
+
+
+def normalize_runtime_stylebook_refs(
+    spec: dict[str, Any],
+    *,
+    project_stylebook_id: int,
+) -> bool:
+    """Persist the project Stylebook on legacy catalog-aware runtime nodes."""
+    nodes = spec.get("nodes")
+    if not isinstance(nodes, list):
+        return False
+    changed = False
+    for node in nodes:
+        if not isinstance(node, dict):
+            continue
+        node_type = node.get("type")
+        if not (_is_db_output_node_type(node_type) or _is_geocode_agent_node_type(node_type)):
+            continue
+        params = node.get("params")
+        if not isinstance(params, dict):
+            params = {}
+            node["params"] = params
+        if (
+            params.get(STYLEBOOK_NODE_PARAM_KEY) != project_stylebook_id
+            or _LEGACY_STYLEBOOK_PARAM_KEY in params
+        ):
+            _apply_stylebook_ref_replacement(params, replacement=project_stylebook_id)
+            changed = True
+    return changed
+
+
 def sanitize_stylebook_refs_for_organization(
     session: Session,
     *,

--- a/packages/backfield-entities/src/backfield_entities/catalog/resolve.py
+++ b/packages/backfield-entities/src/backfield_entities/catalog/resolve.py
@@ -1,65 +1,24 @@
-"""Resolve the effective Stylebook from project context.
-
-Catalog resolution:
-
-1. **Explicit catalog id** — ``catalog_stylebook_id`` from caller; row must exist in project's org.
-2. **Slug** — non-empty ``stylebook_slug`` in that org (rename redirects apply).
-3. **Project ownership** — direct project Stylebook, then its workspace Stylebook during rollout.
-4. **Organization default** — default Stylebook, then first Stylebook by id.
-
-**Surfaces**
-
-* Stylebook HTTP: slug query → project ownership → organization default (**2 → 3 → 4**).
-
-* Worker **DBOutput**: ``resolve_effective_stylebook_id`` delegates here; node ``stylebook_id``
-  maps to ``catalog_stylebook_id`` (**1 → 3 → 4**).
-
-* Worker **GeocodeAgent** DB cache: project-scoped fingerprint lookup works without a catalog id;
-  canonical lookup, adjudication, and materialization use only the node's catalog id, with no
-  organization-default fallback.
-
-If the fallback chain finds no Stylebook, ``LookupError`` is raised; DBOutput persistence may
-catch it and skip catalog-backed canonicalization.
-"""
+"""Resolve the authoritative Stylebook from project ownership."""
 
 from __future__ import annotations
 
-from backfield_db import BackfieldProject, BackfieldWorkspace, Stylebook
-from sqlmodel import Session, col, select
+from backfield_db import BackfieldProject, Stylebook
+from sqlmodel import Session
 
 STYLEBOOK_SLUG_NOT_IN_ORG = "STYLEBOOK_SLUG_NOT_IN_ORG"
+STYLEBOOK_OVERRIDE_CONFLICT = "STYLEBOOK_OVERRIDE_CONFLICT"
 
 
 def resolve_stylebook_id_for_project_id(session: Session, project_id: int) -> int:
-    """Return the project's owned Stylebook with rolling-upgrade fallbacks."""
+    """Return the project's directly owned Stylebook."""
     proj = session.get(BackfieldProject, project_id)
     if proj is None:
         raise LookupError(f"project {project_id} not found")
     oid = int(proj.organization_id)
-
-    if proj.stylebook_id is not None:
-        project_stylebook = session.get(Stylebook, int(proj.stylebook_id))
-        if project_stylebook is None or int(project_stylebook.organization_id) != oid:
-            raise ValueError("project Stylebook does not belong to the project's organization")
-        return int(project_stylebook.id)
-
-    if proj.workspace_id is not None:
-        workspace = session.get(BackfieldWorkspace, int(proj.workspace_id))
-        if workspace is None or int(workspace.organization_id) != oid:
-            raise ValueError("project workspace does not belong to the project's organization")
-        workspace_stylebook = session.get(Stylebook, int(workspace.stylebook_id))
-        if workspace_stylebook is None or int(workspace_stylebook.organization_id) != oid:
-            raise ValueError("workspace Stylebook does not belong to the project's organization")
-        return int(workspace_stylebook.id)
-
-    sb = session.exec(
-        select(Stylebook)
-        .where(Stylebook.organization_id == oid)
-        .order_by(col(Stylebook.is_default).desc(), col(Stylebook.id).asc())
-    ).first()
-    if sb is None or sb.id is None:
-        raise LookupError(f"organization {oid} has no stylebooks")
-    return int(sb.id)
+    project_stylebook = session.get(Stylebook, int(proj.stylebook_id))
+    if project_stylebook is None or int(project_stylebook.organization_id) != oid:
+        raise ValueError("project Stylebook does not belong to the project's organization")
+    return int(project_stylebook.id)
 
 
 def resolve_effective_stylebook_id_for_project(
@@ -69,15 +28,11 @@ def resolve_effective_stylebook_id_for_project(
     stylebook_slug: str | None = None,
     catalog_stylebook_id: int | None = None,
 ) -> int:
-    """Effective catalog row id for the project.
-
-    Precedence: explicit id → slug → project → workspace → organization default.
-
-    Raises ``ValueError`` when ``catalog_stylebook_id`` is invalid or wrong organization.
-
-    Raises ``LookupError`` with :data:`STYLEBOOK_SLUG_NOT_IN_ORG` when slug does not resolve.
-    """
+    """Return project ownership, accepting only matching compatibility overrides."""
     oid = int(project.organization_id)
+    if project.id is None:
+        raise ValueError("project row has no id")
+    project_stylebook_id = resolve_stylebook_id_for_project_id(session, int(project.id))
     if catalog_stylebook_id is not None:
         sb = session.get(Stylebook, int(catalog_stylebook_id))
         if sb is None or sb.id is None:
@@ -86,14 +41,22 @@ def resolve_effective_stylebook_id_for_project(
         if int(sb.organization_id) != oid:
             msg = "stylebook does not belong to the project's organization"
             raise ValueError(msg)
-        return int(sb.id)
+        if int(sb.id) != project_stylebook_id:
+            raise ValueError(
+                f"{STYLEBOOK_OVERRIDE_CONFLICT}: explicit Stylebook does not match "
+                "project assignment"
+            )
 
     raw = (stylebook_slug or "").strip()
     if not raw:
-        return resolve_stylebook_id_for_project_id(session, int(project.id))
+        return project_stylebook_id
     from backfield_entities.catalog.stylebook_library import resolve_stylebook_by_slug
 
     row = resolve_stylebook_by_slug(session, organization_id=oid, slug=raw)
     if row is None:
         raise LookupError(STYLEBOOK_SLUG_NOT_IN_ORG)
-    return int(row.id)
+    if int(row.id) != project_stylebook_id:
+        raise ValueError(
+            f"{STYLEBOOK_OVERRIDE_CONFLICT}: Stylebook name does not match project assignment"
+        )
+    return project_stylebook_id

--- a/packages/backfield-entities/src/backfield_entities/ingest/db_output_settings.py
+++ b/packages/backfield-entities/src/backfield_entities/ingest/db_output_settings.py
@@ -23,8 +23,7 @@ class DbOutputCanonicalSettings(BaseModel):
     )
     stylebook_id: int | None = Field(
         default=None,
-        description="When set, canonical policy uses this Stylebook (same org as project). "
-        "When null, use the organization's default Stylebook.",
+        description="Legacy compatibility value; when set it must match the project Stylebook.",
     )
     canonicalization_mode: CanonicalizationMode = "ai_assisted"
     reconciliation_policy: ReconciliationPolicy = Field(
@@ -80,11 +79,7 @@ def resolve_effective_stylebook_id(
     project_id: int,
     stylebook_id_override: int | None,
 ) -> int:
-    """Return catalog id for DBOutput persistence (node override, else org default).
-
-    Delegates to :func:`resolve_effective_stylebook_id_for_project` so precedence matches
-    the documented bridge order (explicit id → slug — unused here — → organization default).
-    """
+    """Return the project catalog, rejecting a conflicting legacy node value."""
     proj = session.get(BackfieldProject, project_id)
     if proj is None:
         msg = f"project {project_id} not found"

--- a/tests/agate_api/test_local_bootstrap.py
+++ b/tests/agate_api/test_local_bootstrap.py
@@ -19,6 +19,8 @@ from backfield_db import (
 )
 from sqlmodel import Session, SQLModel, create_engine, select
 
+from tests.project_helpers import project_ownership_fields
+
 
 @pytest.fixture
 def bootstrap_engine(tmp_path) -> Generator:
@@ -47,6 +49,7 @@ def test_ensure_default_workspace_preserves_organization_name(bootstrap_engine) 
         session.refresh(org)
         session.add(
             BackfieldProject(
+                **project_ownership_fields(session, int(org.id)),
                 name="General",
                 slug="general",
                 organization_id=int(org.id),
@@ -88,6 +91,7 @@ def test_ensure_default_workspace_preserves_workspace_name(bootstrap_engine) -> 
         session.flush()
         session.add(
             BackfieldProject(
+                **project_ownership_fields(session, int(org.id), workspace_id=int(ws.id)),
                 name="General",
                 slug="general",
                 organization_id=int(org.id),
@@ -121,6 +125,7 @@ def test_run_local_bootstrap_preserves_organization_name(
         session.refresh(org)
         session.add(
             BackfieldProject(
+                **project_ownership_fields(session, int(org.id)),
                 name="General",
                 slug="general",
                 organization_id=int(org.id),

--- a/tests/agate_api/test_processed_item_article_context.py
+++ b/tests/agate_api/test_processed_item_article_context.py
@@ -11,6 +11,8 @@ from backfield_db import (
 from sqlalchemy import create_engine
 from sqlmodel import Session, SQLModel, select
 
+from tests.project_helpers import project_ownership_fields
+
 
 def _org_and_project(session: Session) -> tuple[int, int]:
     session.add(BackfieldOrganization(name="Org", slug="org-art"))
@@ -22,6 +24,7 @@ def _org_and_project(session: Session) -> tuple[int, int]:
     slug = f"proj-art-{oid}"
     session.add(
         BackfieldProject(
+            **project_ownership_fields(session, oid),
             organization_id=oid,
             name="Proj",
             slug=slug,
@@ -124,6 +127,7 @@ def test_article_context_project_mismatch() -> None:
         slug_b = f"other-art-{pid_a}"
         session.add(
             BackfieldProject(
+                **project_ownership_fields(session, oid),
                 organization_id=oid,
                 name="Other",
                 slug=slug_b,

--- a/tests/agate_api/test_processed_item_entity_identity_enrichment.py
+++ b/tests/agate_api/test_processed_item_entity_identity_enrichment.py
@@ -29,6 +29,8 @@ from backfield_entities.entities.organization.types import organization_identity
 from backfield_entities.entities.person.types import person_identity_fingerprint
 from sqlmodel import Session, SQLModel, create_engine
 
+from tests.project_helpers import project_ownership_fields
+
 
 def _context(session: Session, *, suffix: str) -> tuple[int, int, int]:
     organization = BackfieldOrganization(name=f"Org {suffix}", slug=f"org-{suffix}")
@@ -41,12 +43,19 @@ def _context(session: Session, *, suffix: str) -> tuple[int, int, int]:
         slug=f"stylebook-{suffix}",
         is_default=True,
     )
+    session.add(stylebook)
+    session.flush()
     project = BackfieldProject(
+        **project_ownership_fields(
+            session,
+            int(organization.id),
+            stylebook_id=int(stylebook.id),
+        ),
         organization_id=int(organization.id),
+        stylebook_id=int(stylebook.id),
         name=f"Project {suffix}",
         slug=f"project-{suffix}",
     )
-    session.add(stylebook)
     session.add(project)
     session.commit()
     session.refresh(stylebook)

--- a/tests/agate_api/test_processed_item_review_enrichment.py
+++ b/tests/agate_api/test_processed_item_review_enrichment.py
@@ -20,6 +20,8 @@ from backfield_db import (
 from backfield_entities.canonical.link import CANONICAL_LINK_LINKED, CANONICAL_LINK_PENDING
 from sqlmodel import Session, create_engine
 
+from tests.project_helpers import project_ownership_fields
+
 
 def test_geometries_json_equal_sorts_keys() -> None:
     a = {"type": "Point", "coordinates": [1.0, 2.0]}
@@ -57,6 +59,7 @@ def test_enrich_merged_locations_attaches_persisted_and_stylebook_link() -> None
         session.refresh(stylebook)
 
         project = BackfieldProject(
+            **project_ownership_fields(session, int(org.id)),
             organization_id=int(org.id),
             name="Proj",
             slug="proj-enrich",
@@ -162,6 +165,7 @@ def test_enrich_skips_unlinked_canonical() -> None:
         session.refresh(org)
 
         project = BackfieldProject(
+            **project_ownership_fields(session, int(org.id)),
             organization_id=int(org.id),
             name="Proj2",
             slug="proj-enrich-2",
@@ -223,6 +227,7 @@ def test_enrich_appends_manual_location_without_model_row() -> None:
         session.refresh(org)
 
         project = BackfieldProject(
+            **project_ownership_fields(session, int(org.id)),
             organization_id=int(org.id),
             name="Manual Proj",
             slug="manual-proj",
@@ -312,6 +317,7 @@ def test_enrich_matches_h3_rows_by_display_name_suffix() -> None:
         session.refresh(org)
 
         project = BackfieldProject(
+            **project_ownership_fields(session, int(org.id)),
             organization_id=int(org.id),
             name="Proj H3",
             slug="proj-h3",
@@ -398,6 +404,7 @@ def test_enrich_omits_stylebook_link_when_mention_deleted_for_article() -> None:
         session.refresh(stylebook)
 
         project = BackfieldProject(
+            **project_ownership_fields(session, int(org.id)),
             organization_id=int(org.id),
             name="Proj3",
             slug="proj-enrich-3",
@@ -473,6 +480,7 @@ def test_enrich_skips_run_wide_substrate_when_article_id_missing() -> None:
         session.refresh(org)
 
         project = BackfieldProject(
+            **project_ownership_fields(session, int(org.id)),
             organization_id=int(org.id),
             name="Proj Batch",
             slug="proj-batch-bleed",

--- a/tests/agate_api/test_project_stats_means.py
+++ b/tests/agate_api/test_project_stats_means.py
@@ -17,6 +17,8 @@ from api.routers.projects import (
 from backfield_db import AgateGraph, AgateRun, BackfieldOrganization, BackfieldProject
 from sqlmodel import Session, SQLModel, create_engine
 
+from tests.project_helpers import project_ownership_fields
+
 
 def test_mean_ms_empty() -> None:
     assert _mean_ms([]) is None
@@ -50,7 +52,12 @@ def test_project_stats_and_ai_cost_with_succeeded_run() -> None:
         session.add(org)
         session.commit()
         session.refresh(org)
-        project = BackfieldProject(organization_id=org.id, name="General", slug="general")
+        project = BackfieldProject(
+            **project_ownership_fields(session, org.id),
+            organization_id=org.id,
+            name="General",
+            slug="general",
+        )
         session.add(project)
         session.commit()
         session.refresh(project)

--- a/tests/agate_api/test_project_stylebook_ownership.py
+++ b/tests/agate_api/test_project_stylebook_ownership.py
@@ -157,51 +157,100 @@ def test_workspace_stylebook_change_does_not_mutate_existing_project(
         assert project.stylebook_id == ownership_fixture.original_stylebook_id
 
 
-def test_project_response_falls_back_to_workspace_stylebook(
+def test_graph_write_normalizes_runtime_nodes_to_project_stylebook(
     ownership_fixture: ProjectOwnershipFixture,
 ) -> None:
-    with Session(ownership_fixture.engine) as session:
-        workspace = session.get(BackfieldWorkspace, ownership_fixture.workspace_id)
-        assert workspace is not None
-        workspace.stylebook_id = ownership_fixture.replacement_stylebook_id
-        project = BackfieldProject(
-            organization_id=ownership_fixture.organization_id,
-            workspace_id=ownership_fixture.workspace_id,
-            stylebook_id=None,
-            name="Legacy workspace project",
-            slug="legacy-workspace-project",
-        )
-        session.add(workspace)
-        session.add(project)
-        session.commit()
-        session.refresh(project)
-        project_id = int(project.id)
+    project = ownership_fixture.client.post(
+        "/projects",
+        json={
+            "name": "Normalized project",
+            "slug": "normalized-project",
+            "workspace_id": ownership_fixture.workspace_id,
+        },
+    ).json()
 
-    response = ownership_fixture.client.get(f"/projects/{project_id}")
+    response = ownership_fixture.client.post(
+        "/graphs",
+        json={
+            "name": "Normalized flow",
+            "project_id": project["id"],
+            "spec": {
+                "name": "normalized",
+                "nodes": [
+                    {
+                        "id": "geo",
+                        "type": "GeocodeAgent",
+                        "params": {"stylebookId": ownership_fixture.original_stylebook_id},
+                    },
+                    {
+                        "id": "out",
+                        "type": "DBOutput",
+                        "params": {"stylebook_id": ownership_fixture.original_stylebook_id},
+                    },
+                ],
+                "edges": [],
+            },
+        },
+    )
 
-    assert response.status_code == 200
-    assert response.json()["stylebook_id"] == ownership_fixture.replacement_stylebook_id
-    assert response.json()["stylebook_name"] == "Replacement"
+    assert response.status_code == 200, response.text
+    params = [node["params"] for node in response.json()["spec"]["nodes"]]
+    assert params == [
+        {"stylebook_id": ownership_fixture.original_stylebook_id},
+        {"stylebook_id": ownership_fixture.original_stylebook_id},
+    ]
 
 
-def test_project_response_falls_back_to_organization_default(
+def test_graph_create_and_update_reject_conflicting_runtime_stylebook(
     ownership_fixture: ProjectOwnershipFixture,
 ) -> None:
-    with Session(ownership_fixture.engine) as session:
-        project = BackfieldProject(
-            organization_id=ownership_fixture.organization_id,
-            workspace_id=None,
-            stylebook_id=None,
-            name="Legacy orphan project",
-            slug="legacy-orphan-project",
-        )
-        session.add(project)
-        session.commit()
-        session.refresh(project)
-        project_id = int(project.id)
+    project = ownership_fixture.client.post(
+        "/projects",
+        json={
+            "name": "Strict project",
+            "slug": "strict-project",
+            "workspace_id": ownership_fixture.workspace_id,
+        },
+    ).json()
+    mismatch_spec = {
+        "name": "mismatch",
+        "nodes": [
+            {
+                "id": "out",
+                "type": "DBOutput",
+                "params": {"stylebook_id": ownership_fixture.replacement_stylebook_id},
+            },
+        ],
+        "edges": [],
+    }
 
-    response = ownership_fixture.client.get(f"/projects/{project_id}")
+    rejected_create = ownership_fixture.client.post(
+        "/graphs",
+        json={
+            "name": "Rejected flow",
+            "project_id": project["id"],
+            "spec": mismatch_spec,
+        },
+    )
+    assert rejected_create.status_code == 400
+    assert "does not match" in rejected_create.json()["detail"]
 
-    assert response.status_code == 200
-    assert response.json()["stylebook_id"] == ownership_fixture.original_stylebook_id
-    assert response.json()["stylebook_name"] == "Original"
+    created = ownership_fixture.client.post(
+        "/graphs",
+        json={
+            "name": "Accepted flow",
+            "project_id": project["id"],
+            "spec": {"name": "accepted", "nodes": [], "edges": []},
+        },
+    )
+    assert created.status_code == 200
+    rejected_update = ownership_fixture.client.put(
+        f"/graphs/{created.json()['id']}",
+        json={
+            "name": "Rejected update",
+            "project_id": project["id"],
+            "spec": mismatch_spec,
+        },
+    )
+    assert rejected_update.status_code == 400
+    assert "does not match" in rejected_update.json()["detail"]

--- a/tests/agate_api/test_run_cancellation.py
+++ b/tests/agate_api/test_run_cancellation.py
@@ -22,6 +22,7 @@ from sqlalchemy.engine import Engine
 from sqlmodel import Session, SQLModel, create_engine, select
 
 from tests.integration_helpers import patch_test_engine
+from tests.project_helpers import project_ownership_fields
 
 _CANCELLED = "Run cancelled by user"
 
@@ -44,6 +45,7 @@ def cancel_client(
         session.commit()
         session.refresh(organization)
         project = BackfieldProject(
+            **project_ownership_fields(session, int(organization.id)),
             organization_id=int(organization.id),
             name="Cancellation",
             slug="cancellation",
@@ -169,8 +171,7 @@ def test_cancel_bulk_updates_active_items_and_returns_compact_status(cancel_clie
         assert all(
             forbidden not in statement
             for statement in statements
-            if statement.lstrip().startswith("select")
-            and "from agate_processed_item" in statement
+            if statement.lstrip().startswith("select") and "from agate_processed_item" in statement
         )
 
 

--- a/tests/backfield_ai/test_geocode_model_resolve.py
+++ b/tests/backfield_ai/test_geocode_model_resolve.py
@@ -12,6 +12,8 @@ from backfield_db import (
 )
 from sqlmodel import Session, SQLModel, create_engine
 
+from tests.project_helpers import project_ownership_fields
+
 
 @dataclass
 class _GeocodeParams:
@@ -39,7 +41,12 @@ def test_resolve_geocode_models_estimation_falls_back_to_reasoning() -> None:
         session.commit()
         session.refresh(org)
         org_id = int(org.id)  # type: ignore[arg-type]
-        proj = BackfieldProject(name="P", slug="p-geo-est-fb", organization_id=org_id)
+        proj = BackfieldProject(
+            **project_ownership_fields(session, org_id),
+            name="P",
+            slug="p-geo-est-fb",
+            organization_id=org_id,
+        )
         session.add(proj)
         session.commit()
         session.refresh(proj)
@@ -49,9 +56,7 @@ def test_resolve_geocode_models_estimation_falls_back_to_reasoning() -> None:
             geographicReasoningModel="gpt-4o",
             geographicEstimationModel="",
         )
-        eval_m, router_m, geo_m, est_m = resolve_geocode_litellm_models(
-            session, project_id, params
-        )
+        eval_m, router_m, geo_m, est_m = resolve_geocode_litellm_models(session, project_id, params)
         assert eval_m == "gpt-4o-mini"
         assert router_m == "gpt-4o-mini"
         assert geo_m == "gpt-4o"
@@ -77,7 +82,12 @@ def test_resolve_geocode_models_estimation_catalog_pin() -> None:
                 capabilities_json=["text"],
             )
         )
-        proj = BackfieldProject(name="P", slug="p-geo-est-pin", organization_id=org_id)
+        proj = BackfieldProject(
+            **project_ownership_fields(session, org_id),
+            name="P",
+            slug="p-geo-est-pin",
+            organization_id=org_id,
+        )
         session.add(proj)
         session.commit()
         session.refresh(proj)

--- a/tests/backfield_ai/test_merge_platform_keys.py
+++ b/tests/backfield_ai/test_merge_platform_keys.py
@@ -17,6 +17,8 @@ from backfield_db.crypto import encrypt_secret
 from cryptography.fernet import Fernet
 from sqlmodel import Session, SQLModel, create_engine
 
+from tests.project_helpers import project_ownership_fields
+
 
 @pytest.fixture
 def session_with_project(tmp_path, monkeypatch):
@@ -32,7 +34,9 @@ def session_with_project(tmp_path, monkeypatch):
         session.commit()
         session.refresh(org)
         oid = int(org.id)  # type: ignore[arg-type]
-        proj = BackfieldProject(organization_id=oid, name="P", slug="p-plat")
+        proj = BackfieldProject(
+            **project_ownership_fields(session, oid), organization_id=oid, name="P", slug="p-plat"
+        )
         session.add(proj)
         session.commit()
         session.refresh(proj)

--- a/tests/backfield_ai/test_semantic_embedding_model_resolve.py
+++ b/tests/backfield_ai/test_semantic_embedding_model_resolve.py
@@ -26,6 +26,8 @@ from backfield_db import (
 )
 from sqlmodel import Session, SQLModel, create_engine, select
 
+from tests.project_helpers import project_ownership_fields
+
 
 def _engine():
     engine = create_engine("sqlite://", echo=False)
@@ -51,7 +53,12 @@ def test_resolve_semantic_embedding_model_prefers_project_default() -> None:
             capabilities_json=["embedding"],
         )
         session.add(cfg)
-        proj = BackfieldProject(name="P", slug="p-emb", organization_id=org_id)
+        proj = BackfieldProject(
+            **project_ownership_fields(session, org_id),
+            name="P",
+            slug="p-emb",
+            organization_id=org_id,
+        )
         session.add(proj)
         session.commit()
         session.refresh(proj)
@@ -66,9 +73,7 @@ def test_resolve_semantic_embedding_model_prefers_project_default() -> None:
         )
         session.commit()
 
-        assert (
-            resolve_semantic_embedding_model_config_id(session, project_id) == "emb-project"
-        )
+        assert resolve_semantic_embedding_model_config_id(session, project_id) == "emb-project"
 
 
 def test_resolve_semantic_embedding_model_missing_raises() -> None:
@@ -79,6 +84,7 @@ def test_resolve_semantic_embedding_model_missing_raises() -> None:
         session.commit()
         session.refresh(org)
         proj = BackfieldProject(
+            **project_ownership_fields(session, int(org.id)),
             name="P",
             slug="p-emb-miss",
             organization_id=int(org.id),  # type: ignore[arg-type]
@@ -99,6 +105,7 @@ def test_semantic_embedding_configured_false_without_default() -> None:
         session.commit()
         session.refresh(org)
         proj = BackfieldProject(
+            **project_ownership_fields(session, int(org.id)),
             name="P",
             slug="p-emb-cfg0",
             organization_id=int(org.id),  # type: ignore[arg-type]
@@ -129,7 +136,12 @@ def test_semantic_embedding_configured_false_when_project_default_disabled() -> 
             capabilities_json=["embedding"],
         )
         session.add(cfg)
-        proj = BackfieldProject(name="P", slug="p-emb-off", organization_id=org_id)
+        proj = BackfieldProject(
+            **project_ownership_fields(session, org_id),
+            name="P",
+            slug="p-emb-off",
+            organization_id=org_id,
+        )
         session.add(proj)
         session.commit()
         session.refresh(proj)
@@ -172,7 +184,12 @@ def test_semantic_embedding_configured_true_with_enabled_default() -> None:
             capabilities_json=["embedding"],
         )
         session.add(cfg)
-        proj = BackfieldProject(name="P", slug="p-emb-on", organization_id=org_id)
+        proj = BackfieldProject(
+            **project_ownership_fields(session, org_id),
+            name="P",
+            slug="p-emb-on",
+            organization_id=org_id,
+        )
         session.add(proj)
         session.commit()
         session.refresh(proj)
@@ -219,7 +236,12 @@ def test_resolve_semantic_embedding_uses_sole_enabled_when_default_points_off() 
         )
         session.add(cfg_off)
         session.add(cfg_on)
-        proj = BackfieldProject(name="P", slug="p-emb-sole", organization_id=org_id)
+        proj = BackfieldProject(
+            **project_ownership_fields(session, org_id),
+            name="P",
+            slug="p-emb-sole",
+            organization_id=org_id,
+        )
         session.add(proj)
         session.commit()
         session.refresh(proj)
@@ -241,9 +263,7 @@ def test_resolve_semantic_embedding_uses_sole_enabled_when_default_points_off() 
         )
         session.commit()
 
-        assert (
-            resolve_semantic_embedding_model_config_id(session, project_id) == "emb-on-sole"
-        )
+        assert resolve_semantic_embedding_model_config_id(session, project_id) == "emb-on-sole"
         assert semantic_embedding_configured(session, project_id) is True
 
 
@@ -265,7 +285,12 @@ def test_resolve_semantic_embedding_after_default_re_enabled() -> None:
             capabilities_json=["embedding"],
         )
         session.add(cfg)
-        proj = BackfieldProject(name="P", slug="p-emb-reon", organization_id=org_id)
+        proj = BackfieldProject(
+            **project_ownership_fields(session, org_id),
+            name="P",
+            slug="p-emb-reon",
+            organization_id=org_id,
+        )
         session.add(proj)
         session.commit()
         session.refresh(proj)
@@ -319,7 +344,12 @@ def test_resolve_generative_default_prefers_project_default() -> None:
             capabilities_json=["text"],
         )
         session.add(cfg)
-        proj = BackfieldProject(name="P", slug="p-gen-res", organization_id=org_id)
+        proj = BackfieldProject(
+            **project_ownership_fields(session, org_id),
+            name="P",
+            slug="p-gen-res",
+            organization_id=org_id,
+        )
         session.add(proj)
         session.commit()
         session.refresh(proj)
@@ -337,9 +367,7 @@ def test_resolve_generative_default_prefers_project_default() -> None:
         assert (
             resolve_generative_default_model_config_id(session, project_id) == "gen-project-default"
         )
-        assert (
-            resolve_semantic_hyde_model_config_id(session, project_id) == "gen-project-default"
-        )
+        assert resolve_semantic_hyde_model_config_id(session, project_id) == "gen-project-default"
 
 
 def test_resolve_generative_default_falls_back_to_legacy_semantic_hyde_role() -> None:
@@ -360,7 +388,12 @@ def test_resolve_generative_default_falls_back_to_legacy_semantic_hyde_role() ->
             capabilities_json=["text"],
         )
         session.add(cfg)
-        proj = BackfieldProject(name="P", slug="p-hyde-legacy", organization_id=org_id)
+        proj = BackfieldProject(
+            **project_ownership_fields(session, org_id),
+            name="P",
+            slug="p-hyde-legacy",
+            organization_id=org_id,
+        )
         session.add(proj)
         session.commit()
         session.refresh(proj)
@@ -375,9 +408,7 @@ def test_resolve_generative_default_falls_back_to_legacy_semantic_hyde_role() ->
         )
         session.commit()
 
-        assert (
-            resolve_generative_default_model_config_id(session, project_id) == "gen-hyde-legacy"
-        )
+        assert resolve_generative_default_model_config_id(session, project_id) == "gen-hyde-legacy"
 
 
 def test_resolve_generative_default_uses_sole_enabled_generative_when_no_default() -> None:
@@ -398,7 +429,12 @@ def test_resolve_generative_default_uses_sole_enabled_generative_when_no_default
             capabilities_json=["text"],
         )
         session.add(cfg)
-        proj = BackfieldProject(name="P", slug="p-hyde-sole", organization_id=org_id)
+        proj = BackfieldProject(
+            **project_ownership_fields(session, org_id),
+            name="P",
+            slug="p-hyde-sole",
+            organization_id=org_id,
+        )
         session.add(proj)
         session.commit()
         session.refresh(proj)
@@ -415,6 +451,7 @@ def test_resolve_generative_default_missing_raises() -> None:
         session.commit()
         session.refresh(org)
         proj = BackfieldProject(
+            **project_ownership_fields(session, int(org.id)),
             name="P",
             slug="p-hyde-miss",
             organization_id=int(org.id),  # type: ignore[arg-type]

--- a/tests/core_api/test_api_key_scopes.py
+++ b/tests/core_api/test_api_key_scopes.py
@@ -20,6 +20,7 @@ from fastapi.testclient import TestClient
 from sqlmodel import Session, SQLModel, create_engine
 
 from tests.core_api.auth_helpers import attach_test_engine, seed_first_admin
+from tests.project_helpers import project_ownership_fields
 
 
 @pytest.fixture
@@ -50,6 +51,7 @@ def client(tmp_path) -> Generator[TestClient, None, None]:
         s.refresh(ws)
         s.add(
             BackfieldProject(
+                **project_ownership_fields(s, oid, workspace_id=int(ws.id)),
                 name="General",
                 slug="general",
                 organization_id=oid,

--- a/tests/core_api/test_core_api.py
+++ b/tests/core_api/test_core_api.py
@@ -22,6 +22,7 @@ from sqlmodel import Session, SQLModel, create_engine
 
 from tests.core_api.auth_helpers import attach_test_engine, seed_first_admin
 from tests.integration_helpers import patch_test_engine
+from tests.project_helpers import project_ownership_fields
 
 
 @pytest.fixture
@@ -62,6 +63,7 @@ def client(tmp_path, monkeypatch: pytest.MonkeyPatch) -> Generator[TestClient, N
         s.refresh(ws)
         s.add(
             BackfieldProject(
+                **project_ownership_fields(s, int(org.id), workspace_id=int(ws.id)),
                 name="General",
                 slug="general",
                 organization_id=int(org.id),
@@ -70,6 +72,7 @@ def client(tmp_path, monkeypatch: pytest.MonkeyPatch) -> Generator[TestClient, N
         )
         s.add(
             BackfieldProject(
+                **project_ownership_fields(s, int(org.id), workspace_id=int(ws.id)),
                 name="Other",
                 slug="other",
                 organization_id=int(org.id),
@@ -87,6 +90,7 @@ def client(tmp_path, monkeypatch: pytest.MonkeyPatch) -> Generator[TestClient, N
         s.refresh(ws2)
         s.add(
             BackfieldProject(
+                **project_ownership_fields(s, int(org.id), workspace_id=int(ws2.id)),
                 name="Alpha",
                 slug="alpha-proj",
                 organization_id=int(org.id),

--- a/tests/core_api/test_public_api.py
+++ b/tests/core_api/test_public_api.py
@@ -41,6 +41,7 @@ from fastapi.testclient import TestClient
 from sqlmodel import Session, SQLModel, create_engine, select
 
 from tests.core_api.auth_helpers import attach_test_engine, seed_first_admin
+from tests.project_helpers import project_ownership_fields
 
 
 @pytest.fixture
@@ -71,6 +72,7 @@ def public_client(tmp_path) -> Generator[TestClient, None, None]:
         s.refresh(ws)
         s.add(
             BackfieldProject(
+                **project_ownership_fields(s, oid, workspace_id=int(ws.id)),
                 name="General",
                 slug="general",
                 organization_id=oid,
@@ -79,6 +81,7 @@ def public_client(tmp_path) -> Generator[TestClient, None, None]:
         )
         s.add(
             BackfieldProject(
+                **project_ownership_fields(s, oid, workspace_id=int(ws.id)),
                 name="Other",
                 slug="other",
                 organization_id=oid,
@@ -1008,9 +1011,7 @@ def test_public_article_detail_include_text(public_client: TestClient) -> None:
     body = r.json()
     assert "text" in body
     assert body["preview"]
-    assert body["text"] == (
-        "The council approved the budget after a long debate downtown."
-    )
+    assert body["text"] == ("The council approved the budget after a long debate downtown.")
     assert body.get("counts") is None
 
 
@@ -1551,7 +1552,9 @@ def test_public_organization_not_found(public_client: TestClient) -> None:
     assert r.status_code == 404
 
 
-def test_public_entity_search_stylebook_slug_override(public_client: TestClient) -> None:
+def test_public_entity_search_rejects_stylebook_slug_override(
+    public_client: TestClient,
+) -> None:
     engine = public_client.test_engine  # type: ignore[attr-defined]
     with Session(engine) as session:
         org = session.exec(
@@ -1604,19 +1607,16 @@ def test_public_entity_search_stylebook_slug_override(public_client: TestClient)
         headers=headers,
         params={"q": "Newsroom", "stylebook_slug": "mnn-stylebook"},
     )
-    assert overridden.status_code == 200
-    body = overridden.json()
-    assert body["pagination"]["total"] == 1
-    assert body["items"][0]["label"] == "MNN Newsroom"
-    assert body["items"][0]["stylebook_slug"] == "mnn-stylebook"
+    assert overridden.status_code == 400
+    assert "does not match" in overridden.json()["error"]["message"]
 
     types = public_client.get(
         "/public/v1/projects/general/organizations/types",
         headers=headers,
         params={"stylebook_slug": "mnn-stylebook"},
     )
-    assert types.status_code == 200
-    assert "media" in types.json()["types"]
+    assert types.status_code == 400
+    assert "does not match" in types.json()["error"]["message"]
 
     missing = public_client.get(
         "/public/v1/projects/general/organizations/search",
@@ -1828,8 +1828,7 @@ def test_public_mentions_search_facets_and_detail(public_client: TestClient) -> 
     entity_types = {item["entity_type"] for item in body["items"]}
     assert entity_types == {"location", "person", "organization"}
     assert all(
-        item["article"]["headline"] == "City council votes on budget"
-        for item in body["items"]
+        item["article"]["headline"] == "City council votes on budget" for item in body["items"]
     )
 
     by_person = public_client.get(

--- a/tests/core_api/test_public_runs.py
+++ b/tests/core_api/test_public_runs.py
@@ -28,6 +28,7 @@ from fastapi.testclient import TestClient
 from sqlmodel import Session, SQLModel, create_engine, select
 
 from tests.core_api.auth_helpers import attach_test_engine, seed_and_login
+from tests.project_helpers import project_ownership_fields
 
 
 @pytest.fixture
@@ -58,6 +59,7 @@ def public_runs_client(tmp_path) -> Generator[TestClient, None, None]:
         s.refresh(ws)
         s.add(
             BackfieldProject(
+                **project_ownership_fields(s, oid, workspace_id=int(ws.id)),
                 name="General",
                 slug="general",
                 organization_id=oid,

--- a/tests/entities/test_article_embedding_persist.py
+++ b/tests/entities/test_article_embedding_persist.py
@@ -13,6 +13,8 @@ from backfield_entities.ingest.article_embedding.persist import (
 )
 from sqlmodel import Session, SQLModel, create_engine, select
 
+from tests.project_helpers import project_ownership_fields
+
 
 def _engine():
     engine = create_engine("sqlite://", echo=False)
@@ -26,6 +28,7 @@ def _seed_article(session: Session) -> int:
     session.commit()
     session.refresh(org)
     proj = BackfieldProject(
+        **project_ownership_fields(session, int(org.id)),
         name="Demo",
         slug="demo-article-embed",
         organization_id=int(org.id),  # type: ignore[arg-type]

--- a/tests/entities/test_article_metadata_persist.py
+++ b/tests/entities/test_article_metadata_persist.py
@@ -13,6 +13,8 @@ from backfield_entities.ingest.article_metadata.persist import (
 )
 from sqlmodel import Session, SQLModel, create_engine, select
 
+from tests.project_helpers import project_ownership_fields
+
 
 def _engine():
     engine = create_engine("sqlite://", echo=False)
@@ -26,6 +28,7 @@ def _seed_article(session: Session) -> int:
     session.commit()
     session.refresh(org)
     proj = BackfieldProject(
+        **project_ownership_fields(session, int(org.id)),
         name="Demo",
         slug="demo-article-meta",
         organization_id=int(org.id),  # type: ignore[arg-type]

--- a/tests/entities/test_compass_direction_gate.py
+++ b/tests/entities/test_compass_direction_gate.py
@@ -28,6 +28,8 @@ from backfield_entities.entities.location.policy import (
 )
 from sqlmodel import Session, SQLModel, create_engine
 
+from tests.project_helpers import project_ownership_fields
+
 
 def _engine():
     engine = create_engine("sqlite://", echo=False)
@@ -47,7 +49,12 @@ def _seed_stylebook(session: Session) -> tuple[int, int]:
         is_default=True,
     )
     session.add(sb)
-    proj = BackfieldProject(name="Demo", slug="demo-compass", organization_id=int(org.id))  # type: ignore[arg-type]
+    proj = BackfieldProject(
+        **project_ownership_fields(session, int(org.id)),
+        name="Demo",
+        slug="demo-compass",
+        organization_id=int(org.id),
+    )  # type: ignore[arg-type]
     session.add(proj)
     session.commit()
     session.refresh(sb)

--- a/tests/entities/test_connection_rewire.py
+++ b/tests/entities/test_connection_rewire.py
@@ -18,6 +18,8 @@ from backfield_entities.connections.rewire import rewire_connections_for_canonic
 from backfield_entities.entities.person.merge import merge_person_canonical_into
 from sqlmodel import Session, SQLModel, create_engine, select
 
+from tests.project_helpers import project_ownership_fields
+
 
 def _seed(session: Session) -> tuple[int, int, int]:
     org = BackfieldOrganization(name="Org", slug="org-conn-rewire")
@@ -27,7 +29,12 @@ def _seed(session: Session) -> tuple[int, int, int]:
     org_id = int(org.id)  # type: ignore[arg-type]
     stylebook = ensure_default_stylebook_for_organization(session, org_id)
     stylebook_id = int(stylebook.id)  # type: ignore[arg-type]
-    proj = BackfieldProject(name="News", slug="news", organization_id=org_id)
+    proj = BackfieldProject(
+        **project_ownership_fields(session, org_id),
+        name="News",
+        slug="news",
+        organization_id=org_id,
+    )
     session.add(proj)
     session.commit()
     session.refresh(proj)

--- a/tests/entities/test_custom_record_persist.py
+++ b/tests/entities/test_custom_record_persist.py
@@ -13,6 +13,8 @@ from backfield_entities.ingest.custom_record.persist import (
 )
 from sqlmodel import Session, SQLModel, create_engine, select
 
+from tests.project_helpers import project_ownership_fields
+
 
 def _engine():
     engine = create_engine("sqlite://", echo=False)
@@ -26,6 +28,7 @@ def _seed_article(session: Session) -> int:
     session.commit()
     session.refresh(org)
     proj = BackfieldProject(
+        **project_ownership_fields(session, int(org.id)),
         name="Demo",
         slug="demo-custom-record",
         organization_id=int(org.id),  # type: ignore[arg-type]

--- a/tests/entities/test_db_output_stylebook_resolve.py
+++ b/tests/entities/test_db_output_stylebook_resolve.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import pytest
 from backfield_db import (
     BackfieldOrganization,
     BackfieldProject,
@@ -44,9 +45,7 @@ def test_db_output_settings_stylebook_matching_can_be_disabled() -> None:
 
 
 def test_db_output_settings_validate_reconciliation_policy() -> None:
-    settings = DbOutputCanonicalSettings.from_node_params(
-        {"reconciliation_policy": "add_only"}
-    )
+    settings = DbOutputCanonicalSettings.from_node_params({"reconciliation_policy": "add_only"})
     assert settings.reconciliation_policy == "add_only"
 
 
@@ -55,7 +54,7 @@ def test_db_output_settings_semantic_indexing_defaults_off() -> None:
     assert settings.semantic_indexing_enabled is False
 
 
-def test_db_output_delegates_override_to_shared_resolver() -> None:
+def test_db_output_accepts_matching_legacy_value_and_rejects_mismatch() -> None:
     engine = _engine()
     with Session(engine) as session:
         org = BackfieldOrganization(slug="org-dbo", name="O")
@@ -77,17 +76,24 @@ def test_db_output_delegates_override_to_shared_resolver() -> None:
         proj = BackfieldProject(
             organization_id=int(org.id),
             workspace_id=int(ws.id),
+            stylebook_id=int(sb_b.id),
             name="P",
             slug="p-dbo",
         )
         session.add(proj)
         session.commit()
 
+        with pytest.raises(ValueError, match="STYLEBOOK_OVERRIDE_CONFLICT"):
+            resolve_effective_stylebook_id(
+                session,
+                project_id=int(proj.id),
+                stylebook_id_override=int(sb_a.id),
+            )
         assert resolve_effective_stylebook_id(
             session,
             project_id=int(proj.id),
-            stylebook_id_override=int(sb_a.id),
-        ) == int(sb_a.id)
+            stylebook_id_override=int(sb_b.id),
+        ) == int(sb_b.id)
         assert resolve_effective_stylebook_id(
             session,
             project_id=int(proj.id),

--- a/tests/entities/test_full_bundle_roundtrip.py
+++ b/tests/entities/test_full_bundle_roundtrip.py
@@ -34,6 +34,8 @@ from backfield_entities.catalog.full_bundle import (
 )
 from sqlmodel import Session, SQLModel, create_engine, select
 
+from tests.project_helpers import project_ownership_fields
+
 
 def _engine():
     engine = create_engine("sqlite://", echo=False)
@@ -311,16 +313,6 @@ def test_export_import_roundtrip_includes_aliases_meta_connections(tmp_path: Pat
         session.refresh(org)
         oid = int(org.id)  # type: ignore[arg-type]
 
-        project = BackfieldProject(
-            organization_id=oid,
-            name="Demo Project",
-            slug="demo-proj-sidecars",
-        )
-        session.add(project)
-        session.commit()
-        session.refresh(project)
-        project_id = int(project.id)  # type: ignore[arg-type]
-
         sb = Stylebook(
             organization_id=oid,
             name="Sidecar Book",
@@ -331,6 +323,17 @@ def test_export_import_roundtrip_includes_aliases_meta_connections(tmp_path: Pat
         session.commit()
         session.refresh(sb)
         sb_id = int(sb.id)  # type: ignore[arg-type]
+        project = BackfieldProject(
+            **project_ownership_fields(session, oid, stylebook_id=sb_id),
+            organization_id=oid,
+            stylebook_id=sb_id,
+            name="Demo Project",
+            slug="demo-proj-sidecars",
+        )
+        session.add(project)
+        session.commit()
+        session.refresh(project)
+        project_id = int(project.id)  # type: ignore[arg-type]
 
         loc_id = str(uuid4())
         person_id = str(uuid4())

--- a/tests/entities/test_geocode_cache_resolve.py
+++ b/tests/entities/test_geocode_cache_resolve.py
@@ -23,6 +23,8 @@ from backfield_entities.ingest.geocode_cache.resolve import (
 )
 from sqlmodel import Session, SQLModel, create_engine
 
+from tests.project_helpers import project_ownership_fields
+
 
 def test_fingerprint_stable_payload() -> None:
     a = substrate_location_cache_query_fingerprint(
@@ -63,6 +65,7 @@ def _seed_org_sb_project(session: Session) -> tuple[int, int, int]:
     session.commit()
     session.refresh(ws)
     proj = BackfieldProject(
+        **project_ownership_fields(session, oid, workspace_id=int(ws.id)),
         organization_id=oid,
         name="P",
         slug="p-gcc",

--- a/tests/entities/test_graph_stylebook_refs.py
+++ b/tests/entities/test_graph_stylebook_refs.py
@@ -8,6 +8,7 @@ from backfield_db import (
     AgateGraph,
     BackfieldOrganization,
     BackfieldProject,
+    BackfieldWorkspace,
     Stylebook,
 )
 from backfield_entities.catalog.graph_stylebook_refs import (
@@ -15,9 +16,11 @@ from backfield_entities.catalog.graph_stylebook_refs import (
     StylebookGraphRefsError,
     count_stylebook_usage_in_graphs,
     iter_stylebook_refs_from_spec_dict,
+    normalize_runtime_stylebook_refs,
     reassign_stylebook_id_in_spec_dict,
     sanitize_stylebook_refs_for_organization,
     unique_stylebook_ids_from_spec_dict,
+    validate_runtime_stylebook_refs_for_project,
     validate_stylebook_refs_for_organization,
 )
 from sqlmodel import Session, SQLModel, create_engine
@@ -54,6 +57,58 @@ def test_iter_legacy_stylebookId_param() -> None:
     }
     assert iter_stylebook_refs_from_spec_dict(spec) == [("a", 7)]
     assert unique_stylebook_ids_from_spec_dict(spec) == [7]
+
+
+def test_normalize_runtime_nodes_to_project_stylebook() -> None:
+    spec = {
+        "name": "x",
+        "nodes": [
+            {"id": "a", "type": "DBOutput", "params": {}},
+            {"id": "b", "type": "GeocodeAgent", "params": {"stylebookId": 7}},
+            {"id": "c", "type": "PlaceExtract", "params": {}},
+        ],
+        "edges": [],
+    }
+
+    assert normalize_runtime_stylebook_refs(spec, project_stylebook_id=7) is True
+    assert spec["nodes"][0]["params"]["stylebook_id"] == 7
+    assert spec["nodes"][1]["params"] == {"stylebook_id": 7}
+    assert spec["nodes"][2]["params"] == {}
+
+
+def test_validate_runtime_nodes_rejects_conflicting_explicit_stylebook() -> None:
+    spec = {
+        "name": "x",
+        "nodes": [
+            {"id": "a", "type": "DBOutput", "params": {"stylebook_id": 8}},
+            {"id": "b", "type": "GeocodeAgent", "params": {"stylebookId": 7}},
+        ],
+        "edges": [],
+    }
+
+    try:
+        validate_runtime_stylebook_refs_for_project(spec, project_stylebook_id=7)
+    except StylebookGraphRefsError as error:
+        assert "does not match" in str(error)
+        assert "Node a" in str(error)
+    else:
+        raise AssertionError("expected StylebookGraphRefsError")
+
+
+def test_validate_runtime_nodes_accepts_matching_legacy_keys() -> None:
+    spec = {
+        "name": "x",
+        "nodes": [
+            {"id": "a", "type": "DBOutput", "params": {"stylebook_id": 7}},
+            {"id": "b", "type": "GeocodeAgent", "params": {"stylebookId": "7"}},
+        ],
+        "edges": [],
+    }
+
+    validate_runtime_stylebook_refs_for_project(spec, project_stylebook_id=7)
+    assert normalize_runtime_stylebook_refs(spec, project_stylebook_id=7) is True
+    assert spec["nodes"][0]["params"] == {"stylebook_id": 7}
+    assert spec["nodes"][1]["params"] == {"stylebook_id": 7}
 
 
 def test_reassign_stylebook_id_in_spec_dict() -> None:
@@ -116,12 +171,22 @@ def test_count_usage_across_graphs() -> None:
         session.refresh(sb_b)
         aid = int(sb_a.id)  # type: ignore[arg-type]
         bid = int(sb_b.id)  # type: ignore[arg-type]
+        workspace = BackfieldWorkspace(
+            organization_id=oid,
+            stylebook_id=aid,
+            name="Workspace",
+            slug="workspace-gref",
+        )
+        session.add(workspace)
+        session.commit()
+        session.refresh(workspace)
 
         proj = BackfieldProject(
             organization_id=oid,
             name="P",
             slug="p-gref",
-            workspace_id=None,
+            workspace_id=int(workspace.id),
+            stylebook_id=aid,
         )
         session.add(proj)
         session.commit()
@@ -206,9 +271,7 @@ def test_sanitize_missing_stylebook_to_org_default() -> None:
         session.refresh(sb)
 
         spec = _minimal_spec_with_stylebook("n", 99999)
-        changed = sanitize_stylebook_refs_for_organization(
-            session, organization_id=oid, spec=spec
-        )
+        changed = sanitize_stylebook_refs_for_organization(session, organization_id=oid, spec=spec)
         assert changed is True
         assert spec["nodes"][0]["params"].get(STYLEBOOK_NODE_PARAM_KEY) is None
         validate_stylebook_refs_for_organization(session, organization_id=oid, spec=spec)
@@ -243,9 +306,7 @@ def test_sanitize_db_output_clears_missing_stylebook() -> None:
             ],
             "edges": [],
         }
-        changed = sanitize_stylebook_refs_for_organization(
-            session, organization_id=oid, spec=spec
-        )
+        changed = sanitize_stylebook_refs_for_organization(session, organization_id=oid, spec=spec)
         assert changed is True
         assert STYLEBOOK_NODE_PARAM_KEY not in spec["nodes"][0]["params"] or (
             spec["nodes"][0]["params"].get(STYLEBOOK_NODE_PARAM_KEY) is None

--- a/tests/entities/test_link_commit_gate.py
+++ b/tests/entities/test_link_commit_gate.py
@@ -36,6 +36,8 @@ from backfield_entities.entities.person.recall import canonical_ids_from_person_
 from backfield_entities.entities.person.types import normalize_person_text
 from sqlmodel import Session, SQLModel, create_engine, select
 
+from tests.project_helpers import project_ownership_fields
+
 
 def _engine():
     engine = create_engine("sqlite://", echo=False)
@@ -58,7 +60,12 @@ def _seed_stylebook(session: Session) -> tuple[int, int]:
     session.add(sb)
     session.commit()
     session.refresh(sb)
-    proj = BackfieldProject(name="Demo", slug="demo-link-commit-gate", organization_id=oid)
+    proj = BackfieldProject(
+        **project_ownership_fields(session, oid),
+        name="Demo",
+        slug="demo-link-commit-gate",
+        organization_id=oid,
+    )
     session.add(proj)
     session.commit()
     session.refresh(proj)

--- a/tests/entities/test_location_delete.py
+++ b/tests/entities/test_location_delete.py
@@ -19,6 +19,8 @@ from backfield_entities.entities.location.delete import (
 from sqlalchemy.engine import Engine
 from sqlmodel import Session, SQLModel, create_engine
 
+from tests.project_helpers import project_ownership_fields
+
 
 def _engine(tmp_path) -> Engine:
     path = tmp_path / "delete-canonical.db"
@@ -47,6 +49,7 @@ def test_delete_location_canonical_and_requeue(tmp_path) -> None:
         session.commit()
         session.refresh(sb)
         project = BackfieldProject(
+            **project_ownership_fields(session, int(org.id)),
             organization_id=int(org.id),
             name="Demo",
             slug="demo",
@@ -117,7 +120,10 @@ def test_delete_stale_substrate_guard(tmp_path) -> None:
         session.commit()
         session.refresh(sb)
         project = BackfieldProject(
-            organization_id=int(org.id), name="P", slug="p"
+            **project_ownership_fields(session, int(org.id)),
+            organization_id=int(org.id),
+            name="P",
+            slug="p",
         )
         session.add(project)
         session.commit()

--- a/tests/entities/test_location_merge_guard.py
+++ b/tests/entities/test_location_merge_guard.py
@@ -20,6 +20,8 @@ from backfield_entities.entities.linking.substrate_actions import (
 from backfield_entities.entities.location.merge import merge_location_canonical_into
 from sqlmodel import Session, SQLModel, create_engine, select
 
+from tests.project_helpers import project_ownership_fields
+
 
 def _seed(session: Session, *, slug: str) -> tuple[int, int, int]:
     org = BackfieldOrganization(name="Org", slug=slug)
@@ -29,7 +31,12 @@ def _seed(session: Session, *, slug: str) -> tuple[int, int, int]:
     org_id = int(org.id)  # type: ignore[arg-type]
     stylebook = ensure_default_stylebook_for_organization(session, org_id)
     stylebook_id = int(stylebook.id)  # type: ignore[arg-type]
-    proj = BackfieldProject(name="News", slug="news", organization_id=org_id)
+    proj = BackfieldProject(
+        **project_ownership_fields(session, org_id),
+        name="News",
+        slug="news",
+        organization_id=org_id,
+    )
     session.add(proj)
     session.commit()
     session.refresh(proj)

--- a/tests/entities/test_organization_acronym_matching.py
+++ b/tests/entities/test_organization_acronym_matching.py
@@ -30,6 +30,8 @@ from backfield_entities.entities.organization.types import (
 )
 from sqlmodel import Session, SQLModel, create_engine, select
 
+from tests.project_helpers import project_ownership_fields
+
 
 def _engine():
     engine = create_engine("sqlite://", echo=False)
@@ -48,7 +50,12 @@ def _seed(session: Session) -> tuple[int, int]:
     session.commit()
     session.refresh(sb)
     sb_id = int(sb.id)  # type: ignore[arg-type]
-    proj = BackfieldProject(name="Demo", slug="demo-org-acronym", organization_id=oid)
+    proj = BackfieldProject(
+        **project_ownership_fields(session, oid),
+        name="Demo",
+        slug="demo-org-acronym",
+        organization_id=oid,
+    )
     session.add(proj)
     session.commit()
     session.refresh(proj)

--- a/tests/entities/test_organization_persist.py
+++ b/tests/entities/test_organization_persist.py
@@ -31,6 +31,8 @@ from backfield_entities.entities.organization import (
 )
 from sqlmodel import Session, SQLModel, create_engine, select
 
+from tests.project_helpers import project_ownership_fields
+
 
 def _engine():
     engine = create_engine("sqlite://", echo=False)
@@ -49,7 +51,9 @@ def _seed_stylebook(session: Session) -> tuple[int, int]:
     session.commit()
     session.refresh(sb)
     sb_id = int(sb.id)  # type: ignore[arg-type]
-    proj = BackfieldProject(name="Demo", slug="demo-org", organization_id=oid)
+    proj = BackfieldProject(
+        **project_ownership_fields(session, oid), name="Demo", slug="demo-org", organization_id=oid
+    )
     session.add(proj)
     session.commit()
     session.refresh(proj)

--- a/tests/entities/test_organization_policy.py
+++ b/tests/entities/test_organization_policy.py
@@ -21,6 +21,8 @@ from worker.substrate.entities.organization.adjudication import (
     adjudicate_ambiguous_organization_plan_with_llm,
 )
 
+from tests.project_helpers import project_ownership_fields
+
 
 def _adj_json_link(canonical_id: str, confidence: float, rationale: str) -> str:
     return (
@@ -55,7 +57,12 @@ def _seed(session: Session) -> tuple[int, int]:
     session.commit()
     session.refresh(sb)
     sb_id = int(sb.id)  # type: ignore[arg-type]
-    proj = BackfieldProject(name="Demo", slug="demo-org-policy", organization_id=oid)
+    proj = BackfieldProject(
+        **project_ownership_fields(session, oid),
+        name="Demo",
+        slug="demo-org-policy",
+        organization_id=oid,
+    )
     session.add(proj)
     session.commit()
     session.refresh(proj)
@@ -108,9 +115,7 @@ def test_adjudicate_ambiguous_organization_upgrades_when_llm_confident(monkeypat
         )
 
         def _fake_llm(*_a, **_k) -> str:
-            return _adj_json_link(
-                id1, ADJUDICATION_LINK_MIN_CONFIDENCE, "Same police department."
-            )
+            return _adj_json_link(id1, ADJUDICATION_LINK_MIN_CONFIDENCE, "Same police department.")
 
         monkeypatch.setattr(
             "worker.substrate.entities.organization.adjudication.call_llm",

--- a/tests/entities/test_organization_recall.py
+++ b/tests/entities/test_organization_recall.py
@@ -17,6 +17,8 @@ from backfield_entities.entities.organization import (
 )
 from sqlmodel import Session, SQLModel, create_engine
 
+from tests.project_helpers import project_ownership_fields
+
 
 def _engine():
     engine = create_engine("sqlite://", echo=False)
@@ -35,7 +37,12 @@ def _seed(session: Session) -> tuple[int, int]:
     session.commit()
     session.refresh(sb)
     sb_id = int(sb.id)  # type: ignore[arg-type]
-    proj = BackfieldProject(name="Demo", slug="demo-org-recall", organization_id=oid)
+    proj = BackfieldProject(
+        **project_ownership_fields(session, oid),
+        name="Demo",
+        slug="demo-org-recall",
+        organization_id=oid,
+    )
     session.add(proj)
     session.commit()
     session.refresh(proj)

--- a/tests/entities/test_person_persist.py
+++ b/tests/entities/test_person_persist.py
@@ -33,6 +33,8 @@ from backfield_entities.entities.person import (
 )
 from sqlmodel import Session, SQLModel, create_engine, select
 
+from tests.project_helpers import project_ownership_fields
+
 
 def _engine():
     engine = create_engine("sqlite://", echo=False)
@@ -51,7 +53,12 @@ def _seed_stylebook(session: Session) -> tuple[int, int]:
     session.commit()
     session.refresh(sb)
     sb_id = int(sb.id)  # type: ignore[arg-type]
-    proj = BackfieldProject(name="Demo", slug="demo-person", organization_id=oid)
+    proj = BackfieldProject(
+        **project_ownership_fields(session, oid),
+        name="Demo",
+        slug="demo-person",
+        organization_id=oid,
+    )
     session.add(proj)
     session.commit()
     session.refresh(proj)
@@ -62,9 +69,7 @@ def test_allocate_unique_person_canonical_slug_suffixes_on_collision() -> None:
     engine = _engine()
     with Session(engine) as session:
         sb_id, _pid = _seed_stylebook(session)
-        slug = allocate_unique_person_canonical_slug(
-            session, stylebook_id=sb_id, label="Jane Doe"
-        )
+        slug = allocate_unique_person_canonical_slug(session, stylebook_id=sb_id, label="Jane Doe")
         assert slug == "jane-doe"
         session.add(
             StylebookPersonCanonical(
@@ -352,11 +357,7 @@ def test_decide_person_defers_when_alias_matches_but_affiliation_differs() -> No
 
         plan = decide_person_canonical_persist_plan(session, stylebook_id=sb_id, person=person)
         assert plan.decision == CanonicalPersistDecision.DEFER
-        codes = [
-            str(r.get("code"))
-            for r in plan.resolution_reasons
-            if isinstance(r, dict)
-        ]
+        codes = [str(r.get("code")) for r in plan.resolution_reasons if isinstance(r, dict)]
         assert "ambiguous_person_canonical_match" in codes
         recall = next(
             r.get("recall_canonical_ids")

--- a/tests/entities/test_person_recall.py
+++ b/tests/entities/test_person_recall.py
@@ -22,6 +22,8 @@ from backfield_entities.entities.person.recall import (
 )
 from sqlmodel import Session, SQLModel, create_engine
 
+from tests.project_helpers import project_ownership_fields
+
 
 def _engine():
     engine = create_engine("sqlite://", echo=False)
@@ -40,7 +42,12 @@ def _seed(session: Session) -> tuple[int, int]:
     session.commit()
     session.refresh(sb)
     sb_id = int(sb.id)  # type: ignore[arg-type]
-    proj = BackfieldProject(name="Demo", slug="demo-recall", organization_id=oid)
+    proj = BackfieldProject(
+        **project_ownership_fields(session, oid),
+        name="Demo",
+        slug="demo-recall",
+        organization_id=oid,
+    )
     session.add(proj)
     session.commit()
     session.refresh(proj)
@@ -154,9 +161,7 @@ def test_recall_caps_at_default_limit() -> None:
             normalized_name="alex smith",
             affiliation="Org",
         )
-        recall = retrieve_person_canonical_candidates(
-            session, stylebook_id=sb_id, person=person
-        )
+        recall = retrieve_person_canonical_candidates(session, stylebook_id=sb_id, person=person)
         assert len(recall) <= PERSON_RECALL_DEFAULT_LIMIT
         assert len(recall) > 0
 

--- a/tests/entities/test_person_review.py
+++ b/tests/entities/test_person_review.py
@@ -39,6 +39,8 @@ from backfield_entities.entities.person.review import (
 from backfield_entities.entities.person.types import person_identity_fingerprint
 from sqlmodel import Session, SQLModel, create_engine
 
+from tests.project_helpers import project_ownership_fields
+
 
 def _engine():
     engine = create_engine("sqlite://", echo=False)
@@ -57,7 +59,12 @@ def _seed(session: Session) -> tuple[int, int]:
     session.commit()
     session.refresh(sb)
     sb_id = int(sb.id)  # type: ignore[arg-type]
-    proj = BackfieldProject(name="Demo", slug="demo-review", organization_id=oid)
+    proj = BackfieldProject(
+        **project_ownership_fields(session, oid),
+        name="Demo",
+        slug="demo-review",
+        organization_id=oid,
+    )
     session.add(proj)
     session.commit()
     session.refresh(proj)
@@ -122,9 +129,7 @@ def test_deterministic_does_not_override_llm_auto_defer() -> None:
 
 
 def test_inferred_surname_from_review_message_legacy_rows() -> None:
-    assert inferred_surname_from_review_message(
-        "Inferred surname Bowser from son Drew Bowser"
-    )
+    assert inferred_surname_from_review_message("Inferred surname Bowser from son Drew Bowser")
     details = {
         "review_reason_code": REASON_FIRST_NAME_ONLY,
         "review_message": "Inferred surname Bowser from son Drew Bowser",
@@ -275,9 +280,9 @@ def test_policy_non_person_ai_review_recommends_defer() -> None:
             session.refresh(person)
             raw = person.canonical_review_reasons_json
             assert isinstance(raw, list)
-            assert any(
-                isinstance(x, dict) and x.get("suggested_action") == "defer" for x in raw
-            ), name
+            assert any(isinstance(x, dict) and x.get("suggested_action") == "defer" for x in raw), (
+                name
+            )
             assert not any(
                 isinstance(x, dict) and x.get("suggested_action") == "materialize_new" for x in raw
             ), name
@@ -339,9 +344,7 @@ def test_policy_pseudonym_defers_with_defer_suggestion() -> None:
         session.refresh(person)
         raw = person.canonical_review_reasons_json
         assert isinstance(raw, list)
-        assert any(
-            isinstance(x, dict) and x.get("suggested_action") == "defer" for x in raw
-        )
+        assert any(isinstance(x, dict) and x.get("suggested_action") == "defer" for x in raw)
 
 
 def test_policy_flag_review_runs_recall_and_ai_review_suggests_create() -> None:
@@ -407,9 +410,7 @@ def test_policy_first_name_only_defers_with_defer_suggestion() -> None:
         session.refresh(person)
         raw = person.canonical_review_reasons_json
         assert isinstance(raw, list)
-        assert any(
-            isinstance(x, dict) and x.get("suggested_action") == "defer" for x in raw
-        )
+        assert any(isinstance(x, dict) and x.get("suggested_action") == "defer" for x in raw)
 
 
 def test_policy_and_apply_child_auto_waive() -> None:
@@ -475,9 +476,7 @@ def test_child_ai_review_recommends_defer() -> None:
         session.refresh(person)
         raw = person.canonical_review_reasons_json
         assert isinstance(raw, list)
-        assert any(
-            isinstance(x, dict) and x.get("suggested_action") == "defer" for x in raw
-        )
+        assert any(isinstance(x, dict) and x.get("suggested_action") == "defer" for x in raw)
 
 
 def test_policy_flag_review_stays_pending_on_apply() -> None:

--- a/tests/entities/test_public_article_facets.py
+++ b/tests/entities/test_public_article_facets.py
@@ -13,6 +13,8 @@ from backfield_db import (
 from backfield_entities.public.article_facets import get_public_article_facets
 from sqlmodel import Session, SQLModel, create_engine
 
+from tests.project_helpers import project_ownership_fields
+
 
 def test_get_public_article_facets_returns_distinct_values() -> None:
     engine = create_engine("sqlite://", echo=False)
@@ -23,6 +25,7 @@ def test_get_public_article_facets_returns_distinct_values() -> None:
         session.commit()
         session.refresh(org)
         proj = BackfieldProject(
+            **project_ownership_fields(session, int(org.id)),
             name="News",
             slug="news",
             organization_id=int(org.id),  # type: ignore[arg-type]

--- a/tests/entities/test_public_article_geo_cell_detail.py
+++ b/tests/entities/test_public_article_geo_cell_detail.py
@@ -24,6 +24,8 @@ from backfield_entities.public.article_geo_cells import (
 from h3 import cell_to_parent, latlng_to_cell
 from sqlmodel import Session, SQLModel, create_engine
 
+from tests.project_helpers import project_ownership_fields
+
 CHICAGO_POINT = {"type": "Point", "coordinates": [-87.6298, 41.8781]}
 NEARBY_POINT = {"type": "Point", "coordinates": [-87.63, 41.8785]}
 
@@ -42,6 +44,7 @@ def _seed_project(session: Session) -> int:
     session.commit()
     session.refresh(org)
     proj = BackfieldProject(
+        **project_ownership_fields(session, int(org.id)),
         name="News",
         slug="news",
         organization_id=int(org.id),  # type: ignore[arg-type]

--- a/tests/entities/test_public_article_geo_cells.py
+++ b/tests/entities/test_public_article_geo_cells.py
@@ -23,6 +23,8 @@ from backfield_entities.public.article_geo_cells import (
 from backfield_entities.public.articles import ArticleMetaClause
 from sqlmodel import Session, SQLModel, create_engine
 
+from tests.project_helpers import project_ownership_fields
+
 CHICAGO_POINT = {"type": "Point", "coordinates": [-87.6298, 41.8781]}
 NEARBY_POINT = {"type": "Point", "coordinates": [-87.63, 41.8785]}
 
@@ -41,6 +43,7 @@ def _seed_project(session: Session) -> int:
     session.commit()
     session.refresh(org)
     proj = BackfieldProject(
+        **project_ownership_fields(session, int(org.id)),
         name="News",
         slug="news",
         organization_id=int(org.id),  # type: ignore[arg-type]

--- a/tests/entities/test_public_article_geo_cells_batch.py
+++ b/tests/entities/test_public_article_geo_cells_batch.py
@@ -27,6 +27,8 @@ from backfield_entities.public.article_geo_cells_batch import (
 from h3 import get_resolution
 from sqlmodel import Session, SQLModel, create_engine
 
+from tests.project_helpers import project_ownership_fields
+
 CHICAGO_POINT = {"type": "Point", "coordinates": [-87.6298, 41.8781]}
 NEARBY_POINT = {"type": "Point", "coordinates": [-87.63, 41.8785]}
 
@@ -45,6 +47,7 @@ def _seed_project(session: Session) -> int:
     session.commit()
     session.refresh(org)
     proj = BackfieldProject(
+        **project_ownership_fields(session, int(org.id)),
         name="News",
         slug="news",
         organization_id=int(org.id),  # type: ignore[arg-type]

--- a/tests/entities/test_public_article_geo_search.py
+++ b/tests/entities/test_public_article_geo_search.py
@@ -19,6 +19,8 @@ from backfield_entities.public.article_geo_search import (
 )
 from sqlmodel import Session, SQLModel, create_engine, select
 
+from tests.project_helpers import project_ownership_fields
+
 
 def _seed_geo_articles(session: Session) -> int:
     org = BackfieldOrganization(name="Org", slug="org-public-geo-articles")
@@ -26,6 +28,7 @@ def _seed_geo_articles(session: Session) -> int:
     session.commit()
     session.refresh(org)
     proj = BackfieldProject(
+        **project_ownership_fields(session, int(org.id)),
         name="News",
         slug="news",
         organization_id=int(org.id),  # type: ignore[arg-type]

--- a/tests/entities/test_public_article_hub.py
+++ b/tests/entities/test_public_article_hub.py
@@ -27,6 +27,8 @@ from backfield_entities.public.article_hub import (
 )
 from sqlmodel import Session, SQLModel, create_engine
 
+from tests.project_helpers import project_ownership_fields
+
 
 def _seed_stylebook(session: Session) -> tuple[int, int]:
     org = BackfieldOrganization(name="Org", slug="org-article-hub")
@@ -37,6 +39,7 @@ def _seed_stylebook(session: Session) -> tuple[int, int]:
 
     stylebook = ensure_default_stylebook_for_organization(session, int(org.id))  # type: ignore[arg-type]
     proj = BackfieldProject(
+        **project_ownership_fields(session, int(org.id)),
         name="News",
         slug="news",
         organization_id=int(org.id),  # type: ignore[arg-type]

--- a/tests/entities/test_public_article_keyword_search.py
+++ b/tests/entities/test_public_article_keyword_search.py
@@ -15,6 +15,8 @@ from backfield_entities.public.keyword_query import article_keyword_tsquery
 from sqlalchemy import func
 from sqlmodel import Session, SQLModel, create_engine, select
 
+from tests.project_helpers import project_ownership_fields
+
 POSTGRES_TEST_URL = os.getenv("TEST_POSTGRES_URL", "").strip()
 
 
@@ -24,6 +26,7 @@ def _seed_sqlite_project(session: Session) -> int:
     session.commit()
     session.refresh(org)
     proj = BackfieldProject(
+        **project_ownership_fields(session, int(org.id)),
         name="News",
         slug="news",
         organization_id=int(org.id),  # type: ignore[arg-type]
@@ -176,7 +179,5 @@ def test_postgres_exclude_search(postgres_engine) -> None:
 
 def test_postgres_websearch_to_tsquery_parses_phrase(postgres_engine) -> None:
     with Session(postgres_engine) as session:
-        parsed = session.exec(
-            select(func.websearch_to_tsquery("english", '"long debate"'))
-        ).one()
+        parsed = session.exec(select(func.websearch_to_tsquery("english", '"long debate"'))).one()
     assert parsed is not None

--- a/tests/entities/test_public_article_metadata.py
+++ b/tests/entities/test_public_article_metadata.py
@@ -17,6 +17,8 @@ from backfield_entities.public.article_metadata import (
 )
 from sqlmodel import Session, SQLModel, create_engine
 
+from tests.project_helpers import project_ownership_fields
+
 
 def _seed_article_with_metadata(session: Session) -> tuple[int, int]:
     org = BackfieldOrganization(name="Org", slug="org-public-metadata")
@@ -24,6 +26,7 @@ def _seed_article_with_metadata(session: Session) -> tuple[int, int]:
     session.commit()
     session.refresh(org)
     proj = BackfieldProject(
+        **project_ownership_fields(session, int(org.id)),
         name="News",
         slug="news",
         organization_id=int(org.id),  # type: ignore[arg-type]

--- a/tests/entities/test_public_article_processing.py
+++ b/tests/entities/test_public_article_processing.py
@@ -23,6 +23,8 @@ from backfield_entities.public.article_processing import list_public_article_pro
 from sqlalchemy.exc import OperationalError
 from sqlmodel import Session, SQLModel, create_engine, select
 
+from tests.project_helpers import project_ownership_fields
+
 
 def _seed_project(session: Session) -> tuple[int, int]:
     org = BackfieldOrganization(name="Backfield", slug="default")
@@ -40,6 +42,7 @@ def _seed_project(session: Session) -> tuple[int, int]:
     session.commit()
     session.refresh(ws)
     project = BackfieldProject(
+        **project_ownership_fields(session, int(org.id), workspace_id=int(ws.id)),
         name="General",
         slug="general",
         organization_id=int(org.id),
@@ -308,9 +311,7 @@ def test_list_public_article_processing_dedupes_pointer_and_scan_paths() -> None
             article_id=article_id,
         )
         meta_rows = [
-            row
-            for row in rows
-            if row.run_id == "run-meta" and row.processed_item_id == 42
+            row for row in rows if row.run_id == "run-meta" and row.processed_item_id == 42
         ]
         assert len(meta_rows) == 1
 

--- a/tests/entities/test_public_article_semantic_search.py
+++ b/tests/entities/test_public_article_semantic_search.py
@@ -17,6 +17,8 @@ from backfield_entities.public.article_semantic_search import (
 )
 from sqlmodel import Session, SQLModel, create_engine
 
+from tests.project_helpers import project_ownership_fields
+
 
 def _seed_project_with_embeddings(session: Session) -> tuple[int, str, str]:
     org = BackfieldOrganization(name="Org", slug="org-public-semantic-articles")
@@ -24,6 +26,7 @@ def _seed_project_with_embeddings(session: Session) -> tuple[int, str, str]:
     session.commit()
     session.refresh(org)
     proj = BackfieldProject(
+        **project_ownership_fields(session, int(org.id)),
         name="News",
         slug="news",
         organization_id=int(org.id),  # type: ignore[arg-type]

--- a/tests/entities/test_public_articles.py
+++ b/tests/entities/test_public_articles.py
@@ -21,6 +21,8 @@ from backfield_entities.public.articles import (
 )
 from sqlmodel import Session, SQLModel, create_engine
 
+from tests.project_helpers import project_ownership_fields
+
 
 def test_article_preview_truncates_long_text() -> None:
     long_text = "word " * 200
@@ -68,6 +70,7 @@ def test_search_public_articles_matches_body_text() -> None:
         session.commit()
         session.refresh(org)
         proj = BackfieldProject(
+            **project_ownership_fields(session, int(org.id)),
             name="News",
             slug="news",
             organization_id=int(org.id),  # type: ignore[arg-type]
@@ -114,6 +117,7 @@ def test_search_public_articles_filters_metadata_and_dates() -> None:
         session.commit()
         session.refresh(org)
         proj = BackfieldProject(
+            **project_ownership_fields(session, int(org.id)),
             name="News",
             slug="news",
             organization_id=int(org.id),  # type: ignore[arg-type]
@@ -197,6 +201,7 @@ def test_search_public_articles_excludes_metadata() -> None:
         session.commit()
         session.refresh(org)
         proj = BackfieldProject(
+            **project_ownership_fields(session, int(org.id)),
             name="News",
             slug="news",
             organization_id=int(org.id),  # type: ignore[arg-type]
@@ -274,6 +279,7 @@ def test_search_public_articles_filters_author_section_and_mentions() -> None:
         session.commit()
         session.refresh(org)
         proj = BackfieldProject(
+            **project_ownership_fields(session, int(org.id)),
             name="News",
             slug="news",
             organization_id=int(org.id),  # type: ignore[arg-type]
@@ -350,6 +356,7 @@ def test_search_public_articles_meta_clauses() -> None:
         session.commit()
         session.refresh(org)
         proj = BackfieldProject(
+            **project_ownership_fields(session, int(org.id)),
             name="News",
             slug="news",
             organization_id=int(org.id),  # type: ignore[arg-type]
@@ -458,9 +465,7 @@ def test_search_public_articles_meta_clauses() -> None:
             params=PublicArticleSearchParams(
                 meta_type="format",
                 meta_category="news_story",
-                meta_clauses=(
-                    ArticleMetaClause(meta_type="topic", categories=("pro_sports",)),
-                ),
+                meta_clauses=(ArticleMetaClause(meta_type="topic", categories=("pro_sports",)),),
             ),
         )
         assert total == 2

--- a/tests/entities/test_public_locations.py
+++ b/tests/entities/test_public_locations.py
@@ -33,6 +33,8 @@ from backfield_entities.public.mention_filters import PublicEntityMentionListPar
 from backfield_entities.public.stylebook_scope import list_public_location_type_values
 from sqlmodel import Session, SQLModel, create_engine, select
 
+from tests.project_helpers import project_ownership_fields
+
 
 def _seed_locations(session: Session) -> tuple[int, int, str]:
     org = BackfieldOrganization(name="Org", slug="org-public-locations")
@@ -42,7 +44,9 @@ def _seed_locations(session: Session) -> tuple[int, int, str]:
     oid = int(org.id)  # type: ignore[arg-type]
     stylebook = ensure_default_stylebook_for_organization(session, oid)
     stylebook_id = int(stylebook.id)  # type: ignore[arg-type]
-    proj = BackfieldProject(name="News", slug="news", organization_id=oid)
+    proj = BackfieldProject(
+        **project_ownership_fields(session, oid), name="News", slug="news", organization_id=oid
+    )
     session.add(proj)
     session.commit()
     session.refresh(proj)

--- a/tests/entities/test_public_mention_timeline.py
+++ b/tests/entities/test_public_mention_timeline.py
@@ -20,6 +20,8 @@ from backfield_entities.public.mention_timeline import (
 )
 from sqlmodel import Session, SQLModel, create_engine, select
 
+from tests.project_helpers import project_ownership_fields
+
 
 def _seed_person_timeline(session: Session) -> tuple[int, int, str]:
     org = BackfieldOrganization(name="Org", slug="org-public-mention-timeline")
@@ -29,7 +31,9 @@ def _seed_person_timeline(session: Session) -> tuple[int, int, str]:
     oid = int(org.id)  # type: ignore[arg-type]
     stylebook = ensure_default_stylebook_for_organization(session, oid)
     stylebook_id = int(stylebook.id)  # type: ignore[arg-type]
-    proj = BackfieldProject(name="News", slug="news", organization_id=oid)
+    proj = BackfieldProject(
+        **project_ownership_fields(session, oid), name="News", slug="news", organization_id=oid
+    )
     session.add(proj)
     session.commit()
     session.refresh(proj)
@@ -162,7 +166,9 @@ def test_list_public_location_mention_timeline_filters_by_quote() -> None:
         oid = int(org.id)  # type: ignore[arg-type]
         stylebook = ensure_default_stylebook_for_organization(session, oid)
         stylebook_id = int(stylebook.id)  # type: ignore[arg-type]
-        proj = BackfieldProject(name="News", slug="news", organization_id=oid)
+        proj = BackfieldProject(
+            **project_ownership_fields(session, oid), name="News", slug="news", organization_id=oid
+        )
         session.add(proj)
         session.commit()
         session.refresh(proj)

--- a/tests/entities/test_public_mentions.py
+++ b/tests/entities/test_public_mentions.py
@@ -31,6 +31,8 @@ from backfield_entities.public.mentions import (
 )
 from sqlmodel import Session, SQLModel, create_engine
 
+from tests.project_helpers import project_ownership_fields
+
 
 def _seed_mentions(session: Session) -> tuple[int, int, int, int, int]:
     org = BackfieldOrganization(name="Org", slug="org-public-mentions")
@@ -40,7 +42,9 @@ def _seed_mentions(session: Session) -> tuple[int, int, int, int, int]:
     oid = int(org.id)  # type: ignore[arg-type]
     stylebook = ensure_default_stylebook_for_organization(session, oid)
     stylebook_id = int(stylebook.id)  # type: ignore[arg-type]
-    proj = BackfieldProject(name="News", slug="news", organization_id=oid)
+    proj = BackfieldProject(
+        **project_ownership_fields(session, oid), name="News", slug="news", organization_id=oid
+    )
     session.add(proj)
     session.commit()
     session.refresh(proj)
@@ -60,7 +64,7 @@ def _seed_mentions(session: Session) -> tuple[int, int, int, int, int]:
     session.add(
         SubstrateArticleMeta(
             article_id=article_id,
-                meta_type="topic",
+            meta_type="topic",
             category="local_government_politics",
             rationale="test",
             confidence=0.9,

--- a/tests/entities/test_public_organizations.py
+++ b/tests/entities/test_public_organizations.py
@@ -26,6 +26,8 @@ from backfield_entities.public.organizations import (
 from backfield_entities.public.stylebook_scope import list_public_organization_type_values
 from sqlmodel import Session, SQLModel, create_engine
 
+from tests.project_helpers import project_ownership_fields
+
 
 def _seed_organizations(session: Session) -> tuple[int, int, str]:
     org = BackfieldOrganization(name="Org", slug="org-public-orgs")
@@ -35,7 +37,9 @@ def _seed_organizations(session: Session) -> tuple[int, int, str]:
     oid = int(org.id)  # type: ignore[arg-type]
     stylebook = ensure_default_stylebook_for_organization(session, oid)
     stylebook_id = int(stylebook.id)  # type: ignore[arg-type]
-    proj = BackfieldProject(name="News", slug="news", organization_id=oid)
+    proj = BackfieldProject(
+        **project_ownership_fields(session, oid), name="News", slug="news", organization_id=oid
+    )
     session.add(proj)
     session.commit()
     session.refresh(proj)

--- a/tests/entities/test_public_people.py
+++ b/tests/entities/test_public_people.py
@@ -27,6 +27,8 @@ from backfield_entities.public.people import (
 from backfield_entities.public.stylebook_scope import list_public_person_type_values
 from sqlmodel import Session, SQLModel, create_engine, select
 
+from tests.project_helpers import project_ownership_fields
+
 
 def _seed_people(session: Session) -> tuple[int, int, str]:
     org = BackfieldOrganization(name="Org", slug="org-public-people")
@@ -36,7 +38,9 @@ def _seed_people(session: Session) -> tuple[int, int, str]:
     oid = int(org.id)  # type: ignore[arg-type]
     stylebook = ensure_default_stylebook_for_organization(session, oid)
     stylebook_id = int(stylebook.id)  # type: ignore[arg-type]
-    proj = BackfieldProject(name="News", slug="news", organization_id=oid)
+    proj = BackfieldProject(
+        **project_ownership_fields(session, oid), name="News", slug="news", organization_id=oid
+    )
     session.add(proj)
     session.commit()
     session.refresh(proj)
@@ -254,9 +258,7 @@ def test_list_public_person_articles_filters_by_pub_date() -> None:
         session.commit()
         session.refresh(older)
         person = session.exec(
-            select(SubstratePerson).where(
-                SubstratePerson.stylebook_person_canonical_id == mayor_id
-            )
+            select(SubstratePerson).where(SubstratePerson.stylebook_person_canonical_id == mayor_id)
         ).one()
         session.add(
             SubstratePersonMention(

--- a/tests/entities/test_public_project_stats.py
+++ b/tests/entities/test_public_project_stats.py
@@ -30,6 +30,8 @@ from backfield_db.semantic_indexing import (
 from backfield_entities.public.project_stats import get_public_project_summary_stats
 from sqlmodel import Session, SQLModel, create_engine
 
+from tests.project_helpers import project_ownership_fields
+
 
 def _seed_project(session: Session) -> int:
     org = BackfieldOrganization(name="Org", slug="org-project-stats")
@@ -37,6 +39,7 @@ def _seed_project(session: Session) -> int:
     session.commit()
     session.refresh(org)
     proj = BackfieldProject(
+        **project_ownership_fields(session, int(org.id)),
         name="News",
         slug="news",
         organization_id=int(org.id),  # type: ignore[arg-type]

--- a/tests/entities/test_quality_finders.py
+++ b/tests/entities/test_quality_finders.py
@@ -25,6 +25,8 @@ from backfield_entities.quality.finders.location_geography_issues import (
 )
 from sqlmodel import Session, SQLModel, create_engine
 
+from tests.project_helpers import project_ownership_fields
+
 
 def _make_stylebook(session: Session) -> tuple[int, int]:
     org = BackfieldOrganization(name="Test Org", slug="test-org")
@@ -194,7 +196,12 @@ def test_location_geography_issues_distant_linked_places_sqlite() -> None:
         stylebook_id, org_id = _make_stylebook(session)
         org = session.get(BackfieldOrganization, org_id)
         assert org is not None
-        project = BackfieldProject(organization_id=org_id, name="Demo", slug="demo")
+        project = BackfieldProject(
+            **project_ownership_fields(session, org_id),
+            organization_id=org_id,
+            name="Demo",
+            slug="demo",
+        )
         session.add(project)
         session.commit()
         session.refresh(project)
@@ -856,7 +863,12 @@ def test_person_name_mismatch_finder_sqlite() -> None:
     SQLModel.metadata.create_all(engine)
     with Session(engine) as session:
         stylebook_id, org_id = _make_stylebook(session)
-        project = BackfieldProject(organization_id=org_id, name="Demo", slug="demo")
+        project = BackfieldProject(
+            **project_ownership_fields(session, org_id),
+            organization_id=org_id,
+            name="Demo",
+            slug="demo",
+        )
         session.add(project)
         session.commit()
         session.refresh(project)
@@ -936,7 +948,12 @@ def test_organization_name_mismatch_finder_sqlite() -> None:
     SQLModel.metadata.create_all(engine)
     with Session(engine) as session:
         stylebook_id, org_id = _make_stylebook(session)
-        project = BackfieldProject(organization_id=org_id, name="Demo", slug="demo")
+        project = BackfieldProject(
+            **project_ownership_fields(session, org_id),
+            organization_id=org_id,
+            name="Demo",
+            slug="demo",
+        )
         session.add(project)
         session.commit()
         session.refresh(project)
@@ -995,7 +1012,12 @@ def test_location_name_mismatch_finder_sqlite() -> None:
     SQLModel.metadata.create_all(engine)
     with Session(engine) as session:
         stylebook_id, org_id = _make_stylebook(session)
-        project = BackfieldProject(organization_id=org_id, name="Demo", slug="demo")
+        project = BackfieldProject(
+            **project_ownership_fields(session, org_id),
+            organization_id=org_id,
+            name="Demo",
+            slug="demo",
+        )
         session.add(project)
         session.commit()
         session.refresh(project)

--- a/tests/entities/test_resolve_effective_stylebook.py
+++ b/tests/entities/test_resolve_effective_stylebook.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import pytest
 from backfield_db import (
     BackfieldOrganization,
     BackfieldProject,
@@ -22,7 +23,7 @@ def _engine():
     return engine
 
 
-def test_effective_uses_workspace_stylebook_when_project_is_unpinned() -> None:
+def test_effective_requires_direct_project_stylebook() -> None:
     engine = _engine()
     with Session(engine) as session:
         org = BackfieldOrganization(slug="org-eff", name="Org Eff")
@@ -47,6 +48,7 @@ def test_effective_uses_workspace_stylebook_when_project_is_unpinned() -> None:
         proj = BackfieldProject(
             organization_id=int(org.id),
             workspace_id=int(ws.id),
+            stylebook_id=int(sb_a.id),
             name="Proj",
             slug="proj-eff",
         )
@@ -104,7 +106,7 @@ def test_effective_project_stylebook_wins_after_workspace_default_changes() -> N
         assert resolve_stylebook_id_for_project_id(session, int(project.id)) == int(pinned.id)
 
 
-def test_effective_override_by_slug_same_org() -> None:
+def test_conflicting_slug_override_is_rejected() -> None:
     engine = _engine()
     with Session(engine) as session:
         org = BackfieldOrganization(slug="org-eff2", name="Org Eff2")
@@ -129,14 +131,15 @@ def test_effective_override_by_slug_same_org() -> None:
         proj = BackfieldProject(
             organization_id=int(org.id),
             workspace_id=int(ws.id),
+            stylebook_id=int(sb_b.id),
             name="Proj",
             slug="proj-eff2",
         )
         session.add(proj)
         session.commit()
 
-        got = resolve_effective_stylebook_id_for_project(session, proj, stylebook_slug="alpha")
-        assert got == int(sb_a.id)
+        with pytest.raises(ValueError, match="STYLEBOOK_OVERRIDE_CONFLICT"):
+            resolve_effective_stylebook_id_for_project(session, proj, stylebook_slug="alpha")
 
 
 def test_unknown_slug_raises() -> None:
@@ -162,6 +165,7 @@ def test_unknown_slug_raises() -> None:
         proj = BackfieldProject(
             organization_id=int(org.id),
             workspace_id=int(ws.id),
+            stylebook_id=int(sb.id),
             name="Proj",
             slug="proj-eff3",
         )
@@ -176,7 +180,7 @@ def test_unknown_slug_raises() -> None:
             raise AssertionError("expected LookupError")
 
 
-def test_catalog_id_override_wins_workspace_default() -> None:
+def test_conflicting_catalog_id_override_is_rejected() -> None:
     engine = _engine()
     with Session(engine) as session:
         org = BackfieldOrganization(slug="org-cat", name="Org Cat")
@@ -201,22 +205,22 @@ def test_catalog_id_override_wins_workspace_default() -> None:
         proj = BackfieldProject(
             organization_id=int(org.id),
             workspace_id=int(ws.id),
+            stylebook_id=int(sb_b.id),
             name="Proj",
             slug="proj-cat",
         )
         session.add(proj)
         session.commit()
 
-        got = resolve_effective_stylebook_id_for_project(
-            session,
-            proj,
-            catalog_stylebook_id=int(sb_a.id),
-        )
-        assert got == int(sb_a.id)
+        with pytest.raises(ValueError, match="STYLEBOOK_OVERRIDE_CONFLICT"):
+            resolve_effective_stylebook_id_for_project(
+                session,
+                proj,
+                catalog_stylebook_id=int(sb_a.id),
+            )
 
 
-def test_catalog_id_override_wins_slug() -> None:
-    """Explicit integer catalog wins over ``stylebook_slug`` when both are set."""
+def test_matching_catalog_id_and_conflicting_slug_is_rejected() -> None:
     engine = _engine()
     with Session(engine) as session:
         org = BackfieldOrganization(slug="org-both", name="Org Both")
@@ -241,19 +245,20 @@ def test_catalog_id_override_wins_slug() -> None:
         proj = BackfieldProject(
             organization_id=int(org.id),
             workspace_id=int(ws.id),
+            stylebook_id=int(sb_a.id),
             name="Proj",
             slug="proj-both",
         )
         session.add(proj)
         session.commit()
 
-        got = resolve_effective_stylebook_id_for_project(
-            session,
-            proj,
-            stylebook_slug="beta",
-            catalog_stylebook_id=int(sb_a.id),
-        )
-        assert got == int(sb_a.id)
+        with pytest.raises(ValueError, match="STYLEBOOK_OVERRIDE_CONFLICT"):
+            resolve_effective_stylebook_id_for_project(
+                session,
+                proj,
+                stylebook_slug="beta",
+                catalog_stylebook_id=int(sb_a.id),
+            )
 
 
 def test_catalog_id_wrong_organization_raises() -> None:
@@ -293,6 +298,7 @@ def test_catalog_id_wrong_organization_raises() -> None:
         proj = BackfieldProject(
             organization_id=int(org1.id),
             workspace_id=int(ws.id),
+            stylebook_id=int(sb_home.id),
             name="Proj",
             slug="proj-both-o",
         )

--- a/tests/entities/test_semantic_document_sync.py
+++ b/tests/entities/test_semantic_document_sync.py
@@ -30,6 +30,8 @@ from backfield_entities.ingest.semantic_indexing import (
 )
 from sqlmodel import Session, SQLModel, create_engine, select
 
+from tests.project_helpers import project_ownership_fields
+
 
 def _engine():
     engine = create_engine("sqlite://", echo=False)
@@ -43,7 +45,12 @@ def _seed_project(session: Session) -> tuple[int, int]:
     session.commit()
     session.refresh(org)
     oid = int(org.id)  # type: ignore[arg-type]
-    proj = BackfieldProject(name="Demo", slug="demo-semantic", organization_id=oid)
+    proj = BackfieldProject(
+        **project_ownership_fields(session, oid),
+        name="Demo",
+        slug="demo-semantic",
+        organization_id=oid,
+    )
     session.add(proj)
     session.commit()
     session.refresh(proj)

--- a/tests/entities/test_semantic_embedding.py
+++ b/tests/entities/test_semantic_embedding.py
@@ -28,6 +28,8 @@ from backfield_entities.ingest.semantic_indexing.embedding_contract import (
 )
 from sqlmodel import Session, SQLModel, create_engine, select
 
+from tests.project_helpers import project_ownership_fields
+
 
 def _engine():
     engine = create_engine("sqlite://", echo=False)
@@ -41,6 +43,7 @@ def _seed_person_semantic_doc(session: Session) -> tuple[int, int, PendingSemant
     session.commit()
     session.refresh(org)
     proj = BackfieldProject(
+        **project_ownership_fields(session, int(org.id)),
         name="Demo",
         slug="demo-embed",
         organization_id=int(org.id),  # type: ignore[arg-type]

--- a/tests/entities/test_semantic_indexing_cleanup.py
+++ b/tests/entities/test_semantic_indexing_cleanup.py
@@ -15,6 +15,8 @@ from backfield_db.semantic_indexing import SEMANTIC_EMBEDDING_STATUS_PENDING
 from backfield_entities.ingest.semantic_indexing.cleanup import delete_semantic_documents_for_person
 from sqlmodel import Session, SQLModel, create_engine, select
 
+from tests.project_helpers import project_ownership_fields
+
 
 def test_delete_semantic_documents_for_person_allows_substrate_delete() -> None:
     engine = create_engine("sqlite://", connect_args={"check_same_thread": False})
@@ -25,7 +27,12 @@ def test_delete_semantic_documents_for_person_allows_substrate_delete() -> None:
         session.add(org)
         session.commit()
         session.refresh(org)
-        proj = BackfieldProject(organization_id=int(org.id), name="P", slug="p-sem-clean")
+        proj = BackfieldProject(
+            **project_ownership_fields(session, int(org.id)),
+            organization_id=int(org.id),
+            name="P",
+            slug="p-sem-clean",
+        )
         session.add(proj)
         session.commit()
         session.refresh(proj)

--- a/tests/entities/test_semantic_indexing_processed_item_summary.py
+++ b/tests/entities/test_semantic_indexing_processed_item_summary.py
@@ -21,6 +21,8 @@ from backfield_entities.ingest.semantic_indexing.processed_item import (
 from sqlalchemy import create_engine
 from sqlmodel import Session, SQLModel, select
 
+from tests.project_helpers import project_ownership_fields
+
 
 def _seed_project(session: Session) -> tuple[int, int]:
     session.add(BackfieldOrganization(name="Org", slug="org-pi-sem"))
@@ -29,7 +31,14 @@ def _seed_project(session: Session) -> tuple[int, int]:
         select(BackfieldOrganization).where(BackfieldOrganization.slug == "org-pi-sem")
     ).one()
     oid = int(org.id)
-    session.add(BackfieldProject(organization_id=oid, name="Proj", slug=f"proj-pi-sem-{oid}"))
+    session.add(
+        BackfieldProject(
+            **project_ownership_fields(session, oid),
+            organization_id=oid,
+            name="Proj",
+            slug=f"proj-pi-sem-{oid}",
+        )
+    )
     session.commit()
     proj = session.exec(
         select(BackfieldProject).where(BackfieldProject.slug == f"proj-pi-sem-{oid}")

--- a/tests/entities/test_semantic_mention_search_fixtures.py
+++ b/tests/entities/test_semantic_mention_search_fixtures.py
@@ -20,6 +20,8 @@ from backfield_db.semantic_indexing import (
 from sqlalchemy import text
 from sqlmodel import Session, select
 
+from tests.project_helpers import project_ownership_fields
+
 
 def set_person_semantic_doc_embedding(
     session: Session,
@@ -55,7 +57,12 @@ def seed_person_semantic_search_rows(
             select(BackfieldOrganization).where(BackfieldOrganization.slug == "org-sem-search")
         ).one()
         session.add(
-            BackfieldProject(organization_id=int(org.id), name="Proj", slug="proj-sem-search")
+            BackfieldProject(
+                **project_ownership_fields(session, int(org.id)),
+                organization_id=int(org.id),
+                name="Proj",
+                slug="proj-sem-search",
+            )
         )
         session.commit()
         proj = session.exec(

--- a/tests/entities/test_stylebook_library.py
+++ b/tests/entities/test_stylebook_library.py
@@ -36,6 +36,8 @@ from sqlalchemy import event
 from sqlalchemy.engine import Engine
 from sqlmodel import Session, SQLModel, create_engine, select
 
+from tests.project_helpers import project_ownership_fields
+
 
 def _engine():
     engine = create_engine("sqlite://", echo=False)
@@ -182,10 +184,11 @@ def test_delete_reassigns_graph_node_stylebook_refs() -> None:
         bid = int(b.id)  # type: ignore[arg-type]
 
         proj = BackfieldProject(
+            **project_ownership_fields(session, oid, stylebook_id=aid),
             organization_id=oid,
+            stylebook_id=aid,
             name="P",
             slug="p-graph",
-            workspace_id=None,
         )
         session.add(proj)
         session.commit()
@@ -335,7 +338,9 @@ def test_delete_stylebook_resets_linked_substrate_to_pending() -> None:
                 status="active",
             )
         )
-        proj = BackfieldProject(organization_id=oid, name="P", slug="p-sub")
+        proj = BackfieldProject(
+            **project_ownership_fields(session, oid), organization_id=oid, name="P", slug="p-sub"
+        )
         session.add(proj)
         session.commit()
         session.refresh(proj)

--- a/tests/project_helpers.py
+++ b/tests/project_helpers.py
@@ -1,0 +1,76 @@
+"""Explicit helpers for test projects under strict tenancy metadata."""
+
+from __future__ import annotations
+
+from typing import Final
+
+from backfield_db import BackfieldWorkspace, Stylebook
+from sqlmodel import Session, col, select
+
+_UNSET: Final = object()
+
+
+def project_ownership_fields(
+    session: Session,
+    organization_id: int,
+    *,
+    workspace_id: int | None | object = _UNSET,
+    stylebook_id: int | None | object = _UNSET,
+) -> dict[str, int]:
+    """Return only missing project ownership fields, creating valid test rows as needed."""
+    organization_id = int(organization_id)
+    workspace = None
+    if workspace_id is not _UNSET and workspace_id is not None:
+        workspace = session.get(BackfieldWorkspace, int(workspace_id))
+        if workspace is None or int(workspace.organization_id) != organization_id:
+            raise ValueError("test project workspace must belong to its organization")
+
+    stylebook = None
+    if stylebook_id is not _UNSET and stylebook_id is not None:
+        stylebook = session.get(Stylebook, int(stylebook_id))
+        if stylebook is None or int(stylebook.organization_id) != organization_id:
+            raise ValueError("test project Stylebook must belong to its organization")
+    elif workspace is not None:
+        stylebook = session.get(Stylebook, int(workspace.stylebook_id))
+
+    if stylebook is None:
+        stylebook = session.exec(
+            select(Stylebook)
+            .where(Stylebook.organization_id == organization_id)
+            .order_by(col(Stylebook.is_default).desc(), col(Stylebook.id).asc())
+        ).first()
+    if stylebook is None:
+        stylebook = Stylebook(
+            organization_id=organization_id,
+            name=f"Test Stylebook {organization_id}",
+            slug=f"test-stylebook-{organization_id}",
+            is_default=True,
+        )
+        session.add(stylebook)
+        session.flush()
+
+    if workspace is None:
+        workspace = session.exec(
+            select(BackfieldWorkspace)
+            .where(
+                BackfieldWorkspace.organization_id == organization_id,
+                BackfieldWorkspace.stylebook_id == int(stylebook.id),
+            )
+            .order_by(col(BackfieldWorkspace.id).asc())
+        ).first()
+    if workspace is None:
+        workspace = BackfieldWorkspace(
+            organization_id=organization_id,
+            stylebook_id=int(stylebook.id),
+            name=f"Test Workspace {organization_id}",
+            slug=f"test-workspace-{organization_id}-{int(stylebook.id)}",
+        )
+        session.add(workspace)
+        session.flush()
+
+    fields: dict[str, int] = {}
+    if workspace_id is _UNSET or workspace_id is None:
+        fields["workspace_id"] = int(workspace.id)
+    if stylebook_id is _UNSET or stylebook_id is None:
+        fields["stylebook_id"] = int(stylebook.id)
+    return fields

--- a/tests/smoke/smoke_s3_batch.py
+++ b/tests/smoke/smoke_s3_batch.py
@@ -23,6 +23,8 @@ from backfield_entities.catalog.bootstrap import ensure_default_stylebook_for_or
 from sqlmodel import Session, SQLModel, create_engine, select
 from worker import tasks as worker_tasks
 
+from tests.project_helpers import project_ownership_fields
+
 
 def _spec_with_s3() -> str:
     return json.dumps(
@@ -128,6 +130,7 @@ def main() -> int:
 
             ensure_default_stylebook_for_organization(session, int(org.id))
             project = BackfieldProject(
+                **project_ownership_fields(session, int(org.id)),
                 organization_id=int(org.id),
                 name="Smoke Project",
                 slug="smoke-proj",

--- a/tests/stylebook_api/test_mention_occurrence_persistence.py
+++ b/tests/stylebook_api/test_mention_occurrence_persistence.py
@@ -22,6 +22,8 @@ from stylebook_api.mention_occurrences import (
     replace_person_mention_occurrences_for_article,
 )
 
+from tests.project_helpers import project_ownership_fields
+
 
 def _bootstrap_project(session: Session) -> int:
     organization = BackfieldOrganization(name="Org", slug="org-occurrence-spans")
@@ -39,6 +41,7 @@ def _bootstrap_project(session: Session) -> int:
     session.commit()
     session.refresh(workspace)
     project = BackfieldProject(
+        **project_ownership_fields(session, int(organization.id), workspace_id=int(workspace.id)),
         organization_id=int(organization.id),
         workspace_id=int(workspace.id),
         name="Project",

--- a/tests/stylebook_api/test_organization_api.py
+++ b/tests/stylebook_api/test_organization_api.py
@@ -54,6 +54,31 @@ def _add_pending_organization(
     return int(organization.id)  # type: ignore[arg-type]
 
 
+def test_organization_candidate_writes_require_stylebook_editor(
+    member_client: TestClient,
+    stylebook_test_engine: Engine,
+) -> None:
+    with Session(stylebook_test_engine) as session:
+        project = session.exec(
+            select(BackfieldProject).where(BackfieldProject.slug == "demo-proj")
+        ).one()
+        organization_id = _add_pending_organization(
+            session,
+            project_id=int(project.id),
+            name="Candidate Organization",
+            normalized_name="candidate organization",
+        )
+
+    assert (
+        member_client.get("/v1/organizations/candidates?project_slug=demo-proj").status_code == 200
+    )
+    response = member_client.post(
+        f"/v1/organizations/candidates/{organization_id}/clear-recommendation"
+        "?project_slug=demo-proj"
+    )
+    assert response.status_code == 403
+
+
 def test_list_canonical_organizations_empty(editor_client: TestClient) -> None:
     r = editor_client.get(
         "/v1/stylebooks/default/canonical-organizations?limit=10&offset=0",
@@ -493,11 +518,7 @@ def test_import_csv_organizations_analyze_rejects_malformed(editor_client: TestC
 def test_import_csv_organizations_creates_canonicals(
     editor_client: TestClient, stylebook_test_engine: Engine
 ) -> None:
-    csv_data = (
-        "label,organization_type\n"
-        "City Hall,government\n"
-        "Acme Corp,company\n"
-    )
+    csv_data = "label,organization_type\nCity Hall,government\nAcme Corp,company\n"
     r = editor_client.post(
         "/v1/stylebooks/default/import/csv/organizations",
         json={

--- a/tests/stylebook_api/test_person_api.py
+++ b/tests/stylebook_api/test_person_api.py
@@ -67,8 +67,28 @@ def _add_pending_person(
     return int(person.id)  # type: ignore[arg-type]
 
 
-def test_list_canonical_people_empty(
-    editor_client: TestClient) -> None:
+def test_person_candidate_writes_require_stylebook_editor(
+    member_client: TestClient,
+    stylebook_test_engine: Engine,
+) -> None:
+    with Session(stylebook_test_engine) as session:
+        project = session.exec(
+            select(BackfieldProject).where(BackfieldProject.slug == "demo-proj")
+        ).one()
+        person_id = _add_pending_person(
+            session,
+            project_id=int(project.id),
+            name="Candidate Person",
+            normalized_name="candidate person",
+            fingerprint="candidate-person-permission",
+        )
+
+    assert member_client.get("/v1/people/candidates?project_slug=demo-proj").status_code == 200
+    response = member_client.post(f"/v1/people/candidates/{person_id}/defer?project_slug=demo-proj")
+    assert response.status_code == 403
+
+
+def test_list_canonical_people_empty(editor_client: TestClient) -> None:
     r = editor_client.get(
         "/v1/stylebooks/default/canonical-people?limit=10&offset=0",
     )

--- a/tests/stylebook_api/test_stylebook_api.py
+++ b/tests/stylebook_api/test_stylebook_api.py
@@ -9,6 +9,7 @@ import pytest
 from backfield_db import (
     BackfieldOrganization,
     BackfieldProject,
+    BackfieldProjectMembership,
     BackfieldUser,
     BackfieldWorkspace,
     Stylebook,
@@ -98,6 +99,7 @@ def _stylebook_test_stack(
                 name="Demo",
                 slug="demo-proj",
                 workspace_id=wid,
+                stylebook_id=sb_id,
             )
         )
         s.add(
@@ -105,7 +107,8 @@ def _stylebook_test_stack(
                 organization_id=oid,
                 name="No workspace",
                 slug="no-ws-proj",
-                workspace_id=None,
+                workspace_id=wid,
+                stylebook_id=sb_id,
             )
         )
         s.commit()
@@ -147,6 +150,35 @@ def _session_auth_for_user(user: BackfieldUser, *, org_id: int, org_role: str) -
     }
 
 
+def test_location_candidate_reads_need_project_access_but_writes_need_editor(
+    member_client: TestClient,
+    stylebook_test_engine: Engine,
+) -> None:
+    with Session(stylebook_test_engine) as session:
+        project = session.exec(
+            select(BackfieldProject).where(BackfieldProject.slug == "demo-proj")
+        ).one()
+        location = SubstrateLocation(
+            project_id=int(project.id),
+            name="Candidate",
+            normalized_name="candidate",
+            canonical_link_status=CANONICAL_LINK_PENDING,
+        )
+        session.add(location)
+        session.commit()
+        session.refresh(location)
+        location_id = int(location.id)
+
+    read = member_client.get("/v1/candidates?project_slug=demo-proj")
+    write = member_client.post(
+        f"/v1/candidates/{location_id}/note?project_slug=demo-proj",
+        json={"note": "reviewed"},
+    )
+
+    assert read.status_code == 200
+    assert write.status_code == 403
+
+
 @pytest.fixture
 def member_client(
     _stylebook_test_stack: tuple[TestClient, Engine],
@@ -156,6 +188,15 @@ def member_client(
     with Session(engine) as s:
         user = BackfieldUser(email="member@example.com", password_hash="x")
         s.add(user)
+        s.flush()
+        project = s.exec(select(BackfieldProject).where(BackfieldProject.slug == "demo-proj")).one()
+        s.add(
+            BackfieldProjectMembership(
+                user_id=int(user.id),
+                project_id=int(project.id),
+                role="member",
+            )
+        )
         s.commit()
 
     def _get_auth_override() -> dict[str, Any]:
@@ -656,8 +697,7 @@ def test_create_location_creates_standalone_canonical_and_alias_no_substrate(
         assert "west garfield park chicago il" in norms
 
 
-def test_list_canonical_locations_type_filter(
-    editor_client: TestClient) -> None:
+def test_list_canonical_locations_type_filter(editor_client: TestClient) -> None:
     r_city = editor_client.post(
         "/v1/stylebooks/default/canonical-locations",
         json={"label": "Filter City Row", "location_type": "city"},
@@ -690,11 +730,12 @@ def test_list_canonical_locations_type_filter(
 
 
 def test_list_canonical_locations_orders_by_label_case_insensitive(
-    editor_client: TestClient) -> None:
+    editor_client: TestClient,
+) -> None:
     for label in ("Zebra", "alpha", "Mike"):
         r = editor_client.post(
             "/v1/stylebooks/default/canonical-locations",
-                json={"label": label},
+            json={"label": label},
         )
         assert r.status_code == 200
     r = editor_client.get(
@@ -719,7 +760,7 @@ def test_list_canonical_locations_search_prefers_exact_then_prefix_then_contains
     for lb in (a, b, c):
         r = editor_client.post(
             "/v1/stylebooks/default/canonical-locations",
-                json={"label": lb},
+            json={"label": lb},
         )
         assert r.status_code == 200
 
@@ -740,7 +781,7 @@ def test_list_canonical_locations_search_prefers_exact_then_prefix_then_contains
     for lb in (a2, b2, c2):
         r = editor_client.post(
             "/v1/stylebooks/default/canonical-locations",
-                json={"label": lb},
+            json={"label": lb},
         )
         assert r.status_code == 200
 
@@ -755,8 +796,7 @@ def test_list_canonical_locations_search_prefers_exact_then_prefix_then_contains
     assert labels2.index(b2) < labels2.index(c2)
 
 
-def test_list_canonical_locations_returns_catalog_not_substrate(
-    editor_client: TestClient) -> None:
+def test_list_canonical_locations_returns_catalog_not_substrate(editor_client: TestClient) -> None:
     r = editor_client.post(
         "/v1/stylebooks/default/canonical-locations",
         json={"label": "Catalog Test Place", "location_type": "city"},
@@ -1496,9 +1536,7 @@ def test_create_person_from_article_evidence(
         assert occurrence.end_char == end
 
 
-def test_candidates_needs_review_facet(
-    client: TestClient, stylebook_test_engine: object
-) -> None:
+def test_candidates_needs_review_facet(client: TestClient, stylebook_test_engine: object) -> None:
     engine = stylebook_test_engine
     with Session(engine) as s:
         proj = s.exec(select(BackfieldProject).where(BackfieldProject.slug == "demo-proj")).one()
@@ -1557,9 +1595,7 @@ def test_candidates_needs_review_facet(
     assert r_open.json()["total"] == 1
 
 
-def test_accept_candidate_create_new(
-    client: TestClient, stylebook_test_engine: Engine
-) -> None:
+def test_accept_candidate_create_new(client: TestClient, stylebook_test_engine: Engine) -> None:
     engine = stylebook_test_engine
     with Session(engine) as s:
         proj = s.exec(select(BackfieldProject).where(BackfieldProject.slug == "demo-proj")).one()
@@ -2190,10 +2226,9 @@ def test_delete_location_article_scoped_keeps_link_when_other_stories_mention(
         assert int(active[0].article_id) == aid_b
 
 
-def test_delete_location_article_scoped_unlinks_when_canonical_in_non_default_stylebook(
+def test_project_scoped_delete_rejects_conflicting_stylebook_override(
     client: TestClient, stylebook_test_engine: Engine
 ) -> None:
-    """Delete must unlink using the canonical's stylebook, not only the project default."""
     engine = stylebook_test_engine
     with Session(engine) as s:
         org = s.exec(
@@ -2263,16 +2298,14 @@ def test_delete_location_article_scoped_unlinks_when_canonical_in_non_default_st
         s.commit()
 
     r_del = client.delete(
-        f"/v1/locations/{sid}?project_slug=demo-proj"
-        f"&article_id={aid}&stylebook_slug=regional",
+        f"/v1/locations/{sid}?project_slug=demo-proj&article_id={aid}&stylebook_slug=regional",
         headers=_service_headers(),
     )
-    assert r_del.status_code == 200, r_del.text
-    assert r_del.json()["location_deleted"] is True
-    assert r_del.json()["candidates_created"] == 0
+    assert r_del.status_code == 400, r_del.text
+    assert "does not match project assignment" in r_del.json()["detail"]
 
     with Session(engine) as s:
-        assert s.get(SubstrateLocation, sid) is None
+        assert s.get(SubstrateLocation, sid) is not None
 
 
 def test_delete_location_without_article_id_requeues_linked_substrate(
@@ -2575,9 +2608,7 @@ def test_post_link_canonical_idempotent_same_target(
     assert r2.json()["changed"] is False
 
 
-def test_get_canonical_linked_substrates(
-    client: TestClient, stylebook_test_engine: Engine
-) -> None:
+def test_get_canonical_linked_substrates(client: TestClient, stylebook_test_engine: Engine) -> None:
     engine = stylebook_test_engine
     with Session(engine) as s:
         proj = s.exec(select(BackfieldProject).where(BackfieldProject.slug == "demo-proj")).one()
@@ -2714,9 +2745,7 @@ def test_stylebook_canonical_linked_substrates_include_project_fields(
 
     app.dependency_overrides[get_auth_dep] = _get_auth_override
     try:
-        r_all = client.get(
-            f"/v1/stylebooks/default/canonical-locations/{cid}/linked-substrates"
-        )
+        r_all = client.get(f"/v1/stylebooks/default/canonical-locations/{cid}/linked-substrates")
         assert r_all.status_code == 200
         all_rows = r_all.json()["substrates"]
         assert [row["project_slug"] for row in all_rows] == ["demo-proj", "no-ws-proj"]
@@ -2724,8 +2753,7 @@ def test_stylebook_canonical_linked_substrates_include_project_fields(
         assert [row["project_id"] for row in all_rows] == [demo_proj_id, other_proj_id]
 
         r_filtered = client.get(
-            f"/v1/stylebooks/default/canonical-locations/{cid}/linked-substrates"
-            "?project=demo-proj"
+            f"/v1/stylebooks/default/canonical-locations/{cid}/linked-substrates?project=demo-proj"
         )
         assert r_filtered.status_code == 200
         filtered_rows = r_filtered.json()["substrates"]
@@ -2831,15 +2859,11 @@ def test_stylebook_canonical_location_meta_crud(
     assert r3.json()["meta_type"] == "note"
     assert r3.json()["data"] == {"shared": "everywhere"}
 
-    r4 = editor_client.delete(
-        f"/v1/stylebooks/default/canonical-locations/{cid}/meta/{mid}"
-    )
+    r4 = editor_client.delete(f"/v1/stylebooks/default/canonical-locations/{cid}/meta/{mid}")
     assert r4.status_code == 200
 
     with Session(engine) as s:
-        row = s.exec(
-            select(StylebookLocationMeta).where(StylebookLocationMeta.id == mid)
-        ).first()
+        row = s.exec(select(StylebookLocationMeta).where(StylebookLocationMeta.id == mid)).first()
         assert row is None
 
 
@@ -2873,9 +2897,7 @@ def test_stylebook_canonical_location_connections_roundtrip(
         aid = str(ca.id)
         bid = str(cb.id)
 
-    r0 = editor_client.get(
-        f"/v1/stylebooks/default/canonical-locations/{aid}/connections"
-    )
+    r0 = editor_client.get(f"/v1/stylebooks/default/canonical-locations/{aid}/connections")
     assert r0.status_code == 200
     assert r0.json()["connections"] == []
 
@@ -2889,9 +2911,7 @@ def test_stylebook_canonical_location_connections_roundtrip(
     assert body["nature"] == "near"
     assert body.get("evidence_json") is None
 
-    r2 = editor_client.get(
-        f"/v1/stylebooks/default/canonical-locations/{aid}/connections"
-    )
+    r2 = editor_client.get(f"/v1/stylebooks/default/canonical-locations/{aid}/connections")
     assert r2.status_code == 200
     assert len(r2.json()["connections"]) == 1
     assert r2.json()["connections"][0]["to_display_name"] == "Shared Conn B"
@@ -3030,9 +3050,7 @@ def test_stylebook_person_connection_crud(
     assert body["to_display_name"] == "Manual Conn Place"
     assert body.get("evidence_json") is None
 
-    list_res = editor_client.get(
-        f"/v1/stylebooks/default/canonical-people/{person_id}/connections"
-    )
+    list_res = editor_client.get(f"/v1/stylebooks/default/canonical-people/{person_id}/connections")
     assert list_res.status_code == 200
     assert len(list_res.json()["connections"]) == 1
 
@@ -3111,9 +3129,7 @@ def test_stylebook_connection_lists_auto_connection_evidence(
         )
         s.commit()
 
-    response = editor_client.get(
-        f"/v1/stylebooks/default/canonical-locations/{aid}/connections"
-    )
+    response = editor_client.get(f"/v1/stylebooks/default/canonical-locations/{aid}/connections")
     assert response.status_code == 200
     rows = response.json()["connections"]
     assert len(rows) == 1

--- a/tests/stylebook_api/test_stylebook_cleanup_api.py
+++ b/tests/stylebook_api/test_stylebook_cleanup_api.py
@@ -32,6 +32,8 @@ from stylebook_api.deps import get_auth as get_auth_dep
 from stylebook_api.deps import get_session
 from stylebook_api.main import app
 
+from tests.project_helpers import project_ownership_fields
+
 
 def _session_auth_for_user(user: BackfieldUser, *, org_id: int) -> dict[str, Any]:
     return {
@@ -403,9 +405,7 @@ def test_cancel_cleanup_check_run_no_active(
     cleanup_client: tuple[TestClient, Engine],
 ) -> None:
     client, _engine = cleanup_client
-    resp = client.post(
-        "/v1/stylebooks/default/cleanup/checks/duplicate-locations/runs/cancel"
-    )
+    resp = client.post("/v1/stylebooks/default/cleanup/checks/duplicate-locations/runs/cancel")
     assert resp.status_code == 400
     assert "No active check run" in resp.json()["detail"]
 
@@ -459,9 +459,7 @@ def test_delete_empty_cleanup_canonical(cleanup_client: tuple[TestClient, Engine
             )
         ).one()
         canonical_id = str(empty.id)
-    response = client.delete(
-        f"/v1/stylebooks/default/cleanup/canonical-locations/{canonical_id}"
-    )
+    response = client.delete(f"/v1/stylebooks/default/cleanup/canonical-locations/{canonical_id}")
     assert response.status_code == 200
     assert response.json()["id"] == canonical_id
     with Session(engine) as session:
@@ -478,6 +476,7 @@ def test_merge_cleanup_canonical_relinks_and_deletes_source(
         ).one()
         session.add(
             BackfieldProject(
+                **project_ownership_fields(session, int(org.id)),
                 organization_id=int(org.id),
                 name="Demo",
                 slug="demo-proj",
@@ -611,18 +610,14 @@ def test_dismiss_duplicate_person_cluster_after_member_deleted(
 def test_duplicate_organization_clusters(cleanup_client: tuple[TestClient, Engine]) -> None:
     client, _engine = cleanup_client
     _run_cleanup_check(client, "duplicate-organizations")
-    response = client.get(
-        "/v1/stylebooks/default/cleanup/checks/duplicate-organizations?limit=10"
-    )
+    response = client.get("/v1/stylebooks/default/cleanup/checks/duplicate-organizations?limit=10")
     assert response.status_code == 200
     body = response.json()
     assert body["total"] == 2
     # Exact matches sort first ("City Hall"); the cross-form cluster follows.
     assert body["clusters"][0]["label"] == "City Hall"
     assert len(body["clusters"][0]["canonicals"]) == 2
-    cross_form_labels = {
-        canonical["label"] for canonical in body["clusters"][1]["canonicals"]
-    }
+    cross_form_labels = {canonical["label"] for canonical in body["clusters"][1]["canonicals"]}
     assert cross_form_labels == {
         "Cook County State's Attorney's Office",
         "Office of the Cook County State's Attorney",
@@ -646,9 +641,7 @@ def test_dismiss_duplicate_organization_cluster(
 
     _run_cleanup_check(client, "duplicate-organizations")
 
-    before = client.get(
-        "/v1/stylebooks/default/cleanup/checks/duplicate-organizations?limit=10"
-    )
+    before = client.get("/v1/stylebooks/default/cleanup/checks/duplicate-organizations?limit=10")
     assert before.status_code == 200
     assert before.json()["total"] == 2
 
@@ -662,9 +655,7 @@ def test_dismiss_duplicate_organization_cluster(
     assert dismiss.status_code == 200
     assert dismiss.json()["dismissed_pair_count"] == 1
 
-    after = client.get(
-        "/v1/stylebooks/default/cleanup/checks/duplicate-organizations?limit=10"
-    )
+    after = client.get("/v1/stylebooks/default/cleanup/checks/duplicate-organizations?limit=10")
     assert after.status_code == 200
     assert after.json()["total"] == 1
     labels = {
@@ -690,6 +681,7 @@ def test_merge_cleanup_person_relinks_and_deletes_source(
         ).one()
         session.add(
             BackfieldProject(
+                **project_ownership_fields(session, int(org.id)),
                 organization_id=int(org.id),
                 name="Demo",
                 slug="demo-proj",
@@ -700,14 +692,10 @@ def test_merge_cleanup_person_relinks_and_deletes_source(
             select(BackfieldProject).where(BackfieldProject.slug == "demo-proj")
         ).one()
         source = session.exec(
-            select(StylebookPersonCanonical).where(
-                StylebookPersonCanonical.slug == "person-dupe-a"
-            )
+            select(StylebookPersonCanonical).where(StylebookPersonCanonical.slug == "person-dupe-a")
         ).one()
         target = session.exec(
-            select(StylebookPersonCanonical).where(
-                StylebookPersonCanonical.slug == "person-dupe-b"
-            )
+            select(StylebookPersonCanonical).where(StylebookPersonCanonical.slug == "person-dupe-b")
         ).one()
         session.add(
             SubstratePerson(
@@ -751,6 +739,7 @@ def test_merge_cleanup_organization_relinks_and_deletes_source(
         ).one()
         session.add(
             BackfieldProject(
+                **project_ownership_fields(session, int(org.id)),
                 organization_id=int(org.id),
                 name="Demo",
                 slug="demo-proj-org",
@@ -810,6 +799,7 @@ def test_distant_linked_geography_issue(cleanup_client: tuple[TestClient, Engine
         ).one()
         session.add(
             BackfieldProject(
+                **project_ownership_fields(session, int(org.id)),
                 organization_id=int(org.id),
                 name="Geo Demo",
                 slug="geo-demo",
@@ -820,9 +810,7 @@ def test_distant_linked_geography_issue(cleanup_client: tuple[TestClient, Engine
             select(BackfieldProject).where(BackfieldProject.slug == "geo-demo")
         ).one()
         canon = session.exec(
-            select(StylebookLocationCanonical).where(
-                StylebookLocationCanonical.slug == "has-geom"
-            )
+            select(StylebookLocationCanonical).where(StylebookLocationCanonical.slug == "has-geom")
         ).one()
         session.add(
             SubstrateLocation(
@@ -928,7 +916,12 @@ def test_mismatched_people_check(cleanup_client: tuple[TestClient, Engine]) -> N
     with Session(engine) as session:
         org = session.exec(select(BackfieldOrganization)).one()
         sb = session.exec(select(Stylebook)).one()
-        project = BackfieldProject(organization_id=int(org.id), name="Demo", slug="demo")
+        project = BackfieldProject(
+            **project_ownership_fields(session, int(org.id)),
+            organization_id=int(org.id),
+            name="Demo",
+            slug="demo",
+        )
         session.add(project)
         session.commit()
         session.refresh(project)
@@ -975,7 +968,12 @@ def test_dismiss_mismatched_person(cleanup_client: tuple[TestClient, Engine]) ->
     with Session(engine) as session:
         org = session.exec(select(BackfieldOrganization)).one()
         sb = session.exec(select(Stylebook)).one()
-        project = BackfieldProject(organization_id=int(org.id), name="Demo", slug="demo")
+        project = BackfieldProject(
+            **project_ownership_fields(session, int(org.id)),
+            organization_id=int(org.id),
+            name="Demo",
+            slug="demo",
+        )
         session.add(project)
         session.commit()
         session.refresh(project)
@@ -1028,7 +1026,12 @@ def test_mismatched_organizations_check(cleanup_client: tuple[TestClient, Engine
     with Session(engine) as session:
         org = session.exec(select(BackfieldOrganization)).one()
         sb = session.exec(select(Stylebook)).one()
-        project = BackfieldProject(organization_id=int(org.id), name="Demo", slug="demo-org")
+        project = BackfieldProject(
+            **project_ownership_fields(session, int(org.id)),
+            organization_id=int(org.id),
+            name="Demo",
+            slug="demo-org",
+        )
         session.add(project)
         session.commit()
         session.refresh(project)
@@ -1218,9 +1221,7 @@ def test_dismiss_questionable_organization_canonical(
     )
     assert dismiss.status_code == 200
 
-    after = client.get(
-        "/v1/stylebooks/default/cleanup/checks/questionable-organization-canonicals"
-    )
+    after = client.get("/v1/stylebooks/default/cleanup/checks/questionable-organization-canonicals")
     assert after.status_code == 200
     assert after.json()["total"] == before.json()["total"] - 1
     labels = {item["label"] for item in after.json()["canonicals"]}
@@ -1392,9 +1393,7 @@ def test_cleanup_ai_review_start_and_proposal_accept(
     assert start.status_code == 200
     assert start.json()["status"] == "queued"
 
-    latest = client.get(
-        "/v1/stylebooks/default/cleanup/ai-review/latest?check_id=duplicate-people"
-    )
+    latest = client.get("/v1/stylebooks/default/cleanup/ai-review/latest?check_id=duplicate-people")
     assert latest.status_code == 200
     assert latest.json() is not None
 

--- a/tests/stylebook_api/test_stylebook_library_api.py
+++ b/tests/stylebook_api/test_stylebook_library_api.py
@@ -16,6 +16,8 @@ from sqlmodel import Session, SQLModel, create_engine
 from stylebook_api.deps import get_session
 from stylebook_api.main import app
 
+from tests.project_helpers import project_ownership_fields
+
 
 @pytest.fixture
 def _library_client(tmp_path, monkeypatch: pytest.MonkeyPatch) -> Generator[TestClient, None, None]:
@@ -61,6 +63,7 @@ def _library_client(tmp_path, monkeypatch: pytest.MonkeyPatch) -> Generator[Test
         wid = int(ws.id)
         s.add(
             BackfieldProject(
+                **project_ownership_fields(s, oid, workspace_id=wid),
                 organization_id=oid,
                 name="Demo",
                 slug="demo-proj",

--- a/tests/worker/test_cancel_race.py
+++ b/tests/worker/test_cancel_race.py
@@ -18,6 +18,8 @@ from sqlmodel import Session, SQLModel, create_engine
 from worker import tasks as worker_tasks
 from worker.terminal_transitions import apply_item_terminal_status
 
+from tests.project_helpers import project_ownership_fields
+
 
 def _text_flow_spec() -> str:
     return json.dumps(
@@ -54,6 +56,7 @@ def race_engine(tmp_path, monkeypatch):
         ).ensure_default_stylebook_for_organization
         ensure_default(s, organization_id=int(org.id))
         project = BackfieldProject(
+            **project_ownership_fields(s, int(org.id)),
             organization_id=int(org.id),
             name="Cancel",
             slug="cancel-race",

--- a/tests/worker/test_canonical_adjudication.py
+++ b/tests/worker/test_canonical_adjudication.py
@@ -24,6 +24,8 @@ from worker.substrate.entities.person.adjudication import (
     prepare_person_adjudication,
 )
 
+from tests.project_helpers import project_ownership_fields
+
 
 def _adj_json_link(canonical_id: str, confidence: float, rationale: str) -> str:
     return (
@@ -59,6 +61,7 @@ def _bootstrap(session: Session) -> tuple[int, int]:
     session.commit()
     session.refresh(ws)
     proj = BackfieldProject(
+        **project_ownership_fields(session, oid, workspace_id=int(ws.id)),
         organization_id=oid,
         name="P",
         slug="p-adj",
@@ -124,9 +127,7 @@ def test_adjudicate_ambiguous_upgrades_when_llm_confident(monkeypatch) -> None:
         )
 
         def _fake_llm(*_a, **_k) -> str:
-            return (
-                _adj_json_link(id1, 0.92, "Name matches Alpha.")
-            )
+            return _adj_json_link(id1, 0.92, "Name matches Alpha.")
 
         monkeypatch.setattr("worker.substrate.canonical.adjudication.call_llm", _fake_llm)
 
@@ -191,9 +192,7 @@ def test_adjudicate_ambiguous_materialize_when_llm_rejects_link(monkeypatch) -> 
         )
 
         def _fake_llm(*_a, **_k) -> str:
-            return (
-                _adj_json_reject(0.15, "AR vs TX; no fit.")
-            )
+            return _adj_json_reject(0.15, "AR vs TX; no fit.")
 
         monkeypatch.setattr("worker.substrate.canonical.adjudication.call_llm", _fake_llm)
 
@@ -255,9 +254,7 @@ def test_adjudicate_ambiguous_person_materialize_when_llm_rejects_link(monkeypat
         )
 
         def _fake_llm(*_a, **_k) -> str:
-            return (
-                _adj_json_reject(0.33, "None match Greg Abbott, Governor of Texas.")
-            )
+            return _adj_json_reject(0.33, "None match Greg Abbott, Governor of Texas.")
 
         monkeypatch.setattr(
             "worker.substrate.entities.person.adjudication.call_llm",
@@ -325,9 +322,7 @@ def test_adjudicate_ambiguous_person_athlete_materializes_on_llm_reject(monkeypa
         )
 
         def _fake_llm(*_a, **_k) -> str:
-            return (
-                _adj_json_reject(0.4, "Different team but likely same athlete.")
-            )
+            return _adj_json_reject(0.4, "Different team but likely same athlete.")
 
         monkeypatch.setattr(
             "worker.substrate.entities.person.adjudication.call_llm",
@@ -510,9 +505,7 @@ def test_adjudicate_rejects_link_when_confidence_below_floor(monkeypatch) -> Non
         )
 
         def _fake_llm(*_a, **_k) -> str:
-            return (
-                _adj_json_link(id1, 0.85, "Probably the same POI.")
-            )
+            return _adj_json_link(id1, 0.85, "Probably the same POI.")
 
         monkeypatch.setattr("worker.substrate.canonical.adjudication.call_llm", _fake_llm)
 
@@ -573,9 +566,7 @@ def test_adjudicate_accepts_link_at_exact_min_confidence(monkeypatch) -> None:
         )
 
         def _fake_llm(*_a, **_k) -> str:
-            return (
-                _adj_json_link(id1, ADJUDICATION_LINK_MIN_CONFIDENCE, "Exact label match.")
-            )
+            return _adj_json_link(id1, ADJUDICATION_LINK_MIN_CONFIDENCE, "Exact label match.")
 
         monkeypatch.setattr("worker.substrate.canonical.adjudication.call_llm", _fake_llm)
 
@@ -639,9 +630,7 @@ def test_adjudicate_rejects_llm_choice_when_link_pair_denied(monkeypatch) -> Non
         )
 
         def _fake_llm(*_a, **_k) -> str:
-            return (
-                _adj_json_link(cid, 0.95, "Name overlap.")
-            )
+            return _adj_json_link(cid, 0.95, "Name overlap.")
 
         monkeypatch.setattr("worker.substrate.canonical.adjudication.call_llm", _fake_llm)
 
@@ -709,9 +698,7 @@ def test_adjudicate_rejects_llm_choice_when_content_sanity_blocks(monkeypatch) -
         )
 
         def _fake_llm(*_a, **_k) -> str:
-            return (
-                _adj_json_link(park_id, 0.92, "Substrate mentions Jackson Park.")
-            )
+            return _adj_json_link(park_id, 0.92, "Substrate mentions Jackson Park.")
 
         monkeypatch.setattr("worker.substrate.canonical.adjudication.call_llm", _fake_llm)
 
@@ -786,9 +773,7 @@ def test_adjudicate_political_district_fuzzy_plan_runs_llm(monkeypatch) -> None:
         def _fake_llm(prompt: str, *_a, **_k) -> str:
             assert "District identity key" in prompt
             assert "US-WARD-IL-8" in prompt
-            return (
-                _adj_json_link(id1, 0.95, "Same ward number and city.")
-            )
+            return _adj_json_link(id1, 0.95, "Same ward number and city.")
 
         monkeypatch.setattr("worker.substrate.canonical.adjudication.call_llm", _fake_llm)
 
@@ -858,9 +843,7 @@ def test_adjudicate_political_district_coerces_when_district_key_mismatch(monkey
         )
 
         def _fake_llm(*_a, **_k) -> str:
-            return (
-                _adj_json_link(id1, 0.95, "LLM wrongly picks nearby ward.")
-            )
+            return _adj_json_link(id1, 0.95, "LLM wrongly picks nearby ward.")
 
         monkeypatch.setattr("worker.substrate.canonical.adjudication.call_llm", _fake_llm)
 
@@ -931,9 +914,7 @@ def test_adjudicate_political_district_coerces_when_district_kind_conflicts(monk
         )
 
         def _fake_llm(*_a, **_k) -> str:
-            return (
-                _adj_json_link(id1, 0.95, "Name matches Congressional District 13.")
-            )
+            return _adj_json_link(id1, 0.95, "Name matches Congressional District 13.")
 
         monkeypatch.setattr("worker.substrate.canonical.adjudication.call_llm", _fake_llm)
 

--- a/tests/worker/test_cleanup_ai_review_llm_auth.py
+++ b/tests/worker/test_cleanup_ai_review_llm_auth.py
@@ -24,6 +24,8 @@ from worker.substrate.cleanup.cleanup_llm_auth import (
     resolve_cleanup_llm_auth,
 )
 
+from tests.project_helpers import project_ownership_fields
+
 
 @pytest.fixture
 def session_with_org(tmp_path, monkeypatch):
@@ -40,7 +42,12 @@ def session_with_org(tmp_path, monkeypatch):
         session.commit()
         session.refresh(org)
         oid = int(org.id)  # type: ignore[arg-type]
-        proj = BackfieldProject(organization_id=oid, name="P", slug="cleanup-proj")
+        proj = BackfieldProject(
+            **project_ownership_fields(session, oid),
+            organization_id=oid,
+            name="P",
+            slug="cleanup-proj",
+        )
         session.add(proj)
         session.commit()
         session.refresh(proj)

--- a/tests/worker/test_geocode_project_stylebook.py
+++ b/tests/worker/test_geocode_project_stylebook.py
@@ -1,0 +1,87 @@
+"""GeocodeAgent compatibility values must match project ownership."""
+
+from __future__ import annotations
+
+import pytest
+from agate_runtime.context import AgateEnvContext
+from backfield_db import (
+    BackfieldOrganization,
+    BackfieldProject,
+    BackfieldWorkspace,
+    Stylebook,
+)
+from sqlmodel import Session, SQLModel, create_engine
+
+
+def test_geocode_cache_inherits_project_stylebook_and_rejects_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Import after agate_runtime initializes its node registry to avoid its compatibility cycle.
+    from agate_nodes.geocode_agent.runner import attach_geocode_cache_bundle
+
+    engine = create_engine("sqlite://")
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as session:
+        organization = BackfieldOrganization(name="Org", slug="geocode-runtime")
+        session.add(organization)
+        session.flush()
+        assigned = Stylebook(
+            organization_id=int(organization.id),
+            name="Assigned",
+            slug="assigned",
+            is_default=True,
+        )
+        other = Stylebook(
+            organization_id=int(organization.id),
+            name="Other",
+            slug="other",
+        )
+        session.add(assigned)
+        session.add(other)
+        session.flush()
+        workspace = BackfieldWorkspace(
+            organization_id=int(organization.id),
+            stylebook_id=int(assigned.id),
+            name="Workspace",
+            slug="workspace",
+        )
+        session.add(workspace)
+        session.flush()
+        project = BackfieldProject(
+            organization_id=int(organization.id),
+            workspace_id=int(workspace.id),
+            stylebook_id=int(assigned.id),
+            name="Project",
+            slug="project",
+        )
+        session.add(project)
+        session.commit()
+        project_id = int(project.id)
+        assigned_id = int(assigned.id)
+        other_id = int(other.id)
+
+    monkeypatch.setenv("BACKFIELD_PROJECT_ID", str(project_id))
+    monkeypatch.setattr("backfield_db.session.get_engine", lambda: engine)
+
+    inherited_context = AgateEnvContext()
+    attach_geocode_cache_bundle(
+        inherited_context,
+        use_cache=True,
+        stylebook_id=None,
+    )
+    assert "geocode_cache_bundle" in inherited_context.metadata
+
+    matching_context = AgateEnvContext()
+    attach_geocode_cache_bundle(
+        matching_context,
+        use_cache=True,
+        stylebook_id=assigned_id,
+    )
+    assert "geocode_cache_bundle" in matching_context.metadata
+
+    with pytest.raises(ValueError, match="does not match"):
+        attach_geocode_cache_bundle(
+            AgateEnvContext(),
+            use_cache=True,
+            stylebook_id=other_id,
+        )

--- a/tests/worker/test_location_candidate_ai_review.py
+++ b/tests/worker/test_location_candidate_ai_review.py
@@ -13,6 +13,8 @@ from backfield_entities.catalog.bootstrap import ensure_default_stylebook_for_or
 from sqlmodel import Session, SQLModel, create_engine
 from worker.substrate.candidates.ai_review import _process_location_candidate_review
 
+from tests.project_helpers import project_ownership_fields
+
 
 def _bootstrap(session: Session) -> tuple[int, int]:
     organization = BackfieldOrganization(name="Candidate Review", slug="candidate-review")
@@ -32,6 +34,7 @@ def _bootstrap(session: Session) -> tuple[int, int]:
     session.commit()
     session.refresh(workspace)
     project = BackfieldProject(
+        **project_ownership_fields(session, organization_id, workspace_id=int(workspace.id)),
         organization_id=organization_id,
         workspace_id=int(workspace.id),  # type: ignore[arg-type]
         name="Candidate Review",

--- a/tests/worker/test_mention_anchor_provenance.py
+++ b/tests/worker/test_mention_anchor_provenance.py
@@ -24,6 +24,8 @@ from worker.substrate.entities.person.mentions import (
     _upsert_mention_and_occurrence as upsert_person_mention,
 )
 
+from tests.project_helpers import project_ownership_fields
+
 
 def test_raw_entry_id_is_scoped_to_each_article_mention() -> None:
     engine = create_engine("sqlite://")
@@ -34,6 +36,7 @@ def test_raw_entry_id_is_scoped_to_each_article_mention() -> None:
         session.commit()
         session.refresh(organization)
         project = BackfieldProject(
+            **project_ownership_fields(session, int(organization.id)),
             organization_id=int(organization.id),
             name="Project",
             slug="mention-provenance",
@@ -132,6 +135,7 @@ def test_smart_merge_preserves_editorial_fields_but_refreshes_anchor() -> None:
         session.commit()
         session.refresh(organization)
         project = BackfieldProject(
+            **project_ownership_fields(session, int(organization.id)),
             organization_id=int(organization.id),
             name="Project",
             slug="mention-preserve",

--- a/tests/worker/test_private_residence_canonical_flow.py
+++ b/tests/worker/test_private_residence_canonical_flow.py
@@ -7,6 +7,8 @@ from backfield_entities.canonical.link import CANONICAL_LINK_PENDING, CANONICAL_
 from sqlmodel import Session, SQLModel, create_engine, select
 from worker.substrate import persist_from_consolidated
 
+from tests.project_helpers import project_ownership_fields
+
 CHICAGO_POINT = {"type": "Point", "coordinates": [-87.6298, 41.8781]}
 
 
@@ -32,6 +34,7 @@ def _bootstrap_project(session: Session, *, org_slug: str, project_slug: str) ->
     session.refresh(ws)
 
     proj = BackfieldProject(
+        **project_ownership_fields(session, oid, workspace_id=int(ws.id)),
         organization_id=oid,
         name="Proj",
         slug=project_slug,

--- a/tests/worker/test_run_cancellation_postgres.py
+++ b/tests/worker/test_run_cancellation_postgres.py
@@ -23,6 +23,8 @@ from sqlalchemy import delete
 from sqlmodel import Session, create_engine, select
 from worker import tasks as worker_tasks
 
+from tests.project_helpers import project_ownership_fields
+
 _DATABASE_URL = os.getenv("BACKFIELD_DATABASE_URL_DIRECT", "")
 
 
@@ -53,6 +55,7 @@ def test_cancel_wins_before_worker_stores_completion() -> None:
             session.refresh(organization)
             organization_id = int(organization.id)
             project = BackfieldProject(
+                **project_ownership_fields(session, organization_id),
                 organization_id=organization_id,
                 name=f"Cancellation race {suffix}",
                 slug=f"cancellation-race-{suffix}",
@@ -157,14 +160,10 @@ def test_cancel_wins_before_worker_stores_completion() -> None:
             if graph_id is not None:
                 session.execute(delete(AgateGraph).where(AgateGraph.id == graph_id))
             if project_id is not None:
-                session.execute(
-                    delete(BackfieldProject).where(BackfieldProject.id == project_id)
-                )
+                session.execute(delete(BackfieldProject).where(BackfieldProject.id == project_id))
             if organization_id is not None:
                 session.execute(
-                    delete(BackfieldOrganization).where(
-                        BackfieldOrganization.id == organization_id
-                    )
+                    delete(BackfieldOrganization).where(BackfieldOrganization.id == organization_id)
                 )
             session.commit()
         engine.dispose()

--- a/tests/worker/test_s3_batch_worker.py
+++ b/tests/worker/test_s3_batch_worker.py
@@ -18,6 +18,7 @@ from backfield_db import (
     AgateRun,
     BackfieldOrganization,
     BackfieldProject,
+    BackfieldWorkspace,
 )
 from backfield_entities.catalog.bootstrap import ensure_default_stylebook_for_organization
 from sqlalchemy import event, update
@@ -102,8 +103,22 @@ def batch_engine(tmp_path, monkeypatch):
         session.commit()
         session.refresh(org)
         oid = int(org.id)  # type: ignore[arg-type]
-        ensure_default_stylebook_for_organization(session, oid)
-        proj = BackfieldProject(organization_id=oid, name="P", slug="p-s3")
+        stylebook = ensure_default_stylebook_for_organization(session, oid)
+        workspace = BackfieldWorkspace(
+            organization_id=oid,
+            stylebook_id=int(stylebook.id),
+            name="Workspace",
+            slug="s3-worker",
+        )
+        session.add(workspace)
+        session.flush()
+        proj = BackfieldProject(
+            organization_id=oid,
+            workspace_id=int(workspace.id),
+            stylebook_id=int(stylebook.id),
+            name="P",
+            slug="p-s3",
+        )
         session.add(proj)
         session.commit()
         session.refresh(proj)
@@ -186,7 +201,7 @@ def test_finalization_preserves_metadata_and_is_idempotent(batch_engine):
         result_json=json.dumps(
             {
                 "s3_batch": {"valid_executed": 1},
-                "graph_spec_json": "{\"name\":\"snapshot\"}",
+                "graph_spec_json": '{"name":"snapshot"}',
             }
         ),
     )
@@ -221,8 +236,7 @@ def test_failed_and_stale_items_fail_parent(batch_engine):
         engine,
         graph_id,
         ["running"],
-        started_at=datetime.now(UTC)
-        - timedelta(seconds=worker_tasks._STALE_RUNNING_AFTER_S + 5),
+        started_at=datetime.now(UTC) - timedelta(seconds=worker_tasks._STALE_RUNNING_AFTER_S + 5),
     )
 
     with Session(engine) as session:

--- a/tests/worker/test_s3_finalization_postgres.py
+++ b/tests/worker/test_s3_finalization_postgres.py
@@ -20,6 +20,8 @@ from sqlalchemy import delete, event
 from sqlmodel import Session, create_engine
 from worker import tasks as worker_tasks
 
+from tests.project_helpers import project_ownership_fields
+
 _DATABASE_URL = os.getenv("BACKFIELD_DATABASE_URL_DIRECT", "")
 
 
@@ -65,6 +67,7 @@ def test_competing_finalizers_mutate_parent_once(monkeypatch) -> None:
             organization_id = int(organization.id)
 
             project = BackfieldProject(
+                **project_ownership_fields(session, organization_id),
                 organization_id=organization_id,
                 name=f"Finalizer race {suffix}",
                 slug=f"finalizer-race-{suffix}",
@@ -138,14 +141,10 @@ def test_competing_finalizers_mutate_parent_once(monkeypatch) -> None:
             if graph_id is not None:
                 session.execute(delete(AgateGraph).where(AgateGraph.id == graph_id))
             if project_id is not None:
-                session.execute(
-                    delete(BackfieldProject).where(BackfieldProject.id == project_id)
-                )
+                session.execute(delete(BackfieldProject).where(BackfieldProject.id == project_id))
             if organization_id is not None:
                 session.execute(
-                    delete(BackfieldOrganization).where(
-                        BackfieldOrganization.id == organization_id
-                    )
+                    delete(BackfieldOrganization).where(BackfieldOrganization.id == organization_id)
                 )
             session.commit()
         engine.dispose()

--- a/tests/worker/test_s3_ingestion_ledger.py
+++ b/tests/worker/test_s3_ingestion_ledger.py
@@ -30,6 +30,8 @@ from worker.s3_ingestion_ledger import (
 )
 from worker.substrate.content.article import _upsert_article
 
+from tests.project_helpers import project_ownership_fields
+
 
 def _spec(source_id: str | None = None) -> str:
     params: dict[str, Any] = {"bucket": "my-bucket", "folder_path": "p", "max_files": 10}
@@ -109,7 +111,9 @@ def ledger_engine(tmp_path, monkeypatch):
         session.refresh(org)
         oid = int(org.id)  # type: ignore[arg-type]
         ensure_default_stylebook_for_organization(session, oid)
-        proj = BackfieldProject(organization_id=oid, name="P", slug="p-ledger")
+        proj = BackfieldProject(
+            **project_ownership_fields(session, oid), organization_id=oid, name="P", slug="p-ledger"
+        )
         session.add(proj)
         session.commit()
         session.refresh(proj)
@@ -191,6 +195,7 @@ def test_ledger_identity_lookups_are_project_scoped(ledger_engine):
         project = session.get(BackfieldProject, project_id)
         assert project is not None
         other_project = BackfieldProject(
+            **project_ownership_fields(session, int(project.organization_id)),
             organization_id=int(project.organization_id),
             name="Other",
             slug="other-ledger-project",
@@ -265,6 +270,7 @@ def test_identical_revisions_are_processed_independently_by_project(ledger_engin
         project = session.get(BackfieldProject, project_id)
         assert project is not None
         other_project = BackfieldProject(
+            **project_ownership_fields(session, int(project.organization_id)),
             organization_id=int(project.organization_id),
             name="Other",
             slug="other-ledger-project",

--- a/tests/worker/test_s3_output_sync_worker.py
+++ b/tests/worker/test_s3_output_sync_worker.py
@@ -16,6 +16,8 @@ from backfield_db import (
 from sqlmodel import Session, SQLModel, create_engine
 from worker import tasks as worker_tasks
 
+from tests.project_helpers import project_ownership_fields
+
 
 def _spec_with_s3_output() -> str:
     return json.dumps(
@@ -75,7 +77,12 @@ def sync_engine(tmp_path, monkeypatch):
         session.add(org)
         session.commit()
         session.refresh(org)
-        proj = BackfieldProject(organization_id=int(org.id), name="P", slug="p-s3sync")  # type: ignore[arg-type]
+        proj = BackfieldProject(
+            **project_ownership_fields(session, int(org.id)),
+            organization_id=int(org.id),
+            name="P",
+            slug="p-s3sync",
+        )  # type: ignore[arg-type]
         session.add(proj)
         session.commit()
         session.refresh(proj)

--- a/tests/worker/test_single_item_worker.py
+++ b/tests/worker/test_single_item_worker.py
@@ -12,6 +12,7 @@ from backfield_db import (
     AgateRun,
     BackfieldOrganization,
     BackfieldProject,
+    BackfieldWorkspace,
 )
 from sqlmodel import Session, SQLModel, create_engine
 from worker import tasks as worker_tasks
@@ -51,9 +52,19 @@ def single_engine(tmp_path, monkeypatch):
             "backfield_entities.catalog.bootstrap",
             fromlist=["ensure_default_stylebook_for_organization"],
         ).ensure_default_stylebook_for_organization
-        ensure_default(s, organization_id=int(org.id))
+        stylebook = ensure_default(s, organization_id=int(org.id))
+        workspace = BackfieldWorkspace(
+            organization_id=int(org.id),
+            stylebook_id=int(stylebook.id),
+            name="Workspace",
+            slug="single-item-worker",
+        )
+        s.add(workspace)
+        s.flush()
         project = BackfieldProject(
             organization_id=int(org.id),
+            workspace_id=int(workspace.id),
+            stylebook_id=int(stylebook.id),
             name="Single",
             slug="single-item-worker",
         )

--- a/tests/worker/test_substrate_persistence.py
+++ b/tests/worker/test_substrate_persistence.py
@@ -26,6 +26,8 @@ from worker.substrate import _find_mention_span, persist_from_consolidated
 from worker.substrate.content.article import _upsert_article
 from worker.substrate.content.geography_reset import replace_machine_geography_for_article
 
+from tests.project_helpers import project_ownership_fields
+
 CHICAGO_POINT = {"type": "Point", "coordinates": [-87.6298, 41.8781]}
 WGP_POINT = {"type": "Point", "coordinates": [-87.703, 41.914]}
 
@@ -154,6 +156,7 @@ def _bootstrap_project(session: Session, *, org_slug: str, project_slug: str) ->
     session.refresh(ws)
 
     proj = BackfieldProject(
+        **project_ownership_fields(session, oid, workspace_id=int(ws.id)),
         organization_id=oid,
         name="Proj",
         slug=project_slug,
@@ -584,9 +587,7 @@ def test_shared_geocoder_address_id_does_not_collapse_distinct_pois() -> None:
             f"{shared_geocoder_id}:kohl-s-lincolnwood-town-center-lincolnwood-il",
         }
         active_mentions = session.exec(
-            select(SubstrateLocationMention).where(
-                col(SubstrateLocationMention.deleted).is_(False)
-            )
+            select(SubstrateLocationMention).where(col(SubstrateLocationMention.deleted).is_(False))
         ).all()
         assert len(active_mentions) == 2
 
@@ -599,12 +600,8 @@ def test_add_only_does_not_remove_stale_saved_places() -> None:
         project_id = _bootstrap_project(
             session, org_slug="org-add-stale", project_slug="proj-add-stale"
         )
-        session.add(
-            AgateRun(id="run-add-stale-1", graph_id="graph-add-stale", status="pending")
-        )
-        session.add(
-            AgateRun(id="run-add-stale-2", graph_id="graph-add-stale", status="pending")
-        )
+        session.add(AgateRun(id="run-add-stale-1", graph_id="graph-add-stale", status="pending"))
+        session.add(AgateRun(id="run-add-stale-2", graph_id="graph-add-stale", status="pending"))
         session.commit()
 
         persist_from_consolidated(
@@ -634,9 +631,7 @@ def test_add_only_does_not_remove_stale_saved_places() -> None:
         session.commit()
 
         active = session.exec(
-            select(SubstrateLocationMention).where(
-                col(SubstrateLocationMention.deleted).is_(False)
-            )
+            select(SubstrateLocationMention).where(col(SubstrateLocationMention.deleted).is_(False))
         ).all()
         assert len(active) == 1
         assert result.reconciliation_summary.removed == 0
@@ -700,9 +695,7 @@ def test_smart_merge_preserves_editor_touched_stale_places() -> None:
         session.commit()
 
         active = session.exec(
-            select(SubstrateLocationMention).where(
-                col(SubstrateLocationMention.deleted).is_(False)
-            )
+            select(SubstrateLocationMention).where(col(SubstrateLocationMention.deleted).is_(False))
         ).all()
         assert len(active) == 1
         assert active[0].edited is True
@@ -755,9 +748,7 @@ def test_replace_clears_editor_touched_places_and_allows_future_readd() -> None:
 
         assert result.reconciliation_summary.removed == 1
         active = session.exec(
-            select(SubstrateLocationMention).where(
-                col(SubstrateLocationMention.deleted).is_(False)
-            )
+            select(SubstrateLocationMention).where(col(SubstrateLocationMention.deleted).is_(False))
         ).all()
         assert active == []
         assert session.exec(select(SubstrateLocation)).all() == []
@@ -838,9 +829,7 @@ def test_reconciliation_failure_rolls_back_prior_saved_places(monkeypatch) -> No
         assert location is not None
         assert location.external_id == "pelias:chicago"
         active_mentions = session.exec(
-            select(SubstrateLocationMention).where(
-                col(SubstrateLocationMention.deleted).is_(False)
-            )
+            select(SubstrateLocationMention).where(col(SubstrateLocationMention.deleted).is_(False))
         ).all()
         assert len(active_mentions) == 1
 
@@ -1408,9 +1397,7 @@ def test_rerun_retires_stale_article_mentions_when_geocode_identity_changes() ->
         ).all()
         assert len(old_locs) == 0
         midway_new = session.exec(
-            select(SubstrateLocation).where(
-                SubstrateLocation.external_id == "pelias:midway-new"
-            )
+            select(SubstrateLocation).where(SubstrateLocation.external_id == "pelias:midway-new")
         ).one()
         assert midway_new.external_id == "pelias:midway-new"
 
@@ -2884,12 +2871,8 @@ def test_replace_article_geography_keeps_substrate_when_other_stories_mention() 
         session.commit()
         session.refresh(loc)
         lid = int(loc.id)
-        session.add(
-            SubstrateLocationMention(article_id=aid_a, location_id=lid, deleted=False)
-        )
-        session.add(
-            SubstrateLocationMention(article_id=aid_b, location_id=lid, deleted=False)
-        )
+        session.add(SubstrateLocationMention(article_id=aid_a, location_id=lid, deleted=False))
+        session.add(SubstrateLocationMention(article_id=aid_b, location_id=lid, deleted=False))
         session.commit()
 
         stats = replace_machine_geography_for_article(


### PR DESCRIPTION
## Summary
- enforce non-null same-organization workspace and Stylebook ownership on projects
- normalize matching legacy graph refs while rejecting conflicting catalog overrides
- remove Stylebook selection from ordinary node configuration and inherit project ownership in workers
- require project access plus Stylebook edit permission for candidate mutations

This PR is stacked on #117 while the tenancy slices are under development.

## Test plan
- [x] `make lint`
- [x] `make test` (2,327 passed, 10 skipped)
- [x] `make smoke`
- [x] migration 070 applied through `make migrate-host`
- [x] Agate UI tests and production build
- [x] focused pre-PR architecture/correctness review

Made with [Cursor](https://cursor.com)