### PR TITLE
Add the combined Stylebook candidate inbox

### DIFF
--- a/apps/stylebook-api/src/stylebook_api/entities/location/candidates.py
+++ b/apps/stylebook-api/src/stylebook_api/entities/location/candidates.py
@@ -8,6 +8,7 @@ from uuid import UUID
 
 from backfield_auth.gate import require_project_access
 from backfield_db import (
+    BackfieldProject,
     StylebookLocationCanonical,
     SubstrateArticle,
     SubstrateLocation,
@@ -45,6 +46,7 @@ from stylebook_api.helpers.candidate_review_display import (
     first_candidate_review_line,
     format_candidate_review_lines,
 )
+from stylebook_api.helpers.candidate_scope import require_candidate_project_in_stylebook
 from stylebook_api.helpers.project_scope import (
     project_by_slug as _project_by_slug,
 )
@@ -52,7 +54,6 @@ from stylebook_api.helpers.project_scope import (
     require_stylebook_id as _require_stylebook_id,
 )
 from stylebook_api.mention_serialization import article_fields_for_linked_mention
-from stylebook_api.stylebook_permissions import require_stylebook_edit_access_by_id
 
 router = APIRouter(prefix="/v1", tags=["location-candidates"])
 
@@ -91,7 +92,7 @@ class UpdateCandidateNoteBody(BaseModel):
     note: str | None = None
 
 
-def _open_candidate_filters(
+def open_candidate_filters(
     project_id: int,
     *,
     needs_review: bool | None,
@@ -126,7 +127,7 @@ def _open_candidate_filters(
     return filters
 
 
-def _deferred_candidate_filters(
+def deferred_candidate_filters(
     project_id: int, *, q: str | None, type_filter: str | None
 ) -> list[Any]:
     filters: list[Any] = [
@@ -196,7 +197,7 @@ def _canonical_suggestion_payload(loc: SubstrateLocation) -> dict[str, Any] | No
     return out or None
 
 
-def _candidate_dict(loc: SubstrateLocation) -> dict[str, Any]:
+def serialize_candidate(loc: SubstrateLocation) -> dict[str, Any]:
     note = _extract_review_note(loc)
     sug = _canonical_suggestion_payload(loc)
     review_lines = format_candidate_review_lines(loc.canonical_review_reasons_json)
@@ -219,6 +220,14 @@ def _candidate_dict(loc: SubstrateLocation) -> dict[str, Any]:
         row["defer_display_message"] = defer_msg
     if sug is not None:
         row["canonical_suggestion"] = sug
+    return row
+
+
+def _candidate_dict_with_project(
+    loc: SubstrateLocation, project: BackfieldProject
+) -> dict[str, Any]:
+    row = serialize_candidate(loc)
+    row.update(project_slug=project.slug, project_name=project.name)
     return row
 
 
@@ -248,7 +257,7 @@ def _list_open_candidates(
     q: str | None,
     type_filter: str | None,
 ) -> PaginatedCandidatesResponse:
-    filters = _open_candidate_filters(
+    filters = open_candidate_filters(
         project_id,
         needs_review=needs_review,
         q=q,
@@ -264,7 +273,10 @@ def _list_open_candidates(
         .limit(limit)
     )
     rows = list(session.exec(stmt).all())
-    candidates = [_candidate_dict(r) for r in rows]
+    project = session.get(BackfieldProject, project_id)
+    if project is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+    candidates = [_candidate_dict_with_project(r, project) for r in rows]
     return PaginatedCandidatesResponse(
         candidates=candidates,
         total=total,
@@ -282,7 +294,7 @@ def _list_deferred_candidates(
     q: str | None,
     type_filter: str | None,
 ) -> PaginatedCandidatesResponse:
-    filters = _deferred_candidate_filters(project_id, q=q, type_filter=type_filter)
+    filters = deferred_candidate_filters(project_id, q=q, type_filter=type_filter)
     count_stmt = select(func.count()).select_from(SubstrateLocation).where(*filters)
     total = int(session.scalar(count_stmt) or 0)
     stmt = (
@@ -293,7 +305,10 @@ def _list_deferred_candidates(
         .limit(limit)
     )
     rows = list(session.exec(stmt).all())
-    candidates = [_candidate_dict(r) for r in rows]
+    project = session.get(BackfieldProject, project_id)
+    if project is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+    candidates = [_candidate_dict_with_project(r, project) for r in rows]
     return PaginatedCandidatesResponse(
         candidates=candidates,
         total=total,
@@ -532,14 +547,17 @@ def candidate_update_note(
     auth: dict[str, Any] = Depends(get_auth),
 ) -> dict[str, str]:
     """Attach a short editor note to a review queue item (stored on the location row)."""
-    proj = _project_by_slug(session, project_slug)
-    require_project_access(session, auth, int(proj.id))
-    stylebook_id = _require_stylebook_id(session, proj, stylebook_slug)
-    require_stylebook_edit_access_by_id(session, auth=auth, stylebook_id=stylebook_id)
-
     loc = session.get(SubstrateLocation, substrate_location_id)
-    if loc is None or int(loc.project_id) != int(proj.id):
+    if loc is None:
         raise HTTPException(status_code=404, detail="Substrate location not found")
+    require_candidate_project_in_stylebook(
+        session,
+        auth=auth,
+        project_id=int(loc.project_id),
+        project_slug=project_slug,
+        stylebook_slug=stylebook_slug,
+        require_edit=True,
+    )
     if loc.stylebook_location_canonical_id is not None:
         raise HTTPException(status_code=409, detail="Location is already linked to a canonical")
     if str(loc.canonical_link_status) not in (CANONICAL_LINK_PENDING, CANONICAL_LINK_WAIVED):
@@ -662,14 +680,17 @@ def defer_candidate(
     auth: dict[str, Any] = Depends(get_auth),
 ) -> dict[str, str]:
     """Defer canonical linking for a substrate row (remove from open queue without linking)."""
-    proj = _project_by_slug(session, project_slug)
-    require_project_access(session, auth, int(proj.id))
-    stylebook_id = _require_stylebook_id(session, proj, stylebook_slug)
-    require_stylebook_edit_access_by_id(session, auth=auth, stylebook_id=stylebook_id)
-
     loc = session.get(SubstrateLocation, substrate_location_id)
-    if loc is None or int(loc.project_id) != int(proj.id):
+    if loc is None:
         raise HTTPException(status_code=404, detail="Substrate location not found")
+    require_candidate_project_in_stylebook(
+        session,
+        auth=auth,
+        project_id=int(loc.project_id),
+        project_slug=project_slug,
+        stylebook_slug=stylebook_slug,
+        require_edit=True,
+    )
     if loc.stylebook_location_canonical_id is not None:
         raise HTTPException(status_code=409, detail="Location is already linked to a canonical")
     if loc.canonical_link_status != CANONICAL_LINK_PENDING:
@@ -695,14 +716,17 @@ def clear_candidate_recommendation(
     session: Session = Depends(get_session),
     auth: dict[str, Any] = Depends(get_auth),
 ) -> dict[str, str]:
-    proj = _project_by_slug(session, project_slug)
-    require_project_access(session, auth, int(proj.id))
-    stylebook_id = _require_stylebook_id(session, proj, stylebook_slug)
-    require_stylebook_edit_access_by_id(session, auth=auth, stylebook_id=stylebook_id)
-
     loc = session.get(SubstrateLocation, substrate_location_id)
-    if loc is None or int(loc.project_id) != int(proj.id):
+    if loc is None:
         raise HTTPException(status_code=404, detail="Substrate location not found")
+    require_candidate_project_in_stylebook(
+        session,
+        auth=auth,
+        project_id=int(loc.project_id),
+        project_slug=project_slug,
+        stylebook_slug=stylebook_slug,
+        require_edit=True,
+    )
     if loc.stylebook_location_canonical_id is not None:
         raise HTTPException(status_code=409, detail="Location is already linked to a canonical")
     if loc.canonical_link_status != CANONICAL_LINK_PENDING:
@@ -728,14 +752,18 @@ def accept_candidate(
     session: Session = Depends(get_session),
     auth: dict[str, Any] = Depends(get_auth),
 ) -> AcceptCandidateResponse:
-    proj = _project_by_slug(session, project_slug)
-    require_project_access(session, auth, int(proj.id))
-    stylebook_id = _require_stylebook_id(session, proj, stylebook_slug)
-    require_stylebook_edit_access_by_id(session, auth=auth, stylebook_id=stylebook_id)
-
     loc = session.get(SubstrateLocation, substrate_location_id)
-    if loc is None or int(loc.project_id) != int(proj.id):
+    if loc is None:
         raise HTTPException(status_code=404, detail="Substrate location not found")
+    _, guarded_stylebook = require_candidate_project_in_stylebook(
+        session,
+        auth=auth,
+        project_id=int(loc.project_id),
+        project_slug=project_slug,
+        stylebook_slug=stylebook_slug,
+        require_edit=True,
+    )
+    stylebook_id = int(guarded_stylebook.id)
     if loc.stylebook_location_canonical_id is not None:
         raise HTTPException(status_code=409, detail="Location already linked to a canonical")
     if loc.canonical_link_status not in (CANONICAL_LINK_PENDING, CANONICAL_LINK_WAIVED):

--- a/apps/stylebook-api/src/stylebook_api/entities/location/locations.py
+++ b/apps/stylebook-api/src/stylebook_api/entities/location/locations.py
@@ -37,6 +37,7 @@ from sqlmodel import Session, col, func, select
 
 from stylebook_api.catalog_scope import StylebookSlugQuery
 from stylebook_api.deps import get_auth, get_session
+from stylebook_api.helpers.candidate_scope import require_candidate_project_in_stylebook
 from stylebook_api.helpers.project_scope import project_by_slug, require_stylebook_id
 from stylebook_api.mention_occurrences import replace_mention_occurrences_for_article
 from stylebook_api.mention_serialization import article_fields_for_linked_mention
@@ -413,6 +414,15 @@ def unlink_substrate_from_canonical_route(
     loc = session.get(SubstrateLocation, location_id)
     if loc is None or int(loc.project_id) != int(proj.id):
         raise HTTPException(status_code=404, detail="Location not found")
+    _, guarded_stylebook = require_candidate_project_in_stylebook(
+        session,
+        auth=auth,
+        project_id=int(loc.project_id),
+        project_slug=project_slug,
+        stylebook_slug=stylebook_slug,
+        require_edit=True,
+    )
+    stylebook_id = int(guarded_stylebook.id)
     try:
         unlink_substrate_from_canonical(
             session, stylebook_id=stylebook_id, location=loc, provenance="stylebook_ui_unlink"
@@ -444,6 +454,15 @@ def link_substrate_to_canonical_route(
     loc = session.get(SubstrateLocation, location_id)
     if loc is None or int(loc.project_id) != int(proj.id):
         raise HTTPException(status_code=404, detail="Location not found")
+    _, guarded_stylebook = require_candidate_project_in_stylebook(
+        session,
+        auth=auth,
+        project_id=int(loc.project_id),
+        project_slug=project_slug,
+        stylebook_slug=stylebook_slug,
+        require_edit=True,
+    )
+    stylebook_id = int(guarded_stylebook.id)
     try:
         changed = link_substrate_to_canonical_atomic(
             session,

--- a/apps/stylebook-api/src/stylebook_api/entities/organization/candidates.py
+++ b/apps/stylebook-api/src/stylebook_api/entities/organization/candidates.py
@@ -8,6 +8,7 @@ from uuid import UUID
 
 from backfield_auth.gate import require_project_access
 from backfield_db import (
+    BackfieldProject,
     StylebookOrganizationCanonical,
     SubstrateArticle,
     SubstrateOrganization,
@@ -40,6 +41,7 @@ from stylebook_api.helpers.candidate_review_display import (
     first_candidate_review_line,
     format_candidate_review_lines,
 )
+from stylebook_api.helpers.candidate_scope import require_candidate_project_in_stylebook
 from stylebook_api.helpers.project_scope import (
     project_by_slug as _project_by_slug,
 )
@@ -47,12 +49,11 @@ from stylebook_api.helpers.project_scope import (
     require_stylebook_id as _require_stylebook_id,
 )
 from stylebook_api.mention_serialization import article_fields_for_linked_mention
-from stylebook_api.stylebook_permissions import require_stylebook_edit_access_by_id
 
 router = APIRouter(prefix="/v1/organizations", tags=["organization-candidates"])
 
 
-def _substrate_list_sort_key():
+def candidate_sort_key():
     return func.lower(col(SubstrateOrganization.normalized_name))
 
 
@@ -81,7 +82,7 @@ class UpdateCandidateNoteBody(BaseModel):
     note: str | None = None
 
 
-def _open_candidate_filters(
+def open_candidate_filters(
     project_id: int,
     *,
     needs_review: bool | None,
@@ -116,7 +117,7 @@ def _open_candidate_filters(
     return filters
 
 
-def _deferred_candidate_filters(
+def deferred_candidate_filters(
     project_id: int, *, q: str | None, type_filter: str | None
 ) -> list[Any]:
     filters: list[Any] = [
@@ -211,7 +212,7 @@ def _extract_review_note(organization: SubstrateOrganization) -> str | None:
     return None
 
 
-def _candidate_dict(organization: SubstrateOrganization) -> dict[str, Any]:
+def serialize_candidate(organization: SubstrateOrganization) -> dict[str, Any]:
     note = _extract_review_note(organization)
     sug = _canonical_suggestion_payload(organization)
     review_lines = format_candidate_review_lines(organization.canonical_review_reasons_json)
@@ -242,6 +243,14 @@ def _candidate_dict(organization: SubstrateOrganization) -> dict[str, Any]:
     return row
 
 
+def _candidate_dict_with_project(
+    organization: SubstrateOrganization, project: BackfieldProject
+) -> dict[str, Any]:
+    row = serialize_candidate(organization)
+    row.update(project_slug=project.slug, project_name=project.name)
+    return row
+
+
 def _list_open_candidates(
     session: Session,
     *,
@@ -252,7 +261,7 @@ def _list_open_candidates(
     q: str | None,
     type_filter: str | None,
 ) -> PaginatedCandidatesResponse:
-    filters = _open_candidate_filters(
+    filters = open_candidate_filters(
         project_id,
         needs_review=needs_review,
         q=q,
@@ -263,12 +272,15 @@ def _list_open_candidates(
     stmt = (
         select(SubstrateOrganization)
         .where(*filters)
-        .order_by(_substrate_list_sort_key().asc(), col(SubstrateOrganization.id).asc())
+        .order_by(candidate_sort_key().asc(), col(SubstrateOrganization.id).asc())
         .offset(offset)
         .limit(limit)
     )
     rows = list(session.exec(stmt).all())
-    candidates = [_candidate_dict(r) for r in rows]
+    project = session.get(BackfieldProject, project_id)
+    if project is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+    candidates = [_candidate_dict_with_project(r, project) for r in rows]
     return PaginatedCandidatesResponse(
         candidates=candidates,
         total=total,
@@ -286,18 +298,21 @@ def _list_deferred_candidates(
     q: str | None,
     type_filter: str | None,
 ) -> PaginatedCandidatesResponse:
-    filters = _deferred_candidate_filters(project_id, q=q, type_filter=type_filter)
+    filters = deferred_candidate_filters(project_id, q=q, type_filter=type_filter)
     count_stmt = select(func.count()).select_from(SubstrateOrganization).where(*filters)
     total = int(session.scalar(count_stmt) or 0)
     stmt = (
         select(SubstrateOrganization)
         .where(*filters)
-        .order_by(_substrate_list_sort_key().asc(), col(SubstrateOrganization.id).asc())
+        .order_by(candidate_sort_key().asc(), col(SubstrateOrganization.id).asc())
         .offset(offset)
         .limit(limit)
     )
     rows = list(session.exec(stmt).all())
-    candidates = [_candidate_dict(r) for r in rows]
+    project = session.get(BackfieldProject, project_id)
+    if project is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+    candidates = [_candidate_dict_with_project(r, project) for r in rows]
     return PaginatedCandidatesResponse(
         candidates=candidates,
         total=total,
@@ -486,14 +501,17 @@ def candidate_update_note(
     auth: dict[str, Any] = Depends(get_auth),
 ) -> dict[str, str]:
     """Attach a short editor note to a review queue item (stored on the organization row)."""
-    proj = _project_by_slug(session, project_slug)
-    require_project_access(session, auth, int(proj.id))
-    stylebook_id = _require_stylebook_id(session, proj, stylebook_slug)
-    require_stylebook_edit_access_by_id(session, auth=auth, stylebook_id=stylebook_id)
-
     organization = session.get(SubstrateOrganization, substrate_organization_id)
-    if organization is None or int(organization.project_id) != int(proj.id):
+    if organization is None:
         raise HTTPException(status_code=404, detail="Substrate organization not found")
+    require_candidate_project_in_stylebook(
+        session,
+        auth=auth,
+        project_id=int(organization.project_id),
+        project_slug=project_slug,
+        stylebook_slug=stylebook_slug,
+        require_edit=True,
+    )
     if organization.stylebook_organization_canonical_id is not None:
         raise HTTPException(status_code=409, detail="Organization is already linked to a canonical")
     if str(organization.canonical_link_status) not in (
@@ -616,14 +634,17 @@ def defer_candidate(
     auth: dict[str, Any] = Depends(get_auth),
 ) -> dict[str, str]:
     """Defer canonical linking for a substrate row (remove from open queue without linking)."""
-    proj = _project_by_slug(session, project_slug)
-    require_project_access(session, auth, int(proj.id))
-    stylebook_id = _require_stylebook_id(session, proj, stylebook_slug)
-    require_stylebook_edit_access_by_id(session, auth=auth, stylebook_id=stylebook_id)
-
     organization = session.get(SubstrateOrganization, substrate_organization_id)
-    if organization is None or int(organization.project_id) != int(proj.id):
+    if organization is None:
         raise HTTPException(status_code=404, detail="Substrate organization not found")
+    require_candidate_project_in_stylebook(
+        session,
+        auth=auth,
+        project_id=int(organization.project_id),
+        project_slug=project_slug,
+        stylebook_slug=stylebook_slug,
+        require_edit=True,
+    )
     if organization.stylebook_organization_canonical_id is not None:
         raise HTTPException(status_code=409, detail="Organization is already linked to a canonical")
     if organization.canonical_link_status != CANONICAL_LINK_PENDING:
@@ -649,14 +670,17 @@ def clear_candidate_recommendation(
     session: Session = Depends(get_session),
     auth: dict[str, Any] = Depends(get_auth),
 ) -> dict[str, str]:
-    proj = _project_by_slug(session, project_slug)
-    require_project_access(session, auth, int(proj.id))
-    stylebook_id = _require_stylebook_id(session, proj, stylebook_slug)
-    require_stylebook_edit_access_by_id(session, auth=auth, stylebook_id=stylebook_id)
-
     organization = session.get(SubstrateOrganization, substrate_organization_id)
-    if organization is None or int(organization.project_id) != int(proj.id):
+    if organization is None:
         raise HTTPException(status_code=404, detail="Substrate organization not found")
+    require_candidate_project_in_stylebook(
+        session,
+        auth=auth,
+        project_id=int(organization.project_id),
+        project_slug=project_slug,
+        stylebook_slug=stylebook_slug,
+        require_edit=True,
+    )
     if organization.stylebook_organization_canonical_id is not None:
         raise HTTPException(status_code=409, detail="Organization is already linked to a canonical")
     if organization.canonical_link_status != CANONICAL_LINK_PENDING:
@@ -682,14 +706,18 @@ def accept_candidate(
     session: Session = Depends(get_session),
     auth: dict[str, Any] = Depends(get_auth),
 ) -> AcceptCandidateResponse:
-    proj = _project_by_slug(session, project_slug)
-    require_project_access(session, auth, int(proj.id))
-    stylebook_id = _require_stylebook_id(session, proj, stylebook_slug)
-    require_stylebook_edit_access_by_id(session, auth=auth, stylebook_id=stylebook_id)
-
     organization = session.get(SubstrateOrganization, substrate_organization_id)
-    if organization is None or int(organization.project_id) != int(proj.id):
+    if organization is None:
         raise HTTPException(status_code=404, detail="Substrate organization not found")
+    _, guarded_stylebook = require_candidate_project_in_stylebook(
+        session,
+        auth=auth,
+        project_id=int(organization.project_id),
+        project_slug=project_slug,
+        stylebook_slug=stylebook_slug,
+        require_edit=True,
+    )
+    stylebook_id = int(guarded_stylebook.id)
     if organization.stylebook_organization_canonical_id is not None:
         raise HTTPException(status_code=409, detail="Organization already linked to a canonical")
     if organization.canonical_link_status not in (CANONICAL_LINK_PENDING, CANONICAL_LINK_WAIVED):

--- a/apps/stylebook-api/src/stylebook_api/entities/organization/organizations.py
+++ b/apps/stylebook-api/src/stylebook_api/entities/organization/organizations.py
@@ -35,6 +35,7 @@ from sqlmodel import Session, col, func, select
 
 from stylebook_api.catalog_scope import StylebookSlugQuery
 from stylebook_api.deps import get_auth, get_session
+from stylebook_api.helpers.candidate_scope import require_candidate_project_in_stylebook
 from stylebook_api.helpers.project_scope import project_by_slug, require_stylebook_id
 from stylebook_api.mention_occurrences import replace_organization_mention_occurrences_for_article
 from stylebook_api.semantic_reindex import enqueue_semantic_reindex
@@ -80,6 +81,15 @@ def unlink_substrate_from_canonical_route(
     organization = session.get(SubstrateOrganization, organization_id)
     if organization is None or int(organization.project_id) != int(proj.id):
         raise HTTPException(status_code=404, detail="Organization not found")
+    _, guarded_stylebook = require_candidate_project_in_stylebook(
+        session,
+        auth=auth,
+        project_id=int(organization.project_id),
+        project_slug=project_slug,
+        stylebook_slug=stylebook_slug,
+        require_edit=True,
+    )
+    stylebook_id = int(guarded_stylebook.id)
     try:
         unlink_substrate_from_canonical(
             session,
@@ -111,6 +121,15 @@ def link_substrate_to_canonical_route(
     organization = session.get(SubstrateOrganization, organization_id)
     if organization is None or int(organization.project_id) != int(proj.id):
         raise HTTPException(status_code=404, detail="Organization not found")
+    _, guarded_stylebook = require_candidate_project_in_stylebook(
+        session,
+        auth=auth,
+        project_id=int(organization.project_id),
+        project_slug=project_slug,
+        stylebook_slug=stylebook_slug,
+        require_edit=True,
+    )
+    stylebook_id = int(guarded_stylebook.id)
     try:
         changed = link_substrate_to_canonical_atomic(
             session,

--- a/apps/stylebook-api/src/stylebook_api/entities/person/candidates.py
+++ b/apps/stylebook-api/src/stylebook_api/entities/person/candidates.py
@@ -8,6 +8,7 @@ from uuid import UUID
 
 from backfield_auth.gate import require_project_access
 from backfield_db import (
+    BackfieldProject,
     StylebookPersonCanonical,
     SubstrateArticle,
     SubstratePerson,
@@ -39,6 +40,7 @@ from stylebook_api.helpers.candidate_review_display import (
     first_candidate_review_line,
     format_candidate_review_lines,
 )
+from stylebook_api.helpers.candidate_scope import require_candidate_project_in_stylebook
 from stylebook_api.helpers.project_scope import (
     project_by_slug as _project_by_slug,
 )
@@ -46,12 +48,11 @@ from stylebook_api.helpers.project_scope import (
     require_stylebook_id as _require_stylebook_id,
 )
 from stylebook_api.mention_serialization import article_fields_for_linked_mention
-from stylebook_api.stylebook_permissions import require_stylebook_edit_access_by_id
 
 router = APIRouter(prefix="/v1/people", tags=["person-candidates"])
 
 
-def _substrate_list_sort_key():
+def candidate_sort_key():
     return func.coalesce(col(SubstratePerson.sort_key), col(SubstratePerson.normalized_name))
 
 
@@ -80,7 +81,7 @@ class UpdateCandidateNoteBody(BaseModel):
     note: str | None = None
 
 
-def _open_candidate_filters(
+def open_candidate_filters(
     project_id: int,
     *,
     needs_review: bool | None,
@@ -115,7 +116,7 @@ def _open_candidate_filters(
     return filters
 
 
-def _deferred_candidate_filters(
+def deferred_candidate_filters(
     project_id: int, *, q: str | None, type_filter: str | None
 ) -> list[Any]:
     filters: list[Any] = [
@@ -201,7 +202,7 @@ def _extract_review_note(person: SubstratePerson) -> str | None:
     return None
 
 
-def _candidate_dict(person: SubstratePerson) -> dict[str, Any]:
+def serialize_candidate(person: SubstratePerson) -> dict[str, Any]:
     note = _extract_review_note(person)
     sug = _canonical_suggestion_payload(person)
     review_lines = format_candidate_review_lines(person.canonical_review_reasons_json)
@@ -231,6 +232,14 @@ def _candidate_dict(person: SubstratePerson) -> dict[str, Any]:
     return row
 
 
+def _candidate_dict_with_project(
+    person: SubstratePerson, project: BackfieldProject
+) -> dict[str, Any]:
+    row = serialize_candidate(person)
+    row.update(project_slug=project.slug, project_name=project.name)
+    return row
+
+
 def _list_open_candidates(
     session: Session,
     *,
@@ -241,7 +250,7 @@ def _list_open_candidates(
     q: str | None,
     type_filter: str | None,
 ) -> PaginatedCandidatesResponse:
-    filters = _open_candidate_filters(
+    filters = open_candidate_filters(
         project_id,
         needs_review=needs_review,
         q=q,
@@ -252,12 +261,15 @@ def _list_open_candidates(
     stmt = (
         select(SubstratePerson)
         .where(*filters)
-        .order_by(_substrate_list_sort_key().asc(), col(SubstratePerson.id).asc())
+        .order_by(candidate_sort_key().asc(), col(SubstratePerson.id).asc())
         .offset(offset)
         .limit(limit)
     )
     rows = list(session.exec(stmt).all())
-    candidates = [_candidate_dict(r) for r in rows]
+    project = session.get(BackfieldProject, project_id)
+    if project is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+    candidates = [_candidate_dict_with_project(r, project) for r in rows]
     return PaginatedCandidatesResponse(
         candidates=candidates,
         total=total,
@@ -275,18 +287,21 @@ def _list_deferred_candidates(
     q: str | None,
     type_filter: str | None,
 ) -> PaginatedCandidatesResponse:
-    filters = _deferred_candidate_filters(project_id, q=q, type_filter=type_filter)
+    filters = deferred_candidate_filters(project_id, q=q, type_filter=type_filter)
     count_stmt = select(func.count()).select_from(SubstratePerson).where(*filters)
     total = int(session.scalar(count_stmt) or 0)
     stmt = (
         select(SubstratePerson)
         .where(*filters)
-        .order_by(_substrate_list_sort_key().asc(), col(SubstratePerson.id).asc())
+        .order_by(candidate_sort_key().asc(), col(SubstratePerson.id).asc())
         .offset(offset)
         .limit(limit)
     )
     rows = list(session.exec(stmt).all())
-    candidates = [_candidate_dict(r) for r in rows]
+    project = session.get(BackfieldProject, project_id)
+    if project is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+    candidates = [_candidate_dict_with_project(r, project) for r in rows]
     return PaginatedCandidatesResponse(
         candidates=candidates,
         total=total,
@@ -470,14 +485,17 @@ def candidate_update_note(
     auth: dict[str, Any] = Depends(get_auth),
 ) -> dict[str, str]:
     """Attach a short editor note to a review queue item (stored on the person row)."""
-    proj = _project_by_slug(session, project_slug)
-    require_project_access(session, auth, int(proj.id))
-    stylebook_id = _require_stylebook_id(session, proj, stylebook_slug)
-    require_stylebook_edit_access_by_id(session, auth=auth, stylebook_id=stylebook_id)
-
     person = session.get(SubstratePerson, substrate_person_id)
-    if person is None or int(person.project_id) != int(proj.id):
+    if person is None:
         raise HTTPException(status_code=404, detail="Substrate person not found")
+    require_candidate_project_in_stylebook(
+        session,
+        auth=auth,
+        project_id=int(person.project_id),
+        project_slug=project_slug,
+        stylebook_slug=stylebook_slug,
+        require_edit=True,
+    )
     if person.stylebook_person_canonical_id is not None:
         raise HTTPException(status_code=409, detail="Person is already linked to a canonical")
     if str(person.canonical_link_status) not in (CANONICAL_LINK_PENDING, CANONICAL_LINK_WAIVED):
@@ -600,14 +618,17 @@ def defer_candidate(
     auth: dict[str, Any] = Depends(get_auth),
 ) -> dict[str, str]:
     """Defer canonical linking for a substrate row (remove from open queue without linking)."""
-    proj = _project_by_slug(session, project_slug)
-    require_project_access(session, auth, int(proj.id))
-    stylebook_id = _require_stylebook_id(session, proj, stylebook_slug)
-    require_stylebook_edit_access_by_id(session, auth=auth, stylebook_id=stylebook_id)
-
     person = session.get(SubstratePerson, substrate_person_id)
-    if person is None or int(person.project_id) != int(proj.id):
+    if person is None:
         raise HTTPException(status_code=404, detail="Substrate person not found")
+    require_candidate_project_in_stylebook(
+        session,
+        auth=auth,
+        project_id=int(person.project_id),
+        project_slug=project_slug,
+        stylebook_slug=stylebook_slug,
+        require_edit=True,
+    )
     if person.stylebook_person_canonical_id is not None:
         raise HTTPException(status_code=409, detail="Person is already linked to a canonical")
     if person.canonical_link_status != CANONICAL_LINK_PENDING:
@@ -633,14 +654,17 @@ def clear_candidate_recommendation(
     session: Session = Depends(get_session),
     auth: dict[str, Any] = Depends(get_auth),
 ) -> dict[str, str]:
-    proj = _project_by_slug(session, project_slug)
-    require_project_access(session, auth, int(proj.id))
-    stylebook_id = _require_stylebook_id(session, proj, stylebook_slug)
-    require_stylebook_edit_access_by_id(session, auth=auth, stylebook_id=stylebook_id)
-
     person = session.get(SubstratePerson, substrate_person_id)
-    if person is None or int(person.project_id) != int(proj.id):
+    if person is None:
         raise HTTPException(status_code=404, detail="Substrate person not found")
+    require_candidate_project_in_stylebook(
+        session,
+        auth=auth,
+        project_id=int(person.project_id),
+        project_slug=project_slug,
+        stylebook_slug=stylebook_slug,
+        require_edit=True,
+    )
     if person.stylebook_person_canonical_id is not None:
         raise HTTPException(status_code=409, detail="Person is already linked to a canonical")
     if person.canonical_link_status != CANONICAL_LINK_PENDING:
@@ -666,14 +690,18 @@ def accept_candidate(
     session: Session = Depends(get_session),
     auth: dict[str, Any] = Depends(get_auth),
 ) -> AcceptCandidateResponse:
-    proj = _project_by_slug(session, project_slug)
-    require_project_access(session, auth, int(proj.id))
-    stylebook_id = _require_stylebook_id(session, proj, stylebook_slug)
-    require_stylebook_edit_access_by_id(session, auth=auth, stylebook_id=stylebook_id)
-
     person = session.get(SubstratePerson, substrate_person_id)
-    if person is None or int(person.project_id) != int(proj.id):
+    if person is None:
         raise HTTPException(status_code=404, detail="Substrate person not found")
+    _, guarded_stylebook = require_candidate_project_in_stylebook(
+        session,
+        auth=auth,
+        project_id=int(person.project_id),
+        project_slug=project_slug,
+        stylebook_slug=stylebook_slug,
+        require_edit=True,
+    )
+    stylebook_id = int(guarded_stylebook.id)
     if person.stylebook_person_canonical_id is not None:
         raise HTTPException(status_code=409, detail="Person already linked to a canonical")
     if person.canonical_link_status not in (CANONICAL_LINK_PENDING, CANONICAL_LINK_WAIVED):

--- a/apps/stylebook-api/src/stylebook_api/entities/person/people.py
+++ b/apps/stylebook-api/src/stylebook_api/entities/person/people.py
@@ -39,6 +39,7 @@ from sqlmodel import Session, col, func, select
 
 from stylebook_api.catalog_scope import StylebookSlugQuery
 from stylebook_api.deps import get_auth, get_session
+from stylebook_api.helpers.candidate_scope import require_candidate_project_in_stylebook
 from stylebook_api.helpers.project_scope import project_by_slug, require_stylebook_id
 from stylebook_api.mention_occurrences import replace_person_mention_occurrences_for_article
 from stylebook_api.semantic_reindex import (
@@ -88,6 +89,15 @@ def unlink_substrate_from_canonical_route(
     person = session.get(SubstratePerson, person_id)
     if person is None or int(person.project_id) != int(proj.id):
         raise HTTPException(status_code=404, detail="Person not found")
+    _, guarded_stylebook = require_candidate_project_in_stylebook(
+        session,
+        auth=auth,
+        project_id=int(person.project_id),
+        project_slug=project_slug,
+        stylebook_slug=stylebook_slug,
+        require_edit=True,
+    )
+    stylebook_id = int(guarded_stylebook.id)
     try:
         unlink_substrate_from_canonical(
             session, stylebook_id=stylebook_id, person=person, provenance="stylebook_ui_unlink"
@@ -119,6 +129,15 @@ def link_substrate_to_canonical_route(
     person = session.get(SubstratePerson, person_id)
     if person is None or int(person.project_id) != int(proj.id):
         raise HTTPException(status_code=404, detail="Person not found")
+    _, guarded_stylebook = require_candidate_project_in_stylebook(
+        session,
+        auth=auth,
+        project_id=int(person.project_id),
+        project_slug=project_slug,
+        stylebook_slug=stylebook_slug,
+        require_edit=True,
+    )
+    stylebook_id = int(guarded_stylebook.id)
     try:
         changed = link_substrate_to_canonical_atomic(
             session,

--- a/apps/stylebook-api/src/stylebook_api/helpers/candidate_scope.py
+++ b/apps/stylebook-api/src/stylebook_api/helpers/candidate_scope.py
@@ -1,0 +1,50 @@
+"""Authorization boundary for project-owned candidate operations."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from backfield_auth.gate import require_project_access
+from backfield_db import BackfieldProject, Stylebook
+from fastapi import HTTPException
+from sqlmodel import Session
+from stylebook_api.stylebook_permissions import require_stylebook_edit_access_by_id
+from stylebook_api.stylebook_scope import require_stylebook_by_slug_in_auth_org
+
+
+def require_candidate_project_in_stylebook(
+    session: Session,
+    *,
+    auth: dict[str, Any],
+    project_id: int,
+    stylebook_slug: str | None,
+    project_slug: str | None = None,
+    require_edit: bool = False,
+) -> tuple[BackfieldProject, Stylebook]:
+    """Reload and authorize a candidate's project within the requested Stylebook."""
+
+    project = session.get(BackfieldProject, project_id)
+    if project is None or project.id is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+    if project_slug is not None and project.slug != project_slug:
+        raise HTTPException(status_code=404, detail="Candidate not found")
+    require_project_access(session, auth, int(project.id))
+    if stylebook_slug is None:
+        stylebook = session.get(Stylebook, int(project.stylebook_id))
+        if stylebook is None:
+            raise HTTPException(status_code=404, detail="Stylebook not found")
+    else:
+        stylebook = require_stylebook_by_slug_in_auth_org(
+            session,
+            auth=auth,
+            stylebook_slug=stylebook_slug,
+        )
+    if stylebook.id is None or int(project.stylebook_id) != int(stylebook.id):
+        raise HTTPException(status_code=404, detail="Candidate not found")
+    if require_edit:
+        require_stylebook_edit_access_by_id(
+            session,
+            auth=auth,
+            stylebook_id=int(stylebook.id),
+        )
+    return project, stylebook

--- a/apps/stylebook-api/src/stylebook_api/main.py
+++ b/apps/stylebook-api/src/stylebook_api/main.py
@@ -26,6 +26,7 @@ from stylebook_api.routers import (
     stylebook_activity,
     stylebook_bundle_jobs,
     stylebook_candidate_ai_review,
+    stylebook_candidates,
     stylebook_canonicals,
     stylebook_cleanup,
     stylebook_cleanup_ai_review,
@@ -90,6 +91,7 @@ app.include_router(stylebook_canonicals.router)
 app.include_router(stylebook_cleanup.router)
 app.include_router(stylebook_cleanup_ai_review.router)
 app.include_router(stylebook_candidate_ai_review.router)
+app.include_router(stylebook_candidates.router)
 app.include_router(stylebook_person_canonicals.router)
 app.include_router(stylebook_organization_canonicals.router)
 app.include_router(stylebook_permissions.router)

--- a/apps/stylebook-api/src/stylebook_api/routers/stylebook_candidates.py
+++ b/apps/stylebook-api/src/stylebook_api/routers/stylebook_candidates.py
@@ -1,0 +1,292 @@
+"""Combined candidate inboxes for projects assigned to a Stylebook."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, Literal
+
+from backfield_db import (
+    BackfieldProject,
+    SubstrateLocation,
+    SubstrateOrganization,
+    SubstratePerson,
+)
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+from sqlalchemy import and_, or_
+from sqlmodel import Session, col, func, select
+
+from stylebook_api.deps import get_auth, get_session
+from stylebook_api.entities.location import candidates as location_candidates
+from stylebook_api.entities.organization import candidates as organization_candidates
+from stylebook_api.entities.person import candidates as person_candidates
+from stylebook_api.stylebook_scope import (
+    optional_project_filter_to_ids,
+    require_stylebook_by_slug_in_auth_org,
+)
+
+router = APIRouter(prefix="/v1/stylebooks", tags=["stylebook-candidates"])
+
+CandidateEntityType = Literal["locations", "people", "organizations"]
+
+
+class CandidateProjectCount(BaseModel):
+    project_id: int
+    project_slug: str
+    project_name: str
+    count: int
+
+
+class CandidateCountResponse(BaseModel):
+    total: int
+    projects: list[CandidateProjectCount]
+
+
+class PaginatedCandidatesResponse(BaseModel):
+    candidates: list[dict[str, Any]]
+    total: int
+    has_next: bool
+    has_prev: bool
+
+
+class CandidateTypesResponse(BaseModel):
+    types: list[str]
+
+
+def _candidate_spec(
+    entity_type: CandidateEntityType,
+) -> tuple[type[Any], Callable[..., list[Any]], Callable[[Any], dict[str, Any]], Any]:
+    if entity_type == "locations":
+        return (
+            SubstrateLocation,
+            location_candidates.open_candidate_filters,
+            location_candidates.serialize_candidate,
+            col(SubstrateLocation.normalized_name),
+        )
+    if entity_type == "people":
+        return (
+            SubstratePerson,
+            person_candidates.open_candidate_filters,
+            person_candidates.serialize_candidate,
+            person_candidates.candidate_sort_key(),
+        )
+    return (
+        SubstrateOrganization,
+        organization_candidates.open_candidate_filters,
+        organization_candidates.serialize_candidate,
+        organization_candidates.candidate_sort_key(),
+    )
+
+
+def _candidate_filters(
+    *,
+    entity_type: CandidateEntityType,
+    project_ids: list[int],
+    status: str,
+    q: str | None,
+    type_filter: str | None,
+    needs_review: bool | None,
+) -> tuple[type[Any], list[Any], Callable[[Any], dict[str, Any]], Any]:
+    model, open_filters, serializer, sort_column = _candidate_spec(entity_type)
+    if not project_ids:
+        return model, [col(model.id).is_(None)], serializer, sort_column
+    filter_builder = (
+        {
+            "locations": location_candidates.deferred_candidate_filters,
+            "people": person_candidates.deferred_candidate_filters,
+            "organizations": organization_candidates.deferred_candidate_filters,
+        }[entity_type]
+        if status == "deferred"
+        else open_filters
+    )
+    project_filters = []
+    for project_id in project_ids:
+        kwargs: dict[str, Any] = {"q": q, "type_filter": type_filter}
+        if status == "open":
+            kwargs["needs_review"] = needs_review
+        project_filters.append(and_(*filter_builder(project_id, **kwargs)))
+    return model, [or_(*project_filters)], serializer, sort_column
+
+
+def _scope(
+    session: Session,
+    *,
+    auth: dict[str, Any],
+    stylebook_slug: str,
+    project_slug: str | None,
+) -> tuple[list[int], dict[int, BackfieldProject]]:
+    stylebook = require_stylebook_by_slug_in_auth_org(
+        session,
+        auth=auth,
+        stylebook_slug=stylebook_slug,
+    )
+    assert stylebook.id is not None
+    project_ids = optional_project_filter_to_ids(
+        session,
+        auth=auth,
+        project_slug=project_slug,
+        organization_id=int(stylebook.organization_id),
+        stylebook_id=int(stylebook.id),
+    )
+    projects = {
+        int(project.id): project
+        for project in session.exec(
+            select(BackfieldProject).where(col(BackfieldProject.id).in_(project_ids))
+        ).all()
+        if project.id is not None
+    }
+    return project_ids, projects
+
+
+def _validate_status(status: str) -> None:
+    if status not in ("open", "deferred"):
+        raise HTTPException(status_code=400, detail="Only status=open or deferred is supported")
+
+
+@router.get(
+    "/{stylebook_slug}/candidates/{entity_type}",
+    response_model=PaginatedCandidatesResponse,
+)
+def list_candidates(
+    stylebook_slug: str,
+    entity_type: CandidateEntityType,
+    project_slug: str | None = Query(None),
+    status: str = Query("open"),
+    q: str | None = Query(None),
+    type_filter: str | None = Query(None),
+    limit: int = Query(25, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    needs_review: bool | None = Query(None),
+    session: Session = Depends(get_session),
+    auth: dict[str, Any] = Depends(get_auth),
+) -> PaginatedCandidatesResponse:
+    _validate_status(status)
+    project_ids, projects = _scope(
+        session,
+        auth=auth,
+        stylebook_slug=stylebook_slug,
+        project_slug=project_slug,
+    )
+    model, filters, serializer, sort_column = _candidate_filters(
+        entity_type=entity_type,
+        project_ids=project_ids,
+        status=status,
+        q=q,
+        type_filter=type_filter,
+        needs_review=needs_review,
+    )
+    total = int(session.scalar(select(func.count()).select_from(model).where(*filters)) or 0)
+    rows = session.exec(
+        select(model)
+        .where(*filters)
+        .order_by(sort_column.asc(), col(model.id).asc())
+        .offset(offset)
+        .limit(limit)
+    ).all()
+    candidates: list[dict[str, Any]] = []
+    for row in rows:
+        project = projects[int(row.project_id)]
+        payload = serializer(row)
+        payload.update(project_slug=project.slug, project_name=project.name)
+        candidates.append(payload)
+    return PaginatedCandidatesResponse(
+        candidates=candidates,
+        total=total,
+        has_next=offset + len(candidates) < total,
+        has_prev=offset > 0,
+    )
+
+
+@router.get(
+    "/{stylebook_slug}/candidates/{entity_type}/count",
+    response_model=CandidateCountResponse,
+)
+def count_candidates(
+    stylebook_slug: str,
+    entity_type: CandidateEntityType,
+    project_slug: str | None = Query(None),
+    status: str = Query("open"),
+    q: str | None = Query(None),
+    type_filter: str | None = Query(None),
+    needs_review: bool | None = Query(None),
+    session: Session = Depends(get_session),
+    auth: dict[str, Any] = Depends(get_auth),
+) -> CandidateCountResponse:
+    _validate_status(status)
+    project_ids, projects = _scope(
+        session,
+        auth=auth,
+        stylebook_slug=stylebook_slug,
+        project_slug=project_slug,
+    )
+    model, filters, _, _ = _candidate_filters(
+        entity_type=entity_type,
+        project_ids=project_ids,
+        status=status,
+        q=q,
+        type_filter=type_filter,
+        needs_review=needs_review,
+    )
+    rows = session.exec(
+        select(model.project_id, func.count())
+        .where(*filters)
+        .group_by(model.project_id)
+    ).all()
+    counts_by_project = {int(project_id): int(count) for project_id, count in rows}
+    project_counts = [
+        CandidateProjectCount(
+            project_id=project_id,
+            project_slug=project.slug,
+            project_name=project.name,
+            count=counts_by_project.get(project_id, 0),
+        )
+        for project_id, project in sorted(projects.items(), key=lambda item: item[1].name.lower())
+    ]
+    return CandidateCountResponse(
+        total=sum(project.count for project in project_counts),
+        projects=project_counts,
+    )
+
+
+@router.get(
+    "/{stylebook_slug}/candidates/{entity_type}/types",
+    response_model=CandidateTypesResponse,
+)
+def list_candidate_types(
+    stylebook_slug: str,
+    entity_type: CandidateEntityType,
+    project_slug: str | None = Query(None),
+    status: str = Query("open"),
+    session: Session = Depends(get_session),
+    auth: dict[str, Any] = Depends(get_auth),
+) -> CandidateTypesResponse:
+    _validate_status(status)
+    project_ids, _ = _scope(
+        session,
+        auth=auth,
+        stylebook_slug=stylebook_slug,
+        project_slug=project_slug,
+    )
+    model, filters, _, _ = _candidate_filters(
+        entity_type=entity_type,
+        project_ids=project_ids,
+        status=status,
+        q=None,
+        type_filter=None,
+        needs_review=None,
+    )
+    type_column = {
+        "locations": SubstrateLocation.location_type,
+        "people": SubstratePerson.person_type,
+        "organizations": SubstrateOrganization.organization_type,
+    }[entity_type]
+    rows = session.exec(
+        select(func.distinct(type_column)).where(
+            *filters,
+            col(type_column).is_not(None),
+            func.length(func.trim(type_column)) > 0,
+        )
+    ).all()
+    return CandidateTypesResponse(
+        types=sorted({str(value).strip() for value in rows if value is not None})
+    )

--- a/apps/stylebook-api/src/stylebook_api/stylebook_scope.py
+++ b/apps/stylebook-api/src/stylebook_api/stylebook_scope.py
@@ -8,7 +8,7 @@ from backfield_auth.gate import require_project_access, visible_project_ids
 from backfield_db import BackfieldProject, Stylebook
 from backfield_entities.catalog.stylebook_library import resolve_stylebook_by_slug
 from fastapi import HTTPException
-from sqlmodel import Session, select
+from sqlmodel import Session, col, select
 
 
 def require_stylebook_by_slug_in_auth_org(
@@ -41,8 +41,9 @@ def optional_project_filter_to_ids(
     auth: dict[str, Any],
     project_slug: str | None,
     organization_id: int,
+    stylebook_id: int | None = None,
 ) -> list[int]:
-    """Return project ids visible to the caller, optionally narrowed to one project slug."""
+    """Return visible project ids assigned to one Stylebook."""
 
     if project_slug:
         proj = session.exec(
@@ -54,14 +55,16 @@ def optional_project_filter_to_ids(
         if proj is None or proj.id is None:
             raise HTTPException(status_code=404, detail="Project not found")
         require_project_access(session, auth, int(proj.id))
+        if stylebook_id is not None and int(proj.stylebook_id) != stylebook_id:
+            raise HTTPException(status_code=404, detail="Project not found")
         return [int(proj.id)]
 
     visible = visible_project_ids(session, auth)
-    if visible is None:
-        rows = session.exec(
-            select(BackfieldProject.id).where(BackfieldProject.organization_id == organization_id)
-        ).all()
-        return [int(r) for r in rows if r is not None]
-
-    return [int(pid) for pid in visible]
+    filters = [BackfieldProject.organization_id == organization_id]
+    if stylebook_id is not None:
+        filters.append(BackfieldProject.stylebook_id == stylebook_id)
+    if visible is not None:
+        filters.append(col(BackfieldProject.id).in_([int(pid) for pid in visible]))
+    rows = session.exec(select(BackfieldProject.id).where(*filters)).all()
+    return [int(r) for r in rows if r is not None]
 

--- a/apps/stylebook-ui/src/components/CandidateQueuePage.tsx
+++ b/apps/stylebook-ui/src/components/CandidateQueuePage.tsx
@@ -51,7 +51,13 @@ import {
 import Pagination from "@/components/Pagination"
 import { cn } from "@/lib/utils"
 import { candidateQueueNameKey } from "@/lib/candidateQueueSimilarity"
+import { updateCandidateProjectFilter } from "@/lib/candidateQueueState"
 import { isActiveReviewStatus } from "@/lib/cleanupAiReview"
+import {
+  canStartCandidateAiReview,
+  candidateProjectFilterState,
+  candidateProjectOptions,
+} from "@/lib/stylebook-api/stylebookCandidates"
 import { Breadcrumbs } from "@/components/Breadcrumbs"
 import {
   CandidateReviewReasons,
@@ -142,6 +148,7 @@ export function CandidateQueuePage<TCandidate extends QueueCandidateBase>({
   } = page
 
   const aiReviewEnabled = Boolean(config.aiReviewEntityType && stylebookSlug && projectSlug)
+  const aiReviewProjectSelected = canStartCandidateAiReview(projectSlug)
   const [aiReviewDialogOpen, setAiReviewDialogOpen] = useState(false)
   const [stoppingAiReview, setStoppingAiReview] = useState(false)
   const candidateAiReview = useCandidateAiReviewPolling({
@@ -157,6 +164,7 @@ export function CandidateQueuePage<TCandidate extends QueueCandidateBase>({
   )
 
   async function handleAiReviewButtonClick() {
+    if (!aiReviewProjectSelected) return
     if (aiReviewActive) {
       setStoppingAiReview(true)
       try {
@@ -170,6 +178,10 @@ export function CandidateQueuePage<TCandidate extends QueueCandidateBase>({
   }
 
   const LinkModal = config.linkModal
+  const projectFilterState = candidateProjectFilterState(projectSlug, projects)
+  const projectOptions = candidateProjectOptions(projectSlug, projects)
+  const linkModalProjectSlug =
+    candidates.find((candidate) => candidate.id === linkModalId)?.project_slug ?? projectSlug
   const columnCount = config.columns.length + 2
   const tableColgroup = resolveCandidateQueueColgroup(columnCount, config.tableLayout)
   const canonicalBasePath = `${catalogBasePath}/${config.entitySlug}/canonical`
@@ -198,7 +210,12 @@ export function CandidateQueuePage<TCandidate extends QueueCandidateBase>({
     rowActionsBusy ||
     aiReviewActive
   const reviewWithAiDisabled =
-    queueEmpty || loading || rowActionsBusy || candidateAiReview.loading || stoppingAiReview
+    !aiReviewProjectSelected ||
+    queueEmpty ||
+    loading ||
+    rowActionsBusy ||
+    candidateAiReview.loading ||
+    stoppingAiReview
 
   return (
     <div className="container mx-auto p-6 space-y-6">
@@ -242,37 +259,36 @@ export function CandidateQueuePage<TCandidate extends QueueCandidateBase>({
           />
           <h1 className="text-3xl font-bold">{config.copy.pageTitle}</h1>
           <p className="mt-2 text-sm text-muted-foreground">
-            Link candidates from{" "}
+            Review candidates from{" "}
             <span className="font-semibold text-foreground">{projectDisplayName}</span> to Stylebook{" "}
             <span className="font-semibold text-foreground">{stylebookLabel}</span>
           </p>
         </div>
         <div className="flex items-center gap-2">
-          <div className="hidden sm:flex items-center gap-2">
-            <Label className="text-sm text-muted-foreground">Project</Label>
-            <Select
-              value={projectSlug}
-              onValueChange={(slug) => {
-                setSearchParams((prev) => {
-                  const next = new URLSearchParams(prev)
-                  next.set("project_scope", slug)
-                  return next
-                })
-              }}
-              disabled={projectsLoading || projects.length === 0}
-            >
-              <SelectTrigger className="w-[16rem]">
-                <SelectValue placeholder={projectsLoading ? "Loading…" : "Choose a project"} />
-              </SelectTrigger>
-              <SelectContent>
-                {projects.map((p) => (
-                  <SelectItem key={p.id} value={p.slug}>
-                    {p.name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
+          {projectFilterState.visible ? (
+            <div className="hidden sm:flex items-center gap-2">
+              <Label className="text-sm text-muted-foreground">Project</Label>
+              <Select
+                value={projectFilterState.value}
+                onValueChange={(slug) => {
+                  setSearchParams((prev) => updateCandidateProjectFilter(prev, slug))
+                }}
+                disabled={projectsLoading || projects.length === 0}
+              >
+                <SelectTrigger className="w-[16rem]">
+                  <SelectValue placeholder={projectsLoading ? "Loading…" : "Choose a project"} />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">All accessible projects</SelectItem>
+                  {projectOptions.map((project) => (
+                    <SelectItem key={project.project_id} value={project.project_slug}>
+                      {project.project_name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          ) : null}
           <Link to={`${canonicalBasePath}${filterScopeSuffix}`}>
             <Button variant="outline">{config.copy.canonicalButtonLabel}</Button>
           </Link>
@@ -294,6 +310,11 @@ export function CandidateQueuePage<TCandidate extends QueueCandidateBase>({
                       type="button"
                       size="sm"
                       variant={aiReviewActive ? "destructive" : "outline"}
+                      title={
+                        aiReviewProjectSelected
+                          ? undefined
+                          : "Choose a project to review with AI"
+                      }
                       disabled={!aiReviewActive && reviewWithAiDisabled}
                       onClick={() => void handleAiReviewButtonClick()}
                     >
@@ -567,6 +588,9 @@ export function CandidateQueuePage<TCandidate extends QueueCandidateBase>({
                                   </span>
                                 </div>
                               ) : null}
+                              <Badge variant="outline" className="ml-10 font-normal text-xs">
+                                {c.project_name}
+                              </Badge>
                               <CandidateReviewReasons lines={candidateReviewLines(c)} />
                             </div>
                           </TableCell>
@@ -770,7 +794,7 @@ export function CandidateQueuePage<TCandidate extends QueueCandidateBase>({
         onOpenChange={(o) => {
           if (!o) closeLinkModal()
         }}
-        projectSlug={projectSlug}
+        projectSlug={linkModalProjectSlug}
         stylebookSlug={stylebookSlug}
         substrateId={linkModalId}
         initialCanonicalId={linkModalInitialCanonicalId}

--- a/apps/stylebook-ui/src/lib/candidateQueueSimilarity.test.ts
+++ b/apps/stylebook-ui/src/lib/candidateQueueSimilarity.test.ts
@@ -15,21 +15,33 @@ describe("candidateQueueSimilarity", () => {
     const rows = [
       {
         id: 1,
+        project_id: 1,
+        project_slug: "news",
+        project_name: "News",
         canonical_suggestion: { suggested_action: "materialize_new" },
         name: "Ronald Acuña",
       },
       {
         id: 2,
+        project_id: 1,
+        project_slug: "news",
+        project_name: "News",
         canonical_suggestion: { suggested_action: "materialize_new" },
         name: "Ronald Acuña",
       },
       {
         id: 3,
+        project_id: 1,
+        project_slug: "news",
+        project_name: "News",
         canonical_suggestion: { suggested_action: "link_existing" },
         name: "Ronald Acuña",
       },
       {
         id: 4,
+        project_id: 1,
+        project_slug: "news",
+        project_name: "News",
         canonical_suggestion: { suggested_action: "materialize_new" },
         name: "Mike Trout",
       },

--- a/apps/stylebook-ui/src/lib/candidateQueueState.test.ts
+++ b/apps/stylebook-ui/src/lib/candidateQueueState.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest"
+import {
+  CandidateQueueRequestGate,
+  updateCandidateProjectFilter,
+  validCandidateTypeFilter,
+} from "@/lib/candidateQueueState"
+
+describe("CandidateQueueRequestGate", () => {
+  it("rejects responses from an older queue scope", () => {
+    const gate = new CandidateQueueRequestGate()
+    gate.setScope("default|news|open|page-1")
+    const oldRequest = gate.begin("default|news|open|page-1")
+    expect(oldRequest).not.toBeNull()
+
+    gate.setScope("default|sports|open|page-1")
+
+    expect(gate.isCurrent(oldRequest!)).toBe(false)
+    expect(gate.begin("default|news|open|page-1")).toBeNull()
+  })
+
+  it("keeps only the newest request in one scope current", () => {
+    const gate = new CandidateQueueRequestGate()
+    gate.setScope("default|news|open|page-1")
+    const first = gate.begin("default|news|open|page-1")
+    const second = gate.begin("default|news|open|page-1")
+
+    expect(gate.isCurrent(first!)).toBe(false)
+    expect(gate.isCurrent(second!)).toBe(true)
+  })
+})
+
+describe("candidate project navigation", () => {
+  it("preserves workflow scope when setting and clearing evidence filters", () => {
+    const initial = new URLSearchParams("project_scope=workflow&project=news&tab=review")
+
+    const selected = updateCandidateProjectFilter(initial, "sports")
+    expect(selected.toString()).toBe("project_scope=workflow&project=sports&tab=review")
+
+    const all = updateCandidateProjectFilter(selected, "all")
+    expect(all.toString()).toBe("project_scope=workflow&tab=review")
+  })
+})
+
+describe("candidate type filters", () => {
+  it("resets a selection that is unavailable in the new scope", () => {
+    expect(validCandidateTypeFilter("county", ["city", "county"])).toBe("county")
+    expect(validCandidateTypeFilter("county", ["city"])).toBe("all")
+    expect(validCandidateTypeFilter("all", [])).toBe("all")
+  })
+})

--- a/apps/stylebook-ui/src/lib/candidateQueueState.ts
+++ b/apps/stylebook-ui/src/lib/candidateQueueState.ts
@@ -1,0 +1,43 @@
+export type CandidateQueueRequestToken = {
+  scopeKey: string
+  generation: number
+}
+
+export class CandidateQueueRequestGate {
+  private scopeKey = ""
+  private generation = 0
+
+  setScope(scopeKey: string): void {
+    if (scopeKey === this.scopeKey) return
+    this.scopeKey = scopeKey
+    this.generation += 1
+  }
+
+  begin(scopeKey: string): CandidateQueueRequestToken | null {
+    if (scopeKey !== this.scopeKey) return null
+    this.generation += 1
+    return { scopeKey, generation: this.generation }
+  }
+
+  isCurrent(token: CandidateQueueRequestToken): boolean {
+    return token.scopeKey === this.scopeKey && token.generation === this.generation
+  }
+}
+
+export function updateCandidateProjectFilter(
+  current: URLSearchParams,
+  projectSlug: string,
+): URLSearchParams {
+  const next = new URLSearchParams(current)
+  if (projectSlug === "all") next.delete("project")
+  else next.set("project", projectSlug)
+  return next
+}
+
+export function validCandidateTypeFilter(
+  current: string,
+  availableTypes: string[],
+): string {
+  if (current === "all" || availableTypes.includes(current)) return current
+  return "all"
+}

--- a/apps/stylebook-ui/src/lib/entityConfigs/candidateQueueTypes.ts
+++ b/apps/stylebook-ui/src/lib/entityConfigs/candidateQueueTypes.ts
@@ -5,6 +5,9 @@ import type { LinkPickTableRow } from "@/components/LinkPickTable"
 /** Base candidate shape both entity types satisfy for queue behavior. */
 export type QueueCandidateBase = {
   id: number
+  project_id: number
+  project_slug: string
+  project_name: string
   suggested_name?: string
   suggested_type?: string | null
   created_at?: string | null
@@ -32,19 +35,53 @@ export type CandidateContextResult = {
 
 export type CandidateQueueApiAdapter<TCandidate extends QueueCandidateBase> = {
   list: (
-    projectSlug: string,
+    stylebookSlug: string,
+    projectSlug: string | undefined,
     status: CandidateQueueStatus,
     options: { limit: number; offset: number; q?: string; type_filter?: string },
   ) => Promise<PaginatedListResult<TCandidate>>
 
-  listTypes?: (projectSlug: string, status: CandidateQueueStatus) => Promise<{ types: string[] }>
+  count: (
+    stylebookSlug: string,
+    projectSlug: string | undefined,
+    status: CandidateQueueStatus,
+    options: { q?: string; type_filter?: string },
+  ) => Promise<{
+    total: number
+    projects: Array<{
+      project_id: number
+      project_slug: string
+      project_name: string
+      count: number
+    }>
+  }>
+
+  listTypes?: (
+    stylebookSlug: string,
+    projectSlug: string | undefined,
+    status: CandidateQueueStatus,
+  ) => Promise<{ types: string[] }>
 
   getContext: (projectSlug: string, candidateId: number, limit: number) => Promise<CandidateContextResult>
 
-  defer: (projectSlug: string, candidateId: number) => Promise<void>
-  clearRecommendation: (projectSlug: string, candidateId: number) => Promise<void>
-  updateNote: (projectSlug: string, candidateId: number, note: string | null) => Promise<void>
-  linkToCanonical: (candidateId: number, projectSlug: string, canonicalId: string) => Promise<void>
+  defer: (projectSlug: string, candidateId: number, stylebookSlug: string) => Promise<void>
+  clearRecommendation: (
+    projectSlug: string,
+    candidateId: number,
+    stylebookSlug: string,
+  ) => Promise<void>
+  updateNote: (
+    projectSlug: string,
+    candidateId: number,
+    note: string | null,
+    stylebookSlug: string,
+  ) => Promise<void>
+  linkToCanonical: (
+    candidateId: number,
+    projectSlug: string,
+    canonicalId: string,
+    stylebookSlug: string,
+  ) => Promise<void>
 
   getSuggestedCanonicalId: (candidate: TCandidate) => string | null
   getSuggestedCanonicals: (
@@ -58,6 +95,7 @@ export type CandidateQueueApiAdapter<TCandidate extends QueueCandidateBase> = {
     projectSlug: string,
     candidateId: number,
     body: unknown,
+    stylebookSlug: string,
   ) => Promise<{ canonicalId: string }>
 }
 

--- a/apps/stylebook-ui/src/lib/entityConfigs/location/candidateQueue.tsx
+++ b/apps/stylebook-ui/src/lib/entityConfigs/location/candidateQueue.tsx
@@ -7,8 +7,6 @@ import {
   getCanonicalLocation,
   getSuggestedCanonicals,
   linkSubstrateToCanonical,
-  listCandidates,
-  listLocationCandidateTypes,
   updateCandidateNote,
 } from "@/lib/api"
 import {
@@ -28,6 +26,11 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import type { CandidateQueueLinkModalProps, CandidateQueuePageConfig } from "@/lib/entityConfigs/candidateQueueTypes"
+import {
+  countStylebookCandidates,
+  listStylebookCandidateTypes,
+  listStylebookCandidates,
+} from "@/lib/stylebook-api/stylebookCandidates"
 
 function LocationLinkModal({
   substrateId,
@@ -73,7 +76,7 @@ export const locationCandidateQueueConfig: CandidateQueuePageConfig<Candidate> =
     breadcrumbEntityLabel: "Locations",
     canonicalButtonLabel: "Canonical locations",
     reviewQueueDescription:
-      "Unlinked locations for this project. Use “Link” to attach to an existing canonical, or “Create new” to add a new one.",
+      "Unlinked locations from projects using this Stylebook. Link an existing location or create a new one.",
     searchInputId: "candidate-search",
     searchPlaceholder: "Search name…",
     emptyState: "No unlinked locations.",
@@ -119,8 +122,11 @@ export const locationCandidateQueueConfig: CandidateQueuePageConfig<Candidate> =
   },
 
   api: {
-    list: async (projectSlug, status, options) => {
-      const res = await listCandidates(projectSlug, status, false, options)
+    list: async (stylebookSlug, projectSlug, status, options) => {
+      const res = await listStylebookCandidates<Candidate>(stylebookSlug, "locations", status, {
+        ...options,
+        project_slug: projectSlug,
+      })
       return {
         candidates: res.candidates,
         total: res.total,
@@ -128,19 +134,25 @@ export const locationCandidateQueueConfig: CandidateQueuePageConfig<Candidate> =
         has_prev: res.has_prev,
       }
     },
-    listTypes: listLocationCandidateTypes,
+    count: (stylebookSlug, projectSlug, status, options) =>
+      countStylebookCandidates(stylebookSlug, "locations", status, {
+        ...options,
+        project_slug: projectSlug,
+      }),
+    listTypes: (stylebookSlug, projectSlug, status) =>
+      listStylebookCandidateTypes(stylebookSlug, "locations", projectSlug, status),
     getContext: getCandidateContext,
-    defer: async (projectSlug, candidateId) => {
-      await deferCandidate(projectSlug, candidateId)
+    defer: async (projectSlug, candidateId, stylebookSlug) => {
+      await deferCandidate(projectSlug, candidateId, stylebookSlug)
     },
-    clearRecommendation: async (projectSlug, candidateId) => {
-      await clearLocationCandidateRecommendation(projectSlug, candidateId)
+    clearRecommendation: async (projectSlug, candidateId, stylebookSlug) => {
+      await clearLocationCandidateRecommendation(projectSlug, candidateId, stylebookSlug)
     },
-    updateNote: async (projectSlug, candidateId, note) => {
-      await updateCandidateNote(projectSlug, candidateId, note)
+    updateNote: async (projectSlug, candidateId, note, stylebookSlug) => {
+      await updateCandidateNote(projectSlug, candidateId, note, stylebookSlug)
     },
-    linkToCanonical: async (candidateId, projectSlug, canonicalId) => {
-      await linkSubstrateToCanonical(candidateId, projectSlug, canonicalId)
+    linkToCanonical: async (candidateId, projectSlug, canonicalId, stylebookSlug) => {
+      await linkSubstrateToCanonical(candidateId, projectSlug, canonicalId, stylebookSlug)
     },
     getSuggestedCanonicalId: (c) => {
       const cid = (c.canonical_suggestion?.stylebook_location_canonical_id ?? "").trim()
@@ -159,11 +171,12 @@ export const locationCandidateQueueConfig: CandidateQueuePageConfig<Candidate> =
       const canon = await getCanonicalLocation(canonicalId, stylebookSlug, projectSlug)
       return (canon.label ?? "").trim() || canonicalId
     },
-    acceptCreateNew: async (projectSlug, candidateId, body) => {
+    acceptCreateNew: async (projectSlug, candidateId, body, stylebookSlug) => {
       const acceptRes = await acceptCandidate(
         projectSlug,
         candidateId,
         body as Parameters<typeof acceptCandidate>[2],
+        stylebookSlug,
       )
       const cid = acceptRes.stylebook_location_canonical_id
       return { canonicalId: typeof cid === "string" ? cid : "" }

--- a/apps/stylebook-ui/src/lib/entityConfigs/organization/candidateQueue.tsx
+++ b/apps/stylebook-ui/src/lib/entityConfigs/organization/candidateQueue.tsx
@@ -7,7 +7,6 @@ import {
   getOrganizationCandidateContext,
   getSuggestedOrganizationCanonicals,
   linkOrganizationSubstrateToCanonical,
-  listOrganizationCandidates,
   updateOrganizationCandidateNote,
 } from "@/lib/api"
 import { placeExtractTypeLabel } from "@/lib/place-extract-type-label"
@@ -16,6 +15,10 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import type { CandidateQueueLinkModalProps, CandidateQueuePageConfig } from "@/lib/entityConfigs/candidateQueueTypes"
 import { truncateCellText } from "@/lib/candidateQueueTableLayout"
+import {
+  countStylebookCandidates,
+  listStylebookCandidates,
+} from "@/lib/stylebook-api/stylebookCandidates"
 
 function OrganizationLinkModal({
   substrateId,
@@ -47,7 +50,7 @@ export const organizationCandidateQueueConfig: CandidateQueuePageConfig<Organiza
     breadcrumbEntityLabel: "Organizations",
     canonicalButtonLabel: "Canonical organizations",
     reviewQueueDescription:
-      "Unlinked organizations for this project. Use Link to attach to an existing organization, or Create new to add one.",
+      "Unlinked organizations from projects using this Stylebook. Link an existing organization or create a new one.",
     searchInputId: "organization-candidate-search",
     searchPlaceholder: "Search name…",
     emptyState: "No unlinked organizations.",
@@ -95,8 +98,13 @@ export const organizationCandidateQueueConfig: CandidateQueuePageConfig<Organiza
   },
 
   api: {
-    list: async (projectSlug, status, options) => {
-      const res = await listOrganizationCandidates(projectSlug, status, options)
+    list: async (stylebookSlug, projectSlug, status, options) => {
+      const res = await listStylebookCandidates<OrganizationCandidate>(
+        stylebookSlug,
+        "organizations",
+        status,
+        { ...options, project_slug: projectSlug },
+      )
       return {
         candidates: res.candidates,
         total: res.total,
@@ -104,18 +112,28 @@ export const organizationCandidateQueueConfig: CandidateQueuePageConfig<Organiza
         has_prev: res.has_prev,
       }
     },
+    count: (stylebookSlug, projectSlug, status, options) =>
+      countStylebookCandidates(stylebookSlug, "organizations", status, {
+        ...options,
+        project_slug: projectSlug,
+      }),
     getContext: getOrganizationCandidateContext,
-    defer: async (projectSlug, candidateId) => {
-      await deferOrganizationCandidate(projectSlug, candidateId)
+    defer: async (projectSlug, candidateId, stylebookSlug) => {
+      await deferOrganizationCandidate(projectSlug, candidateId, stylebookSlug)
     },
-    clearRecommendation: async (projectSlug, candidateId) => {
-      await clearOrganizationCandidateRecommendation(projectSlug, candidateId)
+    clearRecommendation: async (projectSlug, candidateId, stylebookSlug) => {
+      await clearOrganizationCandidateRecommendation(projectSlug, candidateId, stylebookSlug)
     },
-    updateNote: async (projectSlug, candidateId, note) => {
-      await updateOrganizationCandidateNote(projectSlug, candidateId, note)
+    updateNote: async (projectSlug, candidateId, note, stylebookSlug) => {
+      await updateOrganizationCandidateNote(projectSlug, candidateId, note, stylebookSlug)
     },
-    linkToCanonical: async (candidateId, projectSlug, canonicalId) => {
-      await linkOrganizationSubstrateToCanonical(candidateId, projectSlug, canonicalId)
+    linkToCanonical: async (candidateId, projectSlug, canonicalId, stylebookSlug) => {
+      await linkOrganizationSubstrateToCanonical(
+        candidateId,
+        projectSlug,
+        canonicalId,
+        stylebookSlug,
+      )
     },
     getSuggestedCanonicalId: (c) => {
       const cid = (c.canonical_suggestion?.stylebook_organization_canonical_id ?? "").trim()
@@ -134,11 +152,12 @@ export const organizationCandidateQueueConfig: CandidateQueuePageConfig<Organiza
       const canon = await getCanonicalOrganization(canonicalId, stylebookSlug, projectSlug)
       return (canon.label ?? "").trim() || canonicalId
     },
-    acceptCreateNew: async (projectSlug, candidateId, body) => {
+    acceptCreateNew: async (projectSlug, candidateId, body, stylebookSlug) => {
       const acceptRes = await acceptOrganizationCandidate(
         projectSlug,
         candidateId,
         body as Parameters<typeof acceptOrganizationCandidate>[2],
+        stylebookSlug,
       )
       const cid = acceptRes.stylebook_organization_canonical_id
       return { canonicalId: typeof cid === "string" ? cid.trim() : "" }

--- a/apps/stylebook-ui/src/lib/entityConfigs/person/candidateQueue.tsx
+++ b/apps/stylebook-ui/src/lib/entityConfigs/person/candidateQueue.tsx
@@ -7,7 +7,6 @@ import {
   getPersonCandidateContext,
   getSuggestedPersonCanonicals,
   linkPersonSubstrateToCanonical,
-  listPersonCandidates,
   updatePersonCandidateNote,
 } from "@/lib/api"
 import { placeExtractTypeLabel } from "@/lib/place-extract-type-label"
@@ -17,6 +16,10 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import type { CandidateQueueLinkModalProps, CandidateQueuePageConfig } from "@/lib/entityConfigs/candidateQueueTypes"
 import { truncateCellText } from "@/lib/candidateQueueTableLayout"
+import {
+  countStylebookCandidates,
+  listStylebookCandidates,
+} from "@/lib/stylebook-api/stylebookCandidates"
 
 function PersonLinkModal({
   substrateId,
@@ -55,7 +58,7 @@ export const personCandidateQueueConfig: CandidateQueuePageConfig<PersonCandidat
     breadcrumbEntityLabel: "People",
     canonicalButtonLabel: "Canonical people",
     reviewQueueDescription:
-      "Unlinked people for this project. Use Link to attach to an existing person, or Create new to add one.",
+      "Unlinked people from projects using this Stylebook. Link an existing person or create a new one.",
     searchInputId: "person-candidate-search",
     searchPlaceholder: "Search name…",
     emptyState: "No unlinked people.",
@@ -103,8 +106,13 @@ export const personCandidateQueueConfig: CandidateQueuePageConfig<PersonCandidat
   },
 
   api: {
-    list: async (projectSlug, status, options) => {
-      const res = await listPersonCandidates(projectSlug, status, options)
+    list: async (stylebookSlug, projectSlug, status, options) => {
+      const res = await listStylebookCandidates<PersonCandidate>(
+        stylebookSlug,
+        "people",
+        status,
+        { ...options, project_slug: projectSlug },
+      )
       return {
         candidates: res.candidates,
         total: res.total,
@@ -112,18 +120,28 @@ export const personCandidateQueueConfig: CandidateQueuePageConfig<PersonCandidat
         has_prev: res.has_prev,
       }
     },
+    count: (stylebookSlug, projectSlug, status, options) =>
+      countStylebookCandidates(stylebookSlug, "people", status, {
+        ...options,
+        project_slug: projectSlug,
+      }),
     getContext: getPersonCandidateContext,
-    defer: async (projectSlug, candidateId) => {
-      await deferPersonCandidate(projectSlug, candidateId)
+    defer: async (projectSlug, candidateId, stylebookSlug) => {
+      await deferPersonCandidate(projectSlug, candidateId, stylebookSlug)
     },
-    clearRecommendation: async (projectSlug, candidateId) => {
-      await clearPersonCandidateRecommendation(projectSlug, candidateId)
+    clearRecommendation: async (projectSlug, candidateId, stylebookSlug) => {
+      await clearPersonCandidateRecommendation(projectSlug, candidateId, stylebookSlug)
     },
-    updateNote: async (projectSlug, candidateId, note) => {
-      await updatePersonCandidateNote(projectSlug, candidateId, note)
+    updateNote: async (projectSlug, candidateId, note, stylebookSlug) => {
+      await updatePersonCandidateNote(projectSlug, candidateId, note, stylebookSlug)
     },
-    linkToCanonical: async (candidateId, projectSlug, canonicalId) => {
-      await linkPersonSubstrateToCanonical(candidateId, projectSlug, canonicalId)
+    linkToCanonical: async (candidateId, projectSlug, canonicalId, stylebookSlug) => {
+      await linkPersonSubstrateToCanonical(
+        candidateId,
+        projectSlug,
+        canonicalId,
+        stylebookSlug,
+      )
     },
     getSuggestedCanonicalId: (c) => {
       const cid = (c.canonical_suggestion?.stylebook_person_canonical_id ?? "").trim()
@@ -142,11 +160,12 @@ export const personCandidateQueueConfig: CandidateQueuePageConfig<PersonCandidat
       const canon = await getCanonicalPerson(canonicalId, stylebookSlug, projectSlug)
       return (canon.label ?? "").trim() || canonicalId
     },
-    acceptCreateNew: async (projectSlug, candidateId, body) => {
+    acceptCreateNew: async (projectSlug, candidateId, body, stylebookSlug) => {
       const acceptRes = await acceptPersonCandidate(
         projectSlug,
         candidateId,
         body as Parameters<typeof acceptPersonCandidate>[2],
+        stylebookSlug,
       )
       const cid = acceptRes.stylebook_person_canonical_id
       return { canonicalId: typeof cid === "string" ? cid.trim() : "" }

--- a/apps/stylebook-ui/src/lib/stylebook-api/candidates.ts
+++ b/apps/stylebook-ui/src/lib/stylebook-api/candidates.ts
@@ -13,6 +13,8 @@ export interface CanonicalSuggestion {
 export interface Candidate {
   id: number
   project_id: number
+  project_slug: string
+  project_name: string
   suggested_name?: string
   suggested_type?: string
   suggested_formatted_address?: string | null
@@ -127,8 +129,10 @@ export async function acceptCandidate(
   projectSlug: string,
   substrateLocationId: number,
   body: AcceptCandidateBody,
+  stylebookSlug?: string,
 ): Promise<AcceptCandidateResponse> {
   const params = new URLSearchParams({ project_slug: projectSlug })
+  if (stylebookSlug) params.set("stylebook_slug", stylebookSlug)
   return stylebookJsonFetch<AcceptCandidateResponse>(
     `/v1/candidates/${substrateLocationId}/accept?${params}`,
     {
@@ -141,8 +145,10 @@ export async function acceptCandidate(
 export async function deferCandidate(
   projectSlug: string,
   substrateLocationId: number,
+  stylebookSlug?: string,
 ): Promise<{ message: string }> {
   const params = new URLSearchParams({ project_slug: projectSlug })
+  if (stylebookSlug) params.set("stylebook_slug", stylebookSlug)
   return stylebookJsonFetch<{ message: string }>(
     `/v1/candidates/${substrateLocationId}/defer?${params}`,
     { method: "POST" },
@@ -152,8 +158,10 @@ export async function deferCandidate(
 export async function clearLocationCandidateRecommendation(
   projectSlug: string,
   substrateLocationId: number,
+  stylebookSlug?: string,
 ): Promise<{ message: string }> {
   const params = new URLSearchParams({ project_slug: projectSlug })
+  if (stylebookSlug) params.set("stylebook_slug", stylebookSlug)
   return stylebookJsonFetch<{ message: string }>(
     `/v1/candidates/${substrateLocationId}/clear-recommendation?${params}`,
     { method: "POST" },
@@ -192,8 +200,10 @@ export async function updateCandidateNote(
   projectSlug: string,
   substrateLocationId: number,
   note: string | null,
+  stylebookSlug?: string,
 ): Promise<{ message: string }> {
   const params = new URLSearchParams({ project_slug: projectSlug })
+  if (stylebookSlug) params.set("stylebook_slug", stylebookSlug)
   return stylebookJsonFetch<{ message: string }>(
     `/v1/candidates/${substrateLocationId}/note?${params}`,
     { method: "POST", body: JSON.stringify({ note }) },

--- a/apps/stylebook-ui/src/lib/stylebook-api/locations.ts
+++ b/apps/stylebook-ui/src/lib/stylebook-api/locations.ts
@@ -179,9 +179,12 @@ export async function linkSubstrateToCanonical(
   substrateLocationId: number,
   projectSlug: string,
   stylebookLocationCanonicalId: string,
+  stylebookSlug?: string,
 ): Promise<{ changed: boolean }> {
+  const params = new URLSearchParams({ project_slug: projectSlug })
+  if (stylebookSlug) params.set("stylebook_slug", stylebookSlug)
   return stylebookJsonFetch<{ changed: boolean }>(
-    `/v1/locations/${substrateLocationId}/link-canonical?project_slug=${encodeURIComponent(projectSlug)}`,
+    `/v1/locations/${substrateLocationId}/link-canonical?${params}`,
     {
       method: "POST",
       body: JSON.stringify({ stylebook_location_canonical_id: stylebookLocationCanonicalId }),

--- a/apps/stylebook-ui/src/lib/stylebook-api/organizationCandidates.ts
+++ b/apps/stylebook-ui/src/lib/stylebook-api/organizationCandidates.ts
@@ -13,6 +13,8 @@ export interface OrganizationCanonicalSuggestion {
 export interface OrganizationCandidate {
   id: number
   project_id: number
+  project_slug: string
+  project_name: string
   suggested_name?: string
   suggested_type?: string | null
   created_at?: string | null
@@ -91,8 +93,10 @@ export async function acceptOrganizationCandidate(
   projectSlug: string,
   substrateOrganizationId: number,
   body: AcceptOrganizationCandidateBody,
+  stylebookSlug?: string,
 ): Promise<AcceptOrganizationCandidateResponse> {
   const params = new URLSearchParams({ project_slug: projectSlug })
+  if (stylebookSlug) params.set("stylebook_slug", stylebookSlug)
   return stylebookJsonFetch<AcceptOrganizationCandidateResponse>(
     `/v1/organizations/candidates/${substrateOrganizationId}/accept?${params}`,
     {
@@ -105,8 +109,10 @@ export async function acceptOrganizationCandidate(
 export async function deferOrganizationCandidate(
   projectSlug: string,
   substrateOrganizationId: number,
+  stylebookSlug?: string,
 ): Promise<{ message: string }> {
   const params = new URLSearchParams({ project_slug: projectSlug })
+  if (stylebookSlug) params.set("stylebook_slug", stylebookSlug)
   return stylebookJsonFetch<{ message: string }>(
     `/v1/organizations/candidates/${substrateOrganizationId}/defer?${params}`,
     { method: "POST" },
@@ -116,8 +122,10 @@ export async function deferOrganizationCandidate(
 export async function clearOrganizationCandidateRecommendation(
   projectSlug: string,
   substrateOrganizationId: number,
+  stylebookSlug?: string,
 ): Promise<{ message: string }> {
   const params = new URLSearchParams({ project_slug: projectSlug })
+  if (stylebookSlug) params.set("stylebook_slug", stylebookSlug)
   return stylebookJsonFetch<{ message: string }>(
     `/v1/organizations/candidates/${substrateOrganizationId}/clear-recommendation?${params}`,
     { method: "POST" },
@@ -156,8 +164,10 @@ export async function updateOrganizationCandidateNote(
   projectSlug: string,
   substrateOrganizationId: number,
   note: string | null,
+  stylebookSlug?: string,
 ): Promise<{ message: string }> {
   const params = new URLSearchParams({ project_slug: projectSlug })
+  if (stylebookSlug) params.set("stylebook_slug", stylebookSlug)
   return stylebookJsonFetch<{ message: string }>(
     `/v1/organizations/candidates/${substrateOrganizationId}/note?${params}`,
     { method: "POST", body: JSON.stringify({ note }) },

--- a/apps/stylebook-ui/src/lib/stylebook-api/organizations.ts
+++ b/apps/stylebook-ui/src/lib/stylebook-api/organizations.ts
@@ -185,9 +185,12 @@ export async function linkOrganizationSubstrateToCanonical(
   substrateOrganizationId: number,
   projectSlug: string,
   stylebookOrganizationCanonicalId: string,
+  stylebookSlug?: string,
 ): Promise<{ changed: boolean }> {
+  const params = new URLSearchParams({ project_slug: projectSlug })
+  if (stylebookSlug) params.set("stylebook_slug", stylebookSlug)
   return stylebookJsonFetch<{ changed: boolean }>(
-    `/v1/organizations/${substrateOrganizationId}/link-canonical?project_slug=${encodeURIComponent(projectSlug)}`,
+    `/v1/organizations/${substrateOrganizationId}/link-canonical?${params}`,
     {
       method: "POST",
       body: JSON.stringify({

--- a/apps/stylebook-ui/src/lib/stylebook-api/people.ts
+++ b/apps/stylebook-ui/src/lib/stylebook-api/people.ts
@@ -207,9 +207,12 @@ export async function linkPersonSubstrateToCanonical(
   substratePersonId: number,
   projectSlug: string,
   stylebookPersonCanonicalId: string,
+  stylebookSlug?: string,
 ): Promise<{ changed: boolean }> {
+  const params = new URLSearchParams({ project_slug: projectSlug })
+  if (stylebookSlug) params.set("stylebook_slug", stylebookSlug)
   return stylebookJsonFetch<{ changed: boolean }>(
-    `/v1/people/${substratePersonId}/link-canonical?project_slug=${encodeURIComponent(projectSlug)}`,
+    `/v1/people/${substratePersonId}/link-canonical?${params}`,
     {
       method: "POST",
       body: JSON.stringify({ stylebook_person_canonical_id: stylebookPersonCanonicalId }),

--- a/apps/stylebook-ui/src/lib/stylebook-api/personCandidates.ts
+++ b/apps/stylebook-ui/src/lib/stylebook-api/personCandidates.ts
@@ -13,6 +13,8 @@ export interface PersonCanonicalSuggestion {
 export interface PersonCandidate {
   id: number
   project_id: number
+  project_slug: string
+  project_name: string
   suggested_name?: string
   suggested_title?: string | null
   suggested_affiliation?: string | null
@@ -96,8 +98,10 @@ export async function acceptPersonCandidate(
   projectSlug: string,
   substratePersonId: number,
   body: AcceptPersonCandidateBody,
+  stylebookSlug?: string,
 ): Promise<AcceptPersonCandidateResponse> {
   const params = new URLSearchParams({ project_slug: projectSlug })
+  if (stylebookSlug) params.set("stylebook_slug", stylebookSlug)
   return stylebookJsonFetch<AcceptPersonCandidateResponse>(
     `/v1/people/candidates/${substratePersonId}/accept?${params}`,
     {
@@ -110,8 +114,10 @@ export async function acceptPersonCandidate(
 export async function deferPersonCandidate(
   projectSlug: string,
   substratePersonId: number,
+  stylebookSlug?: string,
 ): Promise<{ message: string }> {
   const params = new URLSearchParams({ project_slug: projectSlug })
+  if (stylebookSlug) params.set("stylebook_slug", stylebookSlug)
   return stylebookJsonFetch<{ message: string }>(
     `/v1/people/candidates/${substratePersonId}/defer?${params}`,
     { method: "POST" },
@@ -121,8 +127,10 @@ export async function deferPersonCandidate(
 export async function clearPersonCandidateRecommendation(
   projectSlug: string,
   substratePersonId: number,
+  stylebookSlug?: string,
 ): Promise<{ message: string }> {
   const params = new URLSearchParams({ project_slug: projectSlug })
+  if (stylebookSlug) params.set("stylebook_slug", stylebookSlug)
   return stylebookJsonFetch<{ message: string }>(
     `/v1/people/candidates/${substratePersonId}/clear-recommendation?${params}`,
     { method: "POST" },
@@ -161,8 +169,10 @@ export async function updatePersonCandidateNote(
   projectSlug: string,
   substratePersonId: number,
   note: string | null,
+  stylebookSlug?: string,
 ): Promise<{ message: string }> {
   const params = new URLSearchParams({ project_slug: projectSlug })
+  if (stylebookSlug) params.set("stylebook_slug", stylebookSlug)
   return stylebookJsonFetch<{ message: string }>(
     `/v1/people/candidates/${substratePersonId}/note?${params}`,
     { method: "POST", body: JSON.stringify({ note }) },

--- a/apps/stylebook-ui/src/lib/stylebook-api/stylebookCandidates.test.ts
+++ b/apps/stylebook-ui/src/lib/stylebook-api/stylebookCandidates.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest"
+import {
+  canStartCandidateAiReview,
+  candidateProjectFilterState,
+  candidateProjectOptions,
+} from "@/lib/stylebook-api/stylebookCandidates"
+
+describe("candidate project filter", () => {
+  it("defaults to all accessible projects", () => {
+    expect(
+      candidateProjectFilterState("", [
+        { project_id: 1, project_slug: "news", project_name: "News", count: 2 },
+        { project_id: 2, project_slug: "sports", project_name: "Sports", count: 1 },
+      ]),
+    ).toEqual({ value: "all", visible: true })
+  })
+
+  it("hides the filter when only one project contributes", () => {
+    expect(
+      candidateProjectFilterState("", [
+        { project_id: 1, project_slug: "news", project_name: "News", count: 2 },
+        { project_id: 2, project_slug: "sports", project_name: "Sports", count: 0 },
+      ]),
+    ).toEqual({ value: "all", visible: false })
+  })
+
+  it("keeps a selected zero-result project filter visible", () => {
+    const projects = [
+      { project_id: 1, project_slug: "news", project_name: "News", count: 2 },
+      { project_id: 2, project_slug: "sports", project_name: "Sports", count: 0 },
+    ]
+    expect(candidateProjectFilterState("sports", projects)).toEqual({
+      value: "sports",
+      visible: true,
+    })
+    expect(
+      candidateProjectOptions("sports", projects).map((project) => project.project_slug),
+    ).toEqual(["news", "sports"])
+  })
+
+  it("requires a selected project for AI review", () => {
+    expect(canStartCandidateAiReview("")).toBe(false)
+    expect(canStartCandidateAiReview("news")).toBe(true)
+  })
+})

--- a/apps/stylebook-ui/src/lib/stylebook-api/stylebookCandidates.ts
+++ b/apps/stylebook-ui/src/lib/stylebook-api/stylebookCandidates.ts
@@ -1,0 +1,97 @@
+import { stylebookJsonFetch } from "@/lib/stylebook-api/client"
+
+export type CandidateEntityType = "locations" | "people" | "organizations"
+
+export type CandidateProjectCount = {
+  project_id: number
+  project_slug: string
+  project_name: string
+  count: number
+}
+
+export type CandidateCountResponse = {
+  total: number
+  projects: CandidateProjectCount[]
+}
+
+export function candidateProjectFilterState(
+  projectSlug: string,
+  projects: CandidateProjectCount[],
+): { value: string; visible: boolean } {
+  return {
+    value: projectSlug || "all",
+    visible:
+      projectSlug.trim().length > 0 ||
+      projects.filter((project) => project.count > 0).length > 1,
+  }
+}
+
+export function candidateProjectOptions(
+  projectSlug: string,
+  projects: CandidateProjectCount[],
+): CandidateProjectCount[] {
+  return projects.filter(
+    (project) => project.count > 0 || project.project_slug === projectSlug,
+  )
+}
+
+export function canStartCandidateAiReview(projectSlug: string): boolean {
+  return projectSlug.trim().length > 0
+}
+
+export type StylebookCandidateFilters = {
+  project_slug?: string
+  type_filter?: string
+  q?: string
+  limit?: number
+  offset?: number
+  needs_review?: boolean
+}
+
+function candidateParams(
+  status: string,
+  filters?: StylebookCandidateFilters,
+): URLSearchParams {
+  const params = new URLSearchParams({ status })
+  if (!filters) return params
+  for (const [key, value] of Object.entries(filters)) {
+    if (value !== undefined && value !== "") params.set(key, String(value))
+  }
+  return params
+}
+
+export async function listStylebookCandidates<TCandidate>(
+  stylebookSlug: string,
+  entityType: CandidateEntityType,
+  status: string,
+  filters?: StylebookCandidateFilters,
+): Promise<{ candidates: TCandidate[]; total: number; has_next: boolean; has_prev: boolean }> {
+  const params = candidateParams(status, filters)
+  return stylebookJsonFetch(
+    `/v1/stylebooks/${encodeURIComponent(stylebookSlug)}/candidates/${entityType}?${params}`,
+  )
+}
+
+export async function countStylebookCandidates(
+  stylebookSlug: string,
+  entityType: CandidateEntityType,
+  status: string,
+  filters?: StylebookCandidateFilters,
+): Promise<CandidateCountResponse> {
+  const params = candidateParams(status, filters)
+  return stylebookJsonFetch(
+    `/v1/stylebooks/${encodeURIComponent(stylebookSlug)}/candidates/${entityType}/count?${params}`,
+  )
+}
+
+export async function listStylebookCandidateTypes(
+  stylebookSlug: string,
+  entityType: CandidateEntityType,
+  projectSlug: string | undefined,
+  status: string,
+): Promise<{ types: string[] }> {
+  const params = candidateParams(status, { project_slug: projectSlug })
+  return stylebookJsonFetch(
+    `/v1/stylebooks/${encodeURIComponent(stylebookSlug)}/candidates/${entityType}/types?${params}`,
+  )
+}

--- a/apps/stylebook-ui/src/lib/useCandidateQueuePage.ts
+++ b/apps/stylebook-ui/src/lib/useCandidateQueuePage.ts
@@ -1,10 +1,13 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react"
 import { useProjectCatalogScope } from "@/lib/catalogNavigation"
-import { fetchProjects, type Project } from "@/lib/api"
 import { pickCreateLinkNudge, candidateQueueNameKey, duplicateCreateNewSummary } from "@/lib/candidateQueueSimilarity"
 import { suggestedRowAction, candidatesWithSuggestedAction } from "@/lib/candidateQueueSuggestions"
 import { useCandidateQueueToasts } from "@/lib/useCandidateQueueToasts"
 import { useCandidateQueueInlineNote } from "@/lib/useCandidateQueueInlineNote"
+import {
+  CandidateQueueRequestGate,
+  validCandidateTypeFilter,
+} from "@/lib/candidateQueueState"
 import type {
   CandidateQueuePageConfig,
   CandidateQueueStatus,
@@ -17,16 +20,18 @@ export function useCandidateQueuePage<TCandidate extends QueueCandidateBase>(
   config: CandidateQueuePageConfig<TCandidate>,
 ) {
   const {
-    projectScopeSlug: projectSlug,
+    projectFilterSlug: projectSlug,
     stylebookSlug,
   } = useProjectCatalogScope()
 
-  const [projects, setProjects] = useState<Project[]>([])
-  const [projectsLoading, setProjectsLoading] = useState(true)
+  const [projects, setProjects] = useState<
+    Array<{ project_id: number; project_slug: string; project_name: string; count: number }>
+  >([])
+  const [projectsLoading, setProjectsLoading] = useState(false)
   const projectDisplayName = useMemo(() => {
-    const row = projects.find((p) => p.slug === projectSlug)
-    const name = row?.name?.trim()
-    return name || projectSlug || "this project"
+    const row = projects.find((p) => p.project_slug === projectSlug)
+    const name = row?.project_name?.trim()
+    return name || "All accessible projects"
   }, [projects, projectSlug])
 
   const [loading, setLoading] = useState(false)
@@ -45,6 +50,16 @@ export function useCandidateQueuePage<TCandidate extends QueueCandidateBase>(
     const base = `${projectSlug}|${stylebookSlug}|${status}|${debouncedQuery}`
     return config.typeFilter ? `${base}|${typeFilter}` : base
   }, [projectSlug, stylebookSlug, status, debouncedQuery, typeFilter, config.typeFilter])
+  const listRequestScopeKey = `${filterKey}|${listPage}`
+  const requestGate = useMemo(() => new CandidateQueueRequestGate(), [])
+  const typeRequestScopeKey = `${stylebookSlug}|${projectSlug}|${status}`
+  const typeRequestGate = useMemo(() => new CandidateQueueRequestGate(), [])
+  useLayoutEffect(() => {
+    requestGate.setScope(listRequestScopeKey)
+  }, [listRequestScopeKey, requestGate])
+  useLayoutEffect(() => {
+    typeRequestGate.setScope(typeRequestScopeKey)
+  }, [typeRequestGate, typeRequestScopeKey])
   const [types, setTypes] = useState<string[]>([])
   const [acceptingId, setAcceptingId] = useState<number | null>(null)
   const [deferringId, setDeferringId] = useState<number | null>(null)
@@ -108,25 +123,7 @@ export function useCandidateQueuePage<TCandidate extends QueueCandidateBase>(
   )
 
   useEffect(() => {
-    let cancelled = false
-    setProjectsLoading(true)
-    void fetchProjects()
-      .then((rows) => {
-        if (!cancelled) setProjects(rows)
-      })
-      .catch(() => {
-        if (!cancelled) setProjects([])
-      })
-      .finally(() => {
-        if (!cancelled) setProjectsLoading(false)
-      })
-    return () => {
-      cancelled = true
-    }
-  }, [])
-
-  useEffect(() => {
-    if (!projectSlug) {
+    if (!stylebookSlug) {
       filterKeySeenRef.current = null
       return
     }
@@ -138,7 +135,7 @@ export function useCandidateQueuePage<TCandidate extends QueueCandidateBase>(
     filterKeySeenRef.current = filterKey
     setListFetchGen((g) => g + 1)
     setListPage(1)
-  }, [filterKey, projectSlug])
+  }, [filterKey, stylebookSlug])
 
   useEffect(() => {
     const t = window.setTimeout(() => setDebouncedQuery(query), 250)
@@ -146,30 +143,59 @@ export function useCandidateQueuePage<TCandidate extends QueueCandidateBase>(
   }, [query])
 
   useEffect(() => {
-    if (!config.api.listTypes || !projectSlug) return
+    if (!config.api.listTypes || !stylebookSlug) {
+      setTypes([])
+      setTypeFilter("all")
+      return
+    }
+    const requestToken = typeRequestGate.begin(typeRequestScopeKey)
+    if (!requestToken) return
+    let cancelled = false
     void (async () => {
       try {
-        const res = await config.api.listTypes!(projectSlug, status)
+        const res = await config.api.listTypes!(
+          stylebookSlug,
+          projectSlug || undefined,
+          status,
+        )
+        if (cancelled || !typeRequestGate.isCurrent(requestToken)) return
         setTypes(res.types)
+        setTypeFilter((current) => validCandidateTypeFilter(current, res.types))
       } catch {
-        setTypes([])
+        if (!cancelled && typeRequestGate.isCurrent(requestToken)) {
+          setTypes([])
+          setTypeFilter("all")
+        }
       }
     })()
-  }, [config.api, projectSlug, status])
+    return () => {
+      cancelled = true
+    }
+  }, [
+    config.api,
+    projectSlug,
+    status,
+    stylebookSlug,
+    typeRequestGate,
+    typeRequestScopeKey,
+  ])
 
   const refreshListQuiet = useCallback(async () => {
-    if (!projectSlug) return
+    if (!stylebookSlug) return
+    const requestToken = requestGate.begin(listRequestScopeKey)
+    if (!requestToken) return
     setError(null)
     const type_filter = config.typeFilter && typeFilter !== "all" ? typeFilter : undefined
     const q = debouncedQuery.trim() || undefined
     const offset = (listPage - 1) * REVIEW_QUEUE_PAGE_SIZE
     try {
-      const res = await config.api.list(projectSlug, status, {
+      const res = await config.api.list(stylebookSlug, projectSlug || undefined, status, {
         limit: REVIEW_QUEUE_PAGE_SIZE,
         offset,
         type_filter,
         q,
       })
+      if (!requestGate.isCurrent(requestToken)) return
       setListTotal(res.total)
       setCandidates(res.candidates)
       setListHasNext(res.has_next)
@@ -178,18 +204,21 @@ export function useCandidateQueuePage<TCandidate extends QueueCandidateBase>(
         setListPage((p) => Math.max(1, p - 1))
       }
     } catch (e) {
+      if (!requestGate.isCurrent(requestToken)) return
       setError(e instanceof Error ? e.message : "Request failed")
+    } finally {
+      if (requestGate.isCurrent(requestToken)) setLoading(false)
     }
-  }, [projectSlug, status, debouncedQuery, typeFilter, listPage, config.api, config.typeFilter])
+  }, [stylebookSlug, projectSlug, status, debouncedQuery, typeFilter, listPage, config.api, config.typeFilter, listRequestScopeKey, requestGate])
 
   const fetchAllFilteredCandidates = useCallback(async (): Promise<TCandidate[]> => {
-    if (!projectSlug) return []
+    if (!stylebookSlug) return []
     const type_filter = config.typeFilter && typeFilter !== "all" ? typeFilter : undefined
     const q = debouncedQuery.trim() || undefined
     const all: TCandidate[] = []
     let offset = 0
     while (true) {
-      const res = await config.api.list(projectSlug, status, {
+      const res = await config.api.list(stylebookSlug, projectSlug || undefined, status, {
         limit: REVIEW_QUEUE_PAGE_SIZE,
         offset,
         type_filter,
@@ -200,39 +229,39 @@ export function useCandidateQueuePage<TCandidate extends QueueCandidateBase>(
       offset += REVIEW_QUEUE_PAGE_SIZE
     }
     return all
-  }, [projectSlug, status, debouncedQuery, typeFilter, config.api, config.typeFilter])
+  }, [stylebookSlug, projectSlug, status, debouncedQuery, typeFilter, config.api, config.typeFilter])
 
   const fetchOpenCandidatesForLabel = useCallback(
     async (label: string) => {
-      if (!projectSlug) return []
-      const res = await config.api.list(projectSlug, "open", {
+      if (!stylebookSlug) return []
+      const res = await config.api.list(stylebookSlug, projectSlug || undefined, "open", {
         limit: 100,
         offset: 0,
         q: label,
       })
       return res.candidates
     },
-    [projectSlug, config.api],
+    [stylebookSlug, projectSlug, config.api],
   )
 
   const queueToasts = useCandidateQueueToasts<TCandidate>({
-    projectSlug,
+    projectSlug: stylebookSlug,
     fetchOpenCandidatesForLabel,
     getCandidateLabel: (c) => c.suggested_name ?? "",
     mapFollowupRow: config.mapFollowupRow,
     linkCandidateToCanonical: async (c, canonicalId) => {
-      if (!projectSlug) return
-      await config.api.linkToCanonical(c.id, projectSlug, canonicalId)
+      await config.api.linkToCanonical(c.id, c.project_slug, canonicalId, stylebookSlug)
     },
     onAfterToastLink: refreshListQuiet,
   })
 
   const saveCandidateNote = useCallback(
     async (candidateId: number, note: string | null) => {
-      if (!projectSlug) return
+      const candidate = candidates.find((row) => row.id === candidateId)
+      if (!candidate) return
       setError(null)
       try {
-        await config.api.updateNote(projectSlug, candidateId, note)
+        await config.api.updateNote(candidate.project_slug, candidateId, note, stylebookSlug)
         setContextById((prev) => {
           const existing = prev[candidateId]
           if (!existing) return prev
@@ -243,13 +272,15 @@ export function useCandidateQueuePage<TCandidate extends QueueCandidateBase>(
         setError(e instanceof Error ? e.message : "Failed to save note")
       }
     },
-    [projectSlug, refreshListQuiet, config.api],
+    [candidates, stylebookSlug, refreshListQuiet, config.api],
   )
 
   const candidateNotes = useCandidateQueueInlineNote({ onSave: saveCandidateNote })
 
   useEffect(() => {
-    if (!projectSlug) return
+    if (!stylebookSlug) return
+    const requestToken = requestGate.begin(listRequestScopeKey)
+    if (!requestToken) return
     let cancelled = false
     void (async () => {
       setLoading(true)
@@ -258,13 +289,18 @@ export function useCandidateQueuePage<TCandidate extends QueueCandidateBase>(
       const q = debouncedQuery.trim() || undefined
       const offset = (listPage - 1) * REVIEW_QUEUE_PAGE_SIZE
       try {
-        const res = await config.api.list(projectSlug, status, {
-          limit: REVIEW_QUEUE_PAGE_SIZE,
-          offset,
-          type_filter,
-          q,
-        })
-        if (cancelled) return
+        setProjectsLoading(true)
+        const [res, counts] = await Promise.all([
+          config.api.list(stylebookSlug, projectSlug || undefined, status, {
+            limit: REVIEW_QUEUE_PAGE_SIZE,
+            offset,
+            type_filter,
+            q,
+          }),
+          config.api.count(stylebookSlug, undefined, status, {}),
+        ])
+        if (cancelled || !requestGate.isCurrent(requestToken)) return
+        setProjects(counts.projects)
         setListTotal(res.total)
         setCandidates(res.candidates)
         setListHasNext(res.has_next)
@@ -278,23 +314,26 @@ export function useCandidateQueuePage<TCandidate extends QueueCandidateBase>(
           setListPage((p) => Math.max(1, p - 1))
         }
       } catch (e) {
-        if (cancelled) return
+        if (cancelled || !requestGate.isCurrent(requestToken)) return
         setError(e instanceof Error ? e.message : "Request failed")
         setListTotal(0)
         setCandidates([])
         setListHasNext(false)
         setListHasPrev(false)
       } finally {
-        if (!cancelled) setLoading(false)
+        if (!cancelled && requestGate.isCurrent(requestToken)) {
+          setLoading(false)
+          setProjectsLoading(false)
+        }
       }
     })()
     return () => {
       cancelled = true
     }
-  }, [projectSlug, status, debouncedQuery, typeFilter, listPage, listFetchGen, config.api, config.typeFilter])
+  }, [stylebookSlug, projectSlug, status, debouncedQuery, typeFilter, listPage, listFetchGen, config.api, config.typeFilter, listRequestScopeKey, requestGate])
 
   useEffect(() => {
-    if (!projectSlug || status !== "open" || listTotal === 0) {
+    if (!stylebookSlug || status !== "open" || listTotal === 0) {
       setQueueRecommendationCount(0)
       return
     }
@@ -314,28 +353,29 @@ export function useCandidateQueuePage<TCandidate extends QueueCandidateBase>(
     return () => {
       cancelled = true
     }
-  }, [projectSlug, status, listTotal, filterKey, fetchAllFilteredCandidates])
+  }, [stylebookSlug, status, listTotal, filterKey, fetchAllFilteredCandidates])
 
   useEffect(() => {
-    if (!projectSlug || status !== "open" || listTotal === 0) {
+    if (!stylebookSlug || status !== "open" || listTotal === 0) {
       return
     }
     if (listTotal > REVIEW_QUEUE_PAGE_SIZE) {
       return
     }
     setQueueRecommendationCount(candidatesWithSuggestedAction(candidates).length)
-  }, [projectSlug, status, listTotal, candidates])
+  }, [stylebookSlug, status, listTotal, candidates])
 
   const refreshCreateLinkNudge = useCallback(
     async (candidateId: number, draftLabel: string) => {
-      if (!projectSlug) return
+      const candidate = candidates.find((row) => row.id === candidateId)
+      if (!candidate) return
       const draft = draftLabel.trim()
       if (!draft) {
         setCreateLinkNudge(null)
         return
       }
       try {
-        const res = await config.api.getSuggestedCanonicals(projectSlug, candidateId, 16)
+        const res = await config.api.getSuggestedCanonicals(candidate.project_slug, candidateId, 16)
         const nudge = pickCreateLinkNudge(res.suggestions, draft)
         setCreateLinkNudge(
           nudge ? { canonicalId: nudge.canonicalId, label: nudge.label } : null,
@@ -344,11 +384,11 @@ export function useCandidateQueuePage<TCandidate extends QueueCandidateBase>(
         setCreateLinkNudge(null)
       }
     },
-    [projectSlug, config.api],
+    [candidates, config.api],
   )
 
   useEffect(() => {
-    if (createModalId === null || !projectSlug) return
+    if (createModalId === null) return
     let cancelled = false
     const draft = config.createDialog.getDraftLabelForNudge(createDraft).trim()
     if (!draft) {
@@ -365,7 +405,7 @@ export function useCandidateQueuePage<TCandidate extends QueueCandidateBase>(
       cancelled = true
       window.clearTimeout(t)
     }
-  }, [createModalId, createDraft, projectSlug, refreshCreateLinkNudge, config.createDialog])
+  }, [createModalId, createDraft, refreshCreateLinkNudge, config.createDialog])
 
   const openCreateModal = useCallback(
     (candidate: TCandidate) => {
@@ -383,7 +423,7 @@ export function useCandidateQueuePage<TCandidate extends QueueCandidateBase>(
   }, [])
 
   const submitCreateFromModal = useCallback(async () => {
-    if (!projectSlug || createModalId === null || !createModalCandidate) return
+    if (createModalId === null || !createModalCandidate) return
     const validationError = config.createDialog.validate(createDraft)
     if (validationError) {
       setError(validationError)
@@ -393,7 +433,12 @@ export function useCandidateQueuePage<TCandidate extends QueueCandidateBase>(
     setError(null)
     try {
       const body = config.createDialog.buildAcceptBody(createDraft, createModalCandidate)
-      const acceptRes = await config.api.acceptCreateNew(projectSlug, createModalId, body)
+      const acceptRes = await config.api.acceptCreateNew(
+        createModalCandidate.project_slug,
+        createModalId,
+        body,
+        stylebookSlug,
+      )
       await refreshListQuiet()
       closeCreateModal()
       const cid = acceptRes.canonicalId.trim()
@@ -409,7 +454,6 @@ export function useCandidateQueuePage<TCandidate extends QueueCandidateBase>(
       setAcceptingId(null)
     }
   }, [
-    projectSlug,
     createModalId,
     createModalCandidate,
     createDraft,
@@ -425,7 +469,6 @@ export function useCandidateQueuePage<TCandidate extends QueueCandidateBase>(
       candidate: TCandidate,
       options?: { silent?: boolean; batchCreatedByNameKey?: Map<string, string> },
     ): Promise<boolean> => {
-      if (!projectSlug) return false
       const action = suggestedRowAction(candidate)
       if (!action) return false
 
@@ -435,11 +478,20 @@ export function useCandidateQueuePage<TCandidate extends QueueCandidateBase>(
         setLinkingSuggestedId(candidate.id)
         setError(null)
         try {
-          await config.api.linkToCanonical(candidate.id, projectSlug, cid)
+          await config.api.linkToCanonical(
+            candidate.id,
+            candidate.project_slug,
+            cid,
+            stylebookSlug,
+          )
           if (!options?.silent) {
             let canonLabel = cid
             try {
-              canonLabel = await config.api.getCanonicalLabel(cid, stylebookSlug, projectSlug)
+              canonLabel = await config.api.getCanonicalLabel(
+                cid,
+                stylebookSlug,
+                candidate.project_slug,
+              )
             } catch {
               // ignore; fall back to id
             }
@@ -466,7 +518,7 @@ export function useCandidateQueuePage<TCandidate extends QueueCandidateBase>(
         setDeferringId(candidate.id)
         setError(null)
         try {
-          await config.api.defer(projectSlug, candidate.id)
+          await config.api.defer(candidate.project_slug, candidate.id, stylebookSlug)
           return true
         } catch (e) {
           if (!options?.silent) {
@@ -493,7 +545,12 @@ export function useCandidateQueuePage<TCandidate extends QueueCandidateBase>(
         setLinkingSuggestedId(candidate.id)
         setError(null)
         try {
-          await config.api.linkToCanonical(candidate.id, projectSlug, cid)
+          await config.api.linkToCanonical(
+            candidate.id,
+            candidate.project_slug,
+            cid,
+            stylebookSlug,
+          )
           return true
         } catch (e) {
           if (!options?.silent) {
@@ -509,7 +566,12 @@ export function useCandidateQueuePage<TCandidate extends QueueCandidateBase>(
       setError(null)
       try {
         const body = config.createDialog.buildAcceptBody(draft, candidate)
-        const acceptRes = await config.api.acceptCreateNew(projectSlug, candidate.id, body)
+        const acceptRes = await config.api.acceptCreateNew(
+          candidate.project_slug,
+          candidate.id,
+          body,
+          stylebookSlug,
+        )
         const cid = acceptRes.canonicalId.trim()
         if (
           options?.batchCreatedByNameKey &&
@@ -538,7 +600,6 @@ export function useCandidateQueuePage<TCandidate extends QueueCandidateBase>(
       }
     },
     [
-      projectSlug,
       stylebookSlug,
       config.api,
       config.createDialog,
@@ -559,11 +620,10 @@ export function useCandidateQueuePage<TCandidate extends QueueCandidateBase>(
 
   const handleDefer = useCallback(
     async (candidate: TCandidate) => {
-      if (!projectSlug) return
       setDeferringId(candidate.id)
       setError(null)
       try {
-        await config.api.defer(projectSlug, candidate.id)
+        await config.api.defer(candidate.project_slug, candidate.id, stylebookSlug)
         await refreshListQuiet()
       } catch (e) {
         setError(e instanceof Error ? e.message : "Defer failed")
@@ -571,16 +631,15 @@ export function useCandidateQueuePage<TCandidate extends QueueCandidateBase>(
         setDeferringId(null)
       }
     },
-    [projectSlug, config.api, refreshListQuiet],
+    [stylebookSlug, config.api, refreshListQuiet],
   )
 
   const handleClearRecommendation = useCallback(
     async (candidate: TCandidate) => {
-      if (!projectSlug) return
       setClearingRecommendationId(candidate.id)
       setError(null)
       try {
-        await config.api.clearRecommendation(projectSlug, candidate.id)
+        await config.api.clearRecommendation(candidate.project_slug, candidate.id, stylebookSlug)
         await refreshListQuiet()
       } catch (e) {
         setError(e instanceof Error ? e.message : "Failed to clear recommendation")
@@ -588,11 +647,11 @@ export function useCandidateQueuePage<TCandidate extends QueueCandidateBase>(
         setClearingRecommendationId(null)
       }
     },
-    [projectSlug, config.api, refreshListQuiet],
+    [stylebookSlug, config.api, refreshListQuiet],
   )
 
   const acceptAiRecommendations = useCallback(async () => {
-    if (!projectSlug || status !== "open") return
+    if (!stylebookSlug || status !== "open") return
 
     setAcceptingAiRecommendations(true)
     setError(null)
@@ -612,7 +671,7 @@ export function useCandidateQueuePage<TCandidate extends QueueCandidateBase>(
       setAcceptingAiRecommendations(false)
     }
   }, [
-    projectSlug,
+    stylebookSlug,
     status,
     fetchAllFilteredCandidates,
     applySuggestedAction,
@@ -621,14 +680,13 @@ export function useCandidateQueuePage<TCandidate extends QueueCandidateBase>(
 
   const toggleExpanded = useCallback(
     async (candidate: TCandidate) => {
-      if (!projectSlug) return
       const next = expandedId === candidate.id ? null : candidate.id
       setExpandedId(next)
       if (next === null) return
       if (contextById[next]) return
       setContextLoadingId(next)
       try {
-        const ctx = await config.api.getContext(projectSlug, next, 3)
+        const ctx = await config.api.getContext(candidate.project_slug, next, 3)
         setContextById((prev) => ({ ...prev, [next]: ctx }))
       } catch (e) {
         setError(e instanceof Error ? e.message : "Failed to load context")
@@ -636,7 +694,7 @@ export function useCandidateQueuePage<TCandidate extends QueueCandidateBase>(
         setContextLoadingId(null)
       }
     },
-    [projectSlug, expandedId, contextById, config.api],
+    [expandedId, contextById, config.api],
   )
 
   const openLinkModal = useCallback(

--- a/docs/api/stylebook.md
+++ b/docs/api/stylebook.md
@@ -43,9 +43,17 @@ Canonical metadata is Stylebook-wide editorial data. Its rows retain a project a
 
 ## Saved entities and candidate review
 
+Stylebook-scoped candidate inboxes use
+`/v1/stylebooks/{stylebook_slug}/candidates/{locations|people|organizations}` and the matching
+`/count` route. They combine only caller-accessible projects assigned to that Stylebook, support
+an optional `project_slug` filter, and return project ID, slug, and name with each candidate.
+Counts include per-project totals for the project filter. The matching `/types` route aggregates
+available candidate types across the same accessible project scope and review status.
+
 Candidate reads require project access. Location, person, and organization candidate mutations
-(notes, deferral, recommendation clearing, and acceptance/linking or canonical creation) also
-require edit permission for the project's Stylebook.
+(notes, deferral, recommendation clearing, acceptance/linking, unlinking, or canonical creation)
+reload the candidate's project and require both project access and edit permission for its
+assigned Stylebook.
 
 Project-scoped saved entity routes manage article evidence before or after a canonical decision:
 
@@ -55,7 +63,10 @@ Project-scoped saved entity routes manage article evidence before or after a can
 
 Saved entities can be inspected, edited, linked or unlinked from a canonical, and removed from an article. Article-evidence create routes for each current domain validate selected quote offsets and create the saved entity, mention, and first occurrence together.
 
-Candidate queues support open and deferred review, notes, context, suggested canonicals, recommendation clearing, acceptance into a new or existing canonical, and type facets. Location clustering is available in addition to the flat location queue.
+Candidate queues support open and deferred review, notes, context, suggested canonicals,
+recommendation clearing, acceptance into a new or existing canonical, and type facets. Existing
+project-specific candidate routes remain compatibility contracts during rolling deployments.
+Location clustering is available in addition to the flat location queue.
 
 Stylebook-scoped candidate AI review can evaluate open locations, people, or organizations. Starting a review queues work; status and cancellation routes expose cooperative progress. Recommendations do not mutate canonical links until accepted.
 

--- a/docs/development/frontend/stylebook.md
+++ b/docs/development/frontend/stylebook.md
@@ -111,16 +111,23 @@ as type-specific pages while sharing their common shells and form classes.
 
 ## Candidate queues
 
-Candidate queues are project-scoped; link and create actions target the Stylebook
-in the path. The shared shell provides:
+Candidate queues are Stylebook-wide inboxes across all accessible projects assigned to that
+Stylebook. “All accessible projects” is the default; when several projects contribute, the page
+shows each candidate's project and offers a project filter. The filter stays hidden when only one
+project contributes. Link and create actions use the candidate's own project. The shared shell
+provides:
 
 - Open and deferred queues with server-side filtering and pagination.
+- Project provenance and optional project filtering.
 - Product-readable review reasons and inline editor notes.
 - Suggested-canonical lookup plus manual Stylebook search.
 - Create-new confirmation with a similar-canonical warning.
 - Link, create, and defer recommendations from AI review.
 - Incremental AI-review polling and bulk acceptance.
 - Post-action notices and an optional related-candidates follow-up.
+
+For rolling deployments, deploy the Stylebook-scoped candidate list, count, and type endpoints
+before deploying this UI. The combined inbox intentionally has no project-route fallback.
 
 Location, person, and organization pages all use this shell. New types must extend
 the configuration seams instead of copying a page body.

--- a/tests/stylebook_api/test_stylebook_api.py
+++ b/tests/stylebook_api/test_stylebook_api.py
@@ -24,6 +24,7 @@ from backfield_db import (
     SubstrateLocation,
     SubstrateLocationMention,
     SubstrateLocationMentionOccurrence,
+    SubstrateOrganization,
     SubstratePerson,
     SubstratePersonMention,
     SubstratePersonMentionOccurrence,
@@ -35,6 +36,7 @@ from backfield_entities.canonical.link import (
     CANONICAL_LINK_WAIVED,
 )
 from fastapi.testclient import TestClient
+from sqlalchemy import event
 from sqlalchemy.engine import Engine
 from sqlmodel import Session, SQLModel, create_engine, select
 from stylebook_api.deps import get_auth as get_auth_dep
@@ -246,6 +248,390 @@ def editor_client(
         yield client
     finally:
         app.dependency_overrides.pop(get_auth_dep, None)
+
+
+def test_stylebook_candidate_inbox_combines_accessible_projects(
+    editor_client: TestClient,
+    stylebook_test_engine: Engine,
+) -> None:
+    with Session(stylebook_test_engine) as session:
+        default_stylebook = session.exec(
+            select(Stylebook).where(Stylebook.slug == "default")
+        ).one()
+        workspace = session.exec(
+            select(BackfieldWorkspace).where(BackfieldWorkspace.slug == "default-ws")
+        ).one()
+        demo = session.exec(
+            select(BackfieldProject).where(BackfieldProject.slug == "demo-proj")
+        ).one()
+        second = session.exec(
+            select(BackfieldProject).where(BackfieldProject.slug == "no-ws-proj")
+        ).one()
+        editor = session.exec(
+            select(BackfieldUser).where(BackfieldUser.email == "editor@example.com")
+        ).one()
+        inaccessible = BackfieldProject(
+            organization_id=int(default_stylebook.organization_id),
+            workspace_id=int(workspace.id),
+            stylebook_id=int(default_stylebook.id),
+            name="Hidden Project",
+            slug="hidden-proj",
+        )
+        other_stylebook = Stylebook(
+            organization_id=int(default_stylebook.organization_id),
+            slug="other",
+            name="Other Stylebook",
+        )
+        external_org = BackfieldOrganization(name="External", slug="external")
+        session.add(inaccessible)
+        session.add(other_stylebook)
+        session.add(external_org)
+        session.flush()
+        session.add(
+            Stylebook(
+                organization_id=int(external_org.id),
+                slug="external",
+                name="External Stylebook",
+                is_default=True,
+            )
+        )
+        other_project = BackfieldProject(
+            organization_id=int(default_stylebook.organization_id),
+            workspace_id=int(workspace.id),
+            stylebook_id=int(other_stylebook.id),
+            name="Other Project",
+            slug="other-proj",
+        )
+        session.add(other_project)
+        session.flush()
+        for project in (demo, second, other_project):
+            session.add(
+                BackfieldProjectMembership(
+                    user_id=int(editor.id),
+                    project_id=int(project.id),
+                    role="member",
+                )
+            )
+        for project, suffix in (
+            (demo, "demo"),
+            (second, "second"),
+            (inaccessible, "hidden"),
+            (other_project, "other"),
+        ):
+            session.add(
+                SubstrateLocation(
+                    project_id=int(project.id),
+                    name=f"Location {suffix}",
+                    normalized_name=f"location {suffix}",
+                    location_type={
+                        "demo": "city",
+                        "second": "county",
+                        "hidden": "state",
+                        "other": "country",
+                    }[suffix],
+                    identity_fingerprint=f"candidate-location-{suffix}",
+                    canonical_link_status=CANONICAL_LINK_PENDING,
+                )
+            )
+            session.add(
+                SubstratePerson(
+                    project_id=int(project.id),
+                    name=f"Person {suffix}",
+                    normalized_name=f"person {suffix}",
+                    identity_fingerprint=f"candidate-person-{suffix}",
+                    canonical_link_status=CANONICAL_LINK_PENDING,
+                )
+            )
+            session.add(
+                SubstrateOrganization(
+                    project_id=int(project.id),
+                    name=f"Organization {suffix}",
+                    normalized_name=f"organization {suffix}",
+                    identity_fingerprint=f"candidate-organization-{suffix}",
+                    canonical_link_status=CANONICAL_LINK_PENDING,
+                )
+            )
+        session.add(
+            SubstrateLocation(
+                project_id=int(second.id),
+                name="Deferred neighborhood",
+                normalized_name="deferred neighborhood",
+                location_type="neighborhood",
+                canonical_link_status=CANONICAL_LINK_WAIVED,
+            )
+        )
+        session.commit()
+
+    for entity_type in ("locations", "people", "organizations"):
+        response = editor_client.get(
+            f"/v1/stylebooks/default/candidates/{entity_type}?limit=1"
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["total"] == 2
+        assert len(body["candidates"]) == 1
+        assert body["has_next"] is True
+        assert {
+            "project_id",
+            "project_slug",
+            "project_name",
+        }.issubset(body["candidates"][0])
+
+        count = editor_client.get(
+            f"/v1/stylebooks/default/candidates/{entity_type}/count"
+        )
+        assert count.status_code == 200
+        count_body = count.json()
+        assert count_body["total"] == 2
+        assert {project["project_slug"] for project in count_body["projects"]} == {
+            "demo-proj",
+            "no-ws-proj",
+        }
+
+        filtered = editor_client.get(
+            f"/v1/stylebooks/default/candidates/{entity_type}?project_slug=demo-proj"
+        )
+        assert filtered.status_code == 200
+        assert filtered.json()["total"] == 1
+        assert filtered.json()["candidates"][0]["project_slug"] == "demo-proj"
+
+        wrong_assignment = editor_client.get(
+            f"/v1/stylebooks/default/candidates/{entity_type}?project_slug=other-proj"
+        )
+        assert wrong_assignment.status_code == 404
+
+    cross_stylebook = editor_client.get("/v1/stylebooks/external/candidates/locations")
+    assert cross_stylebook.status_code == 404
+
+    types = editor_client.get("/v1/stylebooks/default/candidates/locations/types")
+    assert types.status_code == 200
+    assert types.json() == {"types": ["city", "county"]}
+    filtered_types = editor_client.get(
+        "/v1/stylebooks/default/candidates/locations/types?project_slug=demo-proj"
+    )
+    assert filtered_types.status_code == 200
+    assert filtered_types.json() == {"types": ["city"]}
+    deferred_types = editor_client.get(
+        "/v1/stylebooks/default/candidates/locations/types?status=deferred"
+    )
+    assert deferred_types.status_code == 200
+    assert deferred_types.json() == {"types": ["neighborhood"]}
+
+
+@pytest.mark.parametrize(
+    ("endpoint", "candidate_model"),
+    [
+        ("/v1/candidates", SubstrateLocation),
+        ("/v1/people/candidates", SubstratePerson),
+        ("/v1/organizations/candidates", SubstrateOrganization),
+    ],
+)
+def test_legacy_candidate_lists_load_project_once(
+    client: TestClient,
+    stylebook_test_engine: Engine,
+    endpoint: str,
+    candidate_model: type[Any],
+) -> None:
+    with Session(stylebook_test_engine) as session:
+        project = session.exec(
+            select(BackfieldProject).where(BackfieldProject.slug == "demo-proj")
+        ).one()
+        for index in range(3):
+            session.add(
+                candidate_model(
+                    project_id=int(project.id),
+                    name=f"Query count {index}",
+                    normalized_name=f"query count {index}",
+                    canonical_link_status=CANONICAL_LINK_PENDING,
+                )
+            )
+        session.commit()
+
+    project_selects: list[str] = []
+
+    def track_project_selects(
+        _connection: object,
+        _cursor: object,
+        statement: str,
+        _parameters: object,
+        _context: object,
+        _executemany: bool,
+    ) -> None:
+        normalized = statement.lower()
+        if normalized.startswith("select") and "from backfield_project" in normalized:
+            project_selects.append(statement)
+
+    event.listen(stylebook_test_engine, "before_cursor_execute", track_project_selects)
+    try:
+        response = client.get(
+            f"{endpoint}?project_slug=demo-proj",
+            headers=_service_headers(),
+        )
+    finally:
+        event.remove(stylebook_test_engine, "before_cursor_execute", track_project_selects)
+
+    assert response.status_code == 200
+    assert response.json()["total"] == 3
+    assert len(project_selects) == 1
+
+
+def test_candidate_mutation_rejects_conflicting_stylebook(
+    editor_client: TestClient,
+    stylebook_test_engine: Engine,
+) -> None:
+    with Session(stylebook_test_engine) as session:
+        project = session.exec(
+            select(BackfieldProject).where(BackfieldProject.slug == "demo-proj")
+        ).one()
+        editor = session.exec(
+            select(BackfieldUser).where(BackfieldUser.email == "editor@example.com")
+        ).one()
+        session.add(
+            BackfieldProjectMembership(
+                user_id=int(editor.id),
+                project_id=int(project.id),
+                role="member",
+            )
+        )
+        other = Stylebook(
+            organization_id=int(project.organization_id),
+            slug="other",
+            name="Other Stylebook",
+        )
+        candidate = SubstrateLocation(
+            project_id=int(project.id),
+            name="Guarded candidate",
+            normalized_name="guarded candidate",
+            canonical_link_status=CANONICAL_LINK_PENDING,
+        )
+        session.add(other)
+        session.add(candidate)
+        session.commit()
+        session.refresh(candidate)
+        candidate_id = int(candidate.id)
+
+    response = editor_client.post(
+        f"/v1/candidates/{candidate_id}/defer"
+        "?project_slug=demo-proj&stylebook_slug=other"
+    )
+    assert response.status_code in {400, 403, 404}
+    with Session(stylebook_test_engine) as session:
+        candidate = session.get(SubstrateLocation, candidate_id)
+        assert candidate is not None
+        assert candidate.canonical_link_status == CANONICAL_LINK_PENDING
+
+
+@pytest.mark.parametrize("entity_type", ["locations", "people", "organizations"])
+@pytest.mark.parametrize("auth_type", ["member", "api_key"])
+def test_unlink_requires_stylebook_edit_access(
+    _stylebook_test_stack: tuple[TestClient, Engine],
+    entity_type: str,
+    auth_type: str,
+) -> None:
+    client, engine = _stylebook_test_stack
+    with Session(engine) as session:
+        project = session.exec(
+            select(BackfieldProject).where(BackfieldProject.slug == "demo-proj")
+        ).one()
+        stylebook = session.get(Stylebook, int(project.stylebook_id))
+        assert stylebook is not None
+        user = BackfieldUser(
+            email=f"{entity_type}-{auth_type}@example.com",
+            password_hash="x",
+        )
+        session.add(user)
+        session.flush()
+        session.add(
+            BackfieldProjectMembership(
+                user_id=int(user.id),
+                project_id=int(project.id),
+                role="member",
+            )
+        )
+
+        if entity_type == "locations":
+            canonical = StylebookLocationCanonical(
+                stylebook_id=int(stylebook.id),
+                label="Guarded location",
+                slug=f"guarded-location-{auth_type}",
+                location_type="city",
+                status="active",
+            )
+            session.add(canonical)
+            session.flush()
+            candidate: Any = SubstrateLocation(
+                project_id=int(project.id),
+                name="Guarded location",
+                normalized_name="guarded location",
+                stylebook_location_canonical_id=str(canonical.id),
+                canonical_link_status=CANONICAL_LINK_LINKED,
+            )
+        elif entity_type == "people":
+            canonical = StylebookPersonCanonical(
+                stylebook_id=int(stylebook.id),
+                label="Guarded person",
+                slug=f"guarded-person-{auth_type}",
+                status="active",
+            )
+            session.add(canonical)
+            session.flush()
+            candidate = SubstratePerson(
+                project_id=int(project.id),
+                name="Guarded person",
+                normalized_name="guarded person",
+                stylebook_person_canonical_id=str(canonical.id),
+                canonical_link_status=CANONICAL_LINK_LINKED,
+            )
+        else:
+            canonical = StylebookOrganizationCanonical(
+                stylebook_id=int(stylebook.id),
+                label="Guarded organization",
+                slug=f"guarded-organization-{auth_type}",
+                status="active",
+            )
+            session.add(canonical)
+            session.flush()
+            candidate = SubstrateOrganization(
+                project_id=int(project.id),
+                name="Guarded organization",
+                normalized_name="guarded organization",
+                stylebook_organization_canonical_id=str(canonical.id),
+                canonical_link_status=CANONICAL_LINK_LINKED,
+            )
+        session.add(candidate)
+        session.commit()
+        session.refresh(candidate)
+        candidate_id = int(candidate.id)
+        user_id = int(user.id)
+        project_id = int(project.id)
+
+    def get_test_auth() -> dict[str, Any]:
+        if auth_type == "api_key":
+            return {"type": "api_key", "project_id": project_id}
+        with Session(engine) as session:
+            user = session.get(BackfieldUser, user_id)
+            assert user is not None
+            return _session_auth_for_user(user, org_id=1, org_role="member")
+
+    app.dependency_overrides[get_auth_dep] = get_test_auth
+    try:
+        response = client.post(
+            f"/v1/{entity_type}/{candidate_id}/unlink-canonical"
+            "?project_slug=demo-proj"
+        )
+    finally:
+        app.dependency_overrides.pop(get_auth_dep, None)
+
+    assert response.status_code == 403
+    with Session(engine) as session:
+        model = {
+            "locations": SubstrateLocation,
+            "people": SubstratePerson,
+            "organizations": SubstrateOrganization,
+        }[entity_type]
+        candidate = session.get(model, candidate_id)
+        assert candidate is not None
+        assert candidate.canonical_link_status == CANONICAL_LINK_LINKED
 
 
 def test_health(client: TestClient) -> None:


### PR DESCRIPTION
## Summary
- add paginated Stylebook-scoped candidate list, count, and type APIs across entity families
- default the review queue to all accessible assigned projects with project provenance and filtering
- centralize mutation authorization and close link/unlink permission gaps
- preserve project-specific compatibility routes for rolling deployment

This PR is stacked on #118 while the tenancy slices are under development. Deploy the API before the updated Stylebook UI.

## Test plan
- [x] `make lint`
- [x] `make test`
- [x] `make smoke`
- [x] Stylebook UI tests and production build
- [x] independent authorization and UI-state review

Made with [Cursor](https://cursor.com)