### PR TITLE
Allow choosing a project's Stylebook at creation

### DIFF
--- a/apps/agate-api/src/api/routers/projects.py
+++ b/apps/agate-api/src/api/routers/projects.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import re
 import statistics
 from datetime import UTC, datetime
@@ -33,6 +34,8 @@ from pydantic import BaseModel, Field
 from sqlalchemy import case, func, or_
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import Session, col, select
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/projects", tags=["projects"])
 
@@ -78,6 +81,8 @@ class ProjectCreate(BaseModel):
     name: str
     slug: str | None = None
     workspace_id: int
+    # Omitted means "use the workspace's creation default".
+    stylebook_id: int | None = None
 
 
 class ProjectUpdate(BaseModel):
@@ -98,9 +103,34 @@ class ProjectOut(BaseModel):
     stylebook_id: int
     stylebook_name: str
     stylebook_slug: str
-    workspace_stylebook_id: int
-    workspace_stylebook_name: str
-    workspace_stylebook_slug: str
+    # Compatibility fields reporting the workspace's own creation-time default. Null when the
+    # workspace or its Stylebook cannot be resolved.
+    workspace_stylebook_id: int | None = None
+    workspace_stylebook_name: str | None = None
+    workspace_stylebook_slug: str | None = None
+
+
+def _workspace_stylebook(session: Session, workspace_id: int) -> Stylebook | None:
+    """Return the Stylebook a workspace hands to new projects, or ``None`` when broken.
+
+    This can legitimately differ from a project's own Stylebook, because the workspace value
+    is only a creation-time default. It is reported for compatibility only, so a broken row
+    is logged and omitted rather than failing a request; one such row must not take down a
+    whole project listing.
+    """
+    workspace = session.get(BackfieldWorkspace, workspace_id)
+    if workspace is None:
+        logger.warning("project workspace %s is missing", workspace_id)
+        return None
+    stylebook = session.get(Stylebook, int(workspace.stylebook_id))
+    if stylebook is None or int(stylebook.organization_id) != int(workspace.organization_id):
+        logger.warning(
+            "workspace %s has an unresolvable Stylebook assignment (stylebook %s)",
+            workspace_id,
+            workspace.stylebook_id,
+        )
+        return None
+    return stylebook
 
 
 def _project_to_out(session: Session, p: BackfieldProject) -> ProjectOut:
@@ -113,9 +143,8 @@ def _project_to_out(session: Session, p: BackfieldProject) -> ProjectOut:
     stylebook = session.get(Stylebook, sid)
     if stylebook is None:
         raise HTTPException(500, "Invalid project Stylebook ownership")
-    sname = str(stylebook.name)
-    sslug = str(stylebook.slug)
     wid = int(p.workspace_id)
+    workspace_stylebook = _workspace_stylebook(session, wid)
     d = _settings_dict(p)
     return ProjectOut(
         id=int(p.id),
@@ -127,11 +156,17 @@ def _project_to_out(session: Session, p: BackfieldProject) -> ProjectOut:
         updated_at=p.updated_at,
         workspace_id=wid,
         stylebook_id=sid,
-        stylebook_name=sname,
-        stylebook_slug=sslug,
-        workspace_stylebook_id=sid,
-        workspace_stylebook_name=sname,
-        workspace_stylebook_slug=sslug,
+        stylebook_name=str(stylebook.name),
+        stylebook_slug=str(stylebook.slug),
+        workspace_stylebook_id=(
+            int(workspace_stylebook.id) if workspace_stylebook is not None else None
+        ),
+        workspace_stylebook_name=(
+            str(workspace_stylebook.name) if workspace_stylebook is not None else None
+        ),
+        workspace_stylebook_slug=(
+            str(workspace_stylebook.slug) if workspace_stylebook is not None else None
+        ),
     )
 
 
@@ -155,6 +190,27 @@ def list_projects(
         q = q.where(BackfieldProject.id.in_(visible))
     rows = session.exec(q).all()
     return [_project_to_out(session, r) for r in rows if r.id is not None]
+
+
+def _chosen_project_stylebook_id(
+    session: Session,
+    *,
+    organization_id: int,
+    workspace_stylebook_id: int,
+    requested_stylebook_id: int | None,
+) -> int:
+    """Pin the new project to the requested Stylebook, or the workspace default.
+
+    A requested Stylebook must live in the same organization as the workspace. Assignment
+    deliberately does not require Stylebook editor membership; that ACL governs editing
+    catalog contents, not which Stylebook a project writes into.
+    """
+    if requested_stylebook_id is None:
+        return workspace_stylebook_id
+    requested = session.get(Stylebook, int(requested_stylebook_id))
+    if requested is None or int(requested.organization_id) != organization_id:
+        raise HTTPException(400, "Stylebook not found in this organization")
+    return int(requested.id)
 
 
 @router.post("", response_model=ProjectOut)
@@ -182,6 +238,12 @@ def create_project(
         and int(auth_org_id) != organization_id
     ):
         raise HTTPException(403, "Workspace is not in the active organization")
+    require_session_may_assign_project_to_workspace(
+        session,
+        auth,
+        workspace_id=workspace_id,
+        organization_id=organization_id,
+    )
     existing = session.exec(
         select(BackfieldProject).where(
             BackfieldProject.organization_id == organization_id,
@@ -190,14 +252,14 @@ def create_project(
     ).first()
     if existing:
         raise HTTPException(409, "Slug already exists in this organization")
-    stylebook = session.get(Stylebook, int(ws.stylebook_id))
-    if stylebook is None or int(stylebook.organization_id) != organization_id:
+    workspace_stylebook = session.get(Stylebook, int(ws.stylebook_id))
+    if workspace_stylebook is None or int(workspace_stylebook.organization_id) != organization_id:
         raise HTTPException(400, "Workspace has an invalid Stylebook assignment")
-    require_session_may_assign_project_to_workspace(
+    stylebook_id = _chosen_project_stylebook_id(
         session,
-        auth,
-        workspace_id=workspace_id,
         organization_id=organization_id,
+        workspace_stylebook_id=int(workspace_stylebook.id),
+        requested_stylebook_id=body.stylebook_id,
     )
 
     p = BackfieldProject(
@@ -205,7 +267,7 @@ def create_project(
         name=body.name.strip(),
         slug=slug,
         workspace_id=workspace_id,
-        stylebook_id=int(ws.stylebook_id),
+        stylebook_id=stylebook_id,
     )
     session.add(p)
     try:

--- a/apps/agate-ui/src/components/NodePanel.tsx
+++ b/apps/agate-ui/src/components/NodePanel.tsx
@@ -22,11 +22,7 @@ export type GraphPanelContext = {
   organizationId: number | null
   /** Resolved Backfield project id for AI catalog lookups (when known). */
   projectId: number | null
-  workspaceDefaultStylebookId: number | null
-  workspaceStylebookName: string | null
-  /** True when a project is selected but the API did not resolve a workspace Stylebook. */
-  missingWorkspaceStylebook?: boolean
-  /** Flow editor is still fetching the project (for workspace Stylebook). */
+  /** Flow editor is still fetching the project. */
   flowProjectLoading?: boolean
   /** Loads project-effective AI models filtered by capability (e.g. text+json for JSON-using nodes). */
   fetchProjectAiModels?: (capabilities: string[]) => Promise<ProjectAiModelOption[]>

--- a/apps/agate-ui/src/components/ProcessedItemVerificationSection.tsx
+++ b/apps/agate-ui/src/components/ProcessedItemVerificationSection.tsx
@@ -82,7 +82,7 @@ export interface ProcessedItemVerificationSectionProps {
   onItemUpdated: (item: ProcessedItem) => void
   /** Fires when overlay draft dirty state changes (for navigation guard with ``BrowserRouter``). */
   onVerificationDirtyChange?: (dirty: boolean) => void
-  /** Catalog slug from the run's project workspace (for opening Stylebook). */
+  /** Slug of the run project's own Stylebook (read, write, and deep-link target). */
   catalogStylebookSlug?: string | null
   /** Agate project slug for Stylebook ``?project=`` context. */
   catalogProjectSlug?: string | null

--- a/apps/agate-ui/src/components/ProjectDialog.tsx
+++ b/apps/agate-ui/src/components/ProjectDialog.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -19,6 +19,14 @@ import {
 } from '@/components/ui/dialog'
 import type { Project, ProjectCreate } from '@/lib/api'
 import { listMyWorkspaces, type WorkspaceWithProjects } from '@/lib/core-api'
+import { listStylebookCatalogs, type StylebookCatalogRow } from '@/lib/stylebook-org-api'
+import { useAuth } from '@/lib/auth'
+import {
+  resolveStylebookSelection,
+  shouldOfferStylebookChoice,
+  stylebookIdForCreate,
+  type StylebookSelectionInput,
+} from '@/lib/projectStylebookChoice'
 
 interface ProjectDialogProps {
   open: boolean
@@ -38,64 +46,97 @@ export default function ProjectDialog({
   onDelete,
   defaultWorkspaceId = null,
 }: ProjectDialogProps) {
+  const { organizationId } = useAuth()
   const [name, setName] = useState('')
   const [isLoading, setIsLoading] = useState(false)
   const [isDeleting, setIsDeleting] = useState(false)
   const [workspaces, setWorkspaces] = useState<WorkspaceWithProjects[]>([])
   const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string>('') // string for Select
+  const [stylebooks, setStylebooks] = useState<StylebookCatalogRow[]>([])
+  const [chosenStylebookId, setChosenStylebookId] = useState<number | null>(null)
+  const [choicesLoading, setChoicesLoading] = useState(false)
 
   const isEditing = !!project
   const isDefaultProject = project?.slug === 'general'
-
-  const loadWorkspaces = useCallback(async () => {
-    try {
-      const rows = await listMyWorkspaces()
-      // Exclude synthetic grouping (e.g. _ungrouped).
-      const real = rows.filter((w) => w.id > 0 && w.slug !== '_ungrouped')
-      setWorkspaces(real)
-      if (isEditing) return
-      if (defaultWorkspaceId != null && defaultWorkspaceId > 0) {
-        setSelectedWorkspaceId(String(defaultWorkspaceId))
-        return
-      }
-      if (!selectedWorkspaceId) {
-        const def = real.find((w) => w.slug === 'default') ?? real[0]
-        if (def) setSelectedWorkspaceId(String(def.id))
-      }
-    } catch (e) {
-      console.error(e)
-      setWorkspaces([])
-    }
-  }, [defaultWorkspaceId, isEditing, selectedWorkspaceId])
+  const lockedWorkspaceId =
+    defaultWorkspaceId != null && defaultWorkspaceId > 0 ? defaultWorkspaceId : null
 
   useEffect(() => {
-    if (project) {
-      setName(project.name)
-    } else {
-      setName('')
+    setName(project ? project.name : '')
+  }, [project, open])
+
+  // Clear every choice as the dialog closes, so reopening never shows or submits a stale pick.
+  useEffect(() => {
+    if (open) return
+    setWorkspaces([])
+    setSelectedWorkspaceId('')
+    setStylebooks([])
+    setChosenStylebookId(null)
+    setChoicesLoading(false)
+  }, [open])
+
+  useEffect(() => {
+    if (!open || project) return
+    let cancelled = false
+    setChoicesLoading(true)
+
+    const load = async () => {
+      const [workspaceRows, stylebookRows] = await Promise.all([
+        listMyWorkspaces().catch((e) => {
+          console.error(e)
+          return [] as WorkspaceWithProjects[]
+        }),
+        organizationId == null
+          ? Promise.resolve([] as StylebookCatalogRow[])
+          : listStylebookCatalogs(organizationId).catch((e) => {
+              console.error(e)
+              return [] as StylebookCatalogRow[]
+            }),
+      ])
+      if (cancelled) return
+      // Exclude synthetic grouping (e.g. _ungrouped).
+      const real = workspaceRows.filter((w) => w.id > 0 && w.slug !== '_ungrouped')
+      setWorkspaces(real)
+      setStylebooks(stylebookRows)
+      setChoicesLoading(false)
+      if (lockedWorkspaceId != null) {
+        setSelectedWorkspaceId(String(lockedWorkspaceId))
+        return
+      }
+      const def = real.find((w) => w.slug === 'default') ?? real[0]
+      setSelectedWorkspaceId(def ? String(def.id) : '')
     }
-    if (open && !project) {
-      void loadWorkspaces()
+
+    void load()
+    return () => {
+      cancelled = true
     }
-  }, [project, open, loadWorkspaces])
+  }, [open, project, organizationId, lockedWorkspaceId])
+
+  const parsedWorkspaceId = selectedWorkspaceId ? Number(selectedWorkspaceId) : Number.NaN
+  const activeWorkspaceId =
+    lockedWorkspaceId ?? (Number.isFinite(parsedWorkspaceId) ? parsedWorkspaceId : null)
+  const stylebookSelection: StylebookSelectionInput = {
+    stylebooks,
+    workspaceStylebookId:
+      workspaces.find((w) => w.id === activeWorkspaceId)?.stylebook_id ?? null,
+    chosenStylebookId,
+  }
+  const showStylebookChoice = !isEditing && shouldOfferStylebookChoice(stylebooks)
+  const selectedStylebookId = resolveStylebookSelection(stylebookSelection)
+  const busy = isLoading || isDeleting || choicesLoading
 
   const handleSave = async () => {
     if (!name.trim()) return
 
     try {
       setIsLoading(true)
-      const widLocked =
-        defaultWorkspaceId != null && defaultWorkspaceId > 0
-          ? defaultWorkspaceId
-          : null
-      const widSelect =
-        selectedWorkspaceId && workspaces.length > 0
-          ? parseInt(selectedWorkspaceId, 10)
-          : NaN
-      const wid =
-        widLocked ?? (Number.isFinite(widSelect) ? widSelect : null)
-      if (wid == null) return
-      await onSave({ name: name.trim(), workspace_id: wid })
+      if (activeWorkspaceId == null) return
+      await onSave({
+        name: name.trim(),
+        workspace_id: activeWorkspaceId,
+        stylebook_id: stylebookIdForCreate(stylebookSelection),
+      })
       onOpenChange(false)
       setName('')
     } catch (error) {
@@ -120,7 +161,7 @@ export default function ProjectDialog({
   }
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' && !isLoading) {
+    if (e.key === 'Enter' && !busy) {
       handleSave()
     }
   }
@@ -155,15 +196,17 @@ export default function ProjectDialog({
               disabled={isLoading || isDeleting}
             />
           </div>
-          {!isEditing &&
-          workspaces.length > 0 &&
-          (defaultWorkspaceId == null || defaultWorkspaceId <= 0) ? (
+          {!isEditing && workspaces.length > 0 && lockedWorkspaceId == null ? (
             <div className="grid grid-cols-4 items-center gap-4">
               <Label htmlFor="workspace" className="text-right">
                 Workspace
               </Label>
               <div className="col-span-3">
-                <Select value={selectedWorkspaceId} onValueChange={setSelectedWorkspaceId}>
+                <Select
+                  value={selectedWorkspaceId}
+                  onValueChange={setSelectedWorkspaceId}
+                  disabled={busy}
+                >
                   <SelectTrigger id="workspace">
                     <SelectValue placeholder="Select a workspace" />
                   </SelectTrigger>
@@ -175,6 +218,34 @@ export default function ProjectDialog({
                     ))}
                   </SelectContent>
                 </Select>
+              </div>
+            </div>
+          ) : null}
+          {showStylebookChoice ? (
+            <div className="grid grid-cols-4 items-center gap-4">
+              <Label htmlFor="stylebook" className="text-right">
+                Stylebook
+              </Label>
+              <div className="col-span-3">
+                <Select
+                  value={selectedStylebookId != null ? String(selectedStylebookId) : ''}
+                  onValueChange={(value) => setChosenStylebookId(Number(value))}
+                  disabled={busy}
+                >
+                  <SelectTrigger id="stylebook" aria-describedby="stylebook-help">
+                    <SelectValue placeholder="Select a Stylebook" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {stylebooks.map((sb) => (
+                      <SelectItem key={sb.id} value={String(sb.id)}>
+                        {sb.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <p id="stylebook-help" className="mt-1 text-xs text-muted-foreground">
+                  The project keeps this Stylebook after it is created.
+                </p>
               </div>
             </div>
           ) : null}
@@ -201,11 +272,14 @@ export default function ProjectDialog({
             >
               Cancel
             </Button>
-            <Button
-              onClick={handleSave}
-              disabled={!name.trim() || isLoading || isDeleting}
-            >
-              {isLoading ? 'Saving...' : (isEditing ? 'Update' : 'Create')}
+            <Button onClick={handleSave} disabled={!name.trim() || busy}>
+              {isLoading
+                ? 'Saving...'
+                : choicesLoading
+                  ? 'Loading...'
+                  : isEditing
+                    ? 'Update'
+                    : 'Create'}
             </Button>
           </div>
         </DialogFooter>

--- a/apps/agate-ui/src/components/ProjectSettings.tsx
+++ b/apps/agate-ui/src/components/ProjectSettings.tsx
@@ -19,6 +19,7 @@ import { listProjectApiKeys, setProjectApiKey, deleteProjectApiKey, updateProjec
 import ProjectAccessKeysPanel, {
   type ProjectAccessKeysPanelHandle,
 } from '@/components/ProjectAccessKeysPanel'
+import { projectStylebookDisplayName } from '@/lib/projectStylebook'
 import { format } from 'date-fns'
 
 export type ProjectSettingsHandle = {
@@ -365,6 +366,24 @@ const ProjectSettings = forwardRef<ProjectSettingsHandle, ProjectSettingsProps>(
       </div>
     )
 
+  /** Read-only: a project keeps the Stylebook it was created with. */
+  const stylebookSection = (
+    <div>
+      <div className="mb-4">
+        <h3 className="text-lg font-semibold">Stylebook</h3>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Locations, people, and organizations found in this project are saved to this Stylebook.
+          It is chosen when the project is created.
+        </p>
+      </div>
+      <Card>
+        <CardContent className="p-4">
+          <h4 className="font-medium">{projectStylebookDisplayName(project)}</h4>
+        </CardContent>
+      </Card>
+    </div>
+  )
+
   const systemPromptSection = (
           <div className="border-t border-border pt-10">
             <div className="mb-4">
@@ -674,6 +693,7 @@ const ProjectSettings = forwardRef<ProjectSettingsHandle, ProjectSettingsProps>(
     return inlineShell(
       <>
         {errorAlert}
+        {stylebookSection}
         {systemPromptSection}
       </>
     )
@@ -692,6 +712,7 @@ const ProjectSettings = forwardRef<ProjectSettingsHandle, ProjectSettingsProps>(
     <div className="space-y-6 w-full min-w-0">
       {errorAlert}
       {projectNameSection}
+      {stylebookSection}
       {systemPromptSection}
       {credentialsSection(true)}
     </div>

--- a/apps/agate-ui/src/lib/api.test.ts
+++ b/apps/agate-ui/src/lib/api.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createProject } from './api'
+
+function stubFetch() {
+  const fetchMock = vi.fn(
+    async (_input: RequestInfo | URL, _init?: RequestInit) =>
+      new Response(JSON.stringify({ id: 7 }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+  )
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+function sentBody(fetchMock: ReturnType<typeof stubFetch>): Record<string, unknown> {
+  const init = fetchMock.mock.calls[0]?.[1]
+  return JSON.parse(String(init?.body))
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe('createProject', () => {
+  it('sends the chosen Stylebook', async () => {
+    const fetchMock = stubFetch()
+
+    await createProject({ name: 'Investigations', workspace_id: 3, stylebook_id: 9 })
+
+    expect(sentBody(fetchMock).stylebook_id).toBe(9)
+  })
+
+  it('omits the Stylebook so the workspace default applies', async () => {
+    const fetchMock = stubFetch()
+
+    await createProject({ name: 'Investigations', workspace_id: 3 })
+
+    expect(sentBody(fetchMock)).not.toHaveProperty('stylebook_id')
+  })
+
+  it('omits an explicitly null Stylebook rather than sending null', async () => {
+    const fetchMock = stubFetch()
+
+    await createProject({ name: 'Investigations', workspace_id: 3, stylebook_id: null })
+
+    expect(sentBody(fetchMock)).not.toHaveProperty('stylebook_id')
+  })
+})

--- a/apps/agate-ui/src/lib/api.ts
+++ b/apps/agate-ui/src/lib/api.ts
@@ -52,12 +52,17 @@ export interface Project {
   created_at: string
   updated_at?: string
   workspace_id?: number | null
+  /** The project's own Stylebook: authoritative for reads, writes, and Stylebook UI routes. */
   stylebook_id?: number | null
   stylebook_name?: string | null
   stylebook_slug?: string | null
+  /**
+   * The workspace's current Stylebook, which is only the default offered at project creation.
+   * It differs from the project's Stylebook whenever the project was created with an explicit
+   * choice, so never use it to read or write catalog data. Null when it cannot be resolved.
+   */
   workspace_stylebook_id?: number | null
   workspace_stylebook_name?: string | null
-  /** Stable catalog slug for Stylebook UI routes when the workspace resolves a Stylebook. */
   workspace_stylebook_slug?: string | null
 }
 
@@ -299,6 +304,8 @@ export interface ProjectCreate {
   name: string
   slug?: string
   workspace_id: number
+  /** Omit to inherit the workspace's Stylebook. */
+  stylebook_id?: number | null
 }
 
 export interface ProjectUpdate {
@@ -1173,6 +1180,7 @@ export async function createProject(data: ProjectCreate): Promise<Project> {
       name: data.name,
       slug: data.slug,
       workspace_id: data.workspace_id,
+      ...(data.stylebook_id != null ? { stylebook_id: data.stylebook_id } : {}),
     }),
   }) as Promise<Project>
 }

--- a/apps/agate-ui/src/lib/projectStylebook.test.ts
+++ b/apps/agate-ui/src/lib/projectStylebook.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { projectStylebookDisplayName, reviewStylebookSlug } from './projectStylebook'
+import type { Project } from '@/lib/api'
+
+/** A project created with an explicit Stylebook: its workspace still points somewhere else. */
+const DIVERGENT_PROJECT = {
+  id: 1,
+  name: 'Investigations',
+  slug: 'investigations',
+  organization_id: 1,
+  created_at: '2026-01-01T00:00:00Z',
+  stylebook_id: 2,
+  stylebook_name: 'Sports',
+  stylebook_slug: 'sports',
+  workspace_stylebook_id: 1,
+  workspace_stylebook_name: 'House',
+  workspace_stylebook_slug: 'house',
+} as Project
+
+describe('reviewStylebookSlug', () => {
+  it('targets the project Stylebook, never the workspace one', () => {
+    expect(reviewStylebookSlug(DIVERGENT_PROJECT)).toBe('sports')
+    expect(reviewStylebookSlug(DIVERGENT_PROJECT)).not.toBe(
+      DIVERGENT_PROJECT.workspace_stylebook_slug,
+    )
+  })
+
+  it('has no target before the project loads', () => {
+    expect(reviewStylebookSlug(null)).toBeNull()
+    expect(reviewStylebookSlug(undefined)).toBeNull()
+  })
+
+  it('treats a blank or missing project Stylebook as no target', () => {
+    expect(reviewStylebookSlug({ ...DIVERGENT_PROJECT, stylebook_slug: '  ' })).toBeNull()
+    expect(reviewStylebookSlug({ ...DIVERGENT_PROJECT, stylebook_slug: null })).toBeNull()
+  })
+})
+
+describe('projectStylebookDisplayName', () => {
+  it('shows the project Stylebook name', () => {
+    expect(projectStylebookDisplayName({ stylebook_name: 'Sports' })).toBe('Sports')
+  })
+
+  it('stays readable when no name came back', () => {
+    expect(projectStylebookDisplayName({ stylebook_name: null })).toBe('Not available')
+    expect(projectStylebookDisplayName({ stylebook_name: '  ' })).toBe('Not available')
+  })
+})

--- a/apps/agate-ui/src/lib/projectStylebook.ts
+++ b/apps/agate-ui/src/lib/projectStylebook.ts
@@ -1,0 +1,25 @@
+/**
+ * The Stylebook a project reads and writes.
+ *
+ * A project owns its Stylebook directly from the moment it is created. Its workspace only
+ * supplies the default offered at creation, so the two diverge whenever a project was created
+ * with an explicit choice. Anything that reads or writes catalog data for a project must use
+ * the project's own Stylebook.
+ */
+
+import type { Project } from '@/lib/api'
+
+/**
+ * Stylebook slug that story review reads, writes, and deep-links into.
+ *
+ * Never substitute `workspace_stylebook_slug`: that reports the workspace's current default and
+ * would send edits into the wrong Stylebook.
+ */
+export function reviewStylebookSlug(project: Project | null | undefined): string | null {
+  return project?.stylebook_slug?.trim() || null
+}
+
+/** Name shown on project settings for the Stylebook a project writes into. */
+export function projectStylebookDisplayName(project: Pick<Project, 'stylebook_name'>): string {
+  return project.stylebook_name?.trim() || 'Not available'
+}

--- a/apps/agate-ui/src/lib/projectStylebookChoice.test.ts
+++ b/apps/agate-ui/src/lib/projectStylebookChoice.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest'
+import {
+  resolveStylebookSelection,
+  shouldOfferStylebookChoice,
+  stylebookIdForCreate,
+  type StylebookOption,
+} from './projectStylebookChoice'
+
+const stylebook = (id: number, name: string): StylebookOption => ({ id, name })
+
+const ONE_BOOK = [stylebook(1, 'House')]
+const TWO_BOOKS = [stylebook(1, 'House'), stylebook(2, 'Sports')]
+
+describe('shouldOfferStylebookChoice', () => {
+  it('hides the choice when the organization has one Stylebook', () => {
+    expect(shouldOfferStylebookChoice(ONE_BOOK)).toBe(false)
+    expect(shouldOfferStylebookChoice([])).toBe(false)
+  })
+
+  it('offers the choice when the organization has several Stylebooks', () => {
+    expect(shouldOfferStylebookChoice(TWO_BOOKS)).toBe(true)
+  })
+})
+
+describe('resolveStylebookSelection', () => {
+  it('defaults to the selected workspace Stylebook', () => {
+    expect(
+      resolveStylebookSelection({
+        stylebooks: TWO_BOOKS,
+        workspaceStylebookId: 2,
+        chosenStylebookId: null,
+      }),
+    ).toBe(2)
+  })
+
+  it('keeps an explicit pick when the workspace changes', () => {
+    expect(
+      resolveStylebookSelection({
+        stylebooks: TWO_BOOKS,
+        workspaceStylebookId: 1,
+        chosenStylebookId: 2,
+      }),
+    ).toBe(2)
+  })
+
+  it('falls back to the first Stylebook so the control is never blank', () => {
+    expect(
+      resolveStylebookSelection({
+        stylebooks: TWO_BOOKS,
+        workspaceStylebookId: 99,
+        chosenStylebookId: 98,
+      }),
+    ).toBe(1)
+  })
+
+  it('returns null when the organization has no Stylebooks to show', () => {
+    expect(
+      resolveStylebookSelection({
+        stylebooks: [],
+        workspaceStylebookId: 1,
+        chosenStylebookId: null,
+      }),
+    ).toBeNull()
+  })
+})
+
+describe('stylebookIdForCreate', () => {
+  it('sends the picked Stylebook', () => {
+    expect(
+      stylebookIdForCreate({
+        stylebooks: TWO_BOOKS,
+        workspaceStylebookId: 1,
+        chosenStylebookId: 2,
+      }),
+    ).toBe(2)
+  })
+
+  it('sends nothing when the person never picked, so the server applies its own default', () => {
+    expect(
+      stylebookIdForCreate({
+        stylebooks: TWO_BOOKS,
+        workspaceStylebookId: 2,
+        chosenStylebookId: null,
+      }),
+    ).toBeNull()
+  })
+
+  it('never sends a displayed fallback the person did not choose', () => {
+    // The control shows the first Stylebook when the workspace default is unknown; that
+    // display-only value must not be pinned onto the project.
+    const input = {
+      stylebooks: TWO_BOOKS,
+      workspaceStylebookId: null,
+      chosenStylebookId: null,
+    }
+    expect(resolveStylebookSelection(input)).toBe(1)
+    expect(stylebookIdForCreate(input)).toBeNull()
+  })
+
+  it('sends nothing when no choice was offered', () => {
+    expect(
+      stylebookIdForCreate({
+        stylebooks: ONE_BOOK,
+        workspaceStylebookId: 1,
+        chosenStylebookId: null,
+      }),
+    ).toBeNull()
+  })
+
+  it('drops a pick that is no longer in the organization list', () => {
+    expect(
+      stylebookIdForCreate({
+        stylebooks: TWO_BOOKS,
+        workspaceStylebookId: 1,
+        chosenStylebookId: 404,
+      }),
+    ).toBeNull()
+  })
+})

--- a/apps/agate-ui/src/lib/projectStylebookChoice.ts
+++ b/apps/agate-ui/src/lib/projectStylebookChoice.ts
@@ -1,0 +1,63 @@
+/**
+ * Choosing a Stylebook while creating a project.
+ *
+ * A project's Stylebook is fixed when the project is created. The workspace supplies the
+ * default, and the person creating the project may pick a different Stylebook from the
+ * same organization. Most organizations have exactly one Stylebook and never see a choice.
+ */
+
+/** Minimal shape the dialog needs from an organization's Stylebook list. */
+export interface StylebookOption {
+  id: number
+  name: string
+}
+
+export interface StylebookSelectionInput {
+  stylebooks: StylebookOption[]
+  /** Default from the workspace currently selected in the dialog. */
+  workspaceStylebookId: number | null
+  /** Set once the person creating the project picks a Stylebook themselves. */
+  chosenStylebookId: number | null
+}
+
+export function shouldOfferStylebookChoice(stylebooks: StylebookOption[]): boolean {
+  return stylebooks.length > 1
+}
+
+/**
+ * The Stylebook the dialog shows as selected.
+ *
+ * An explicit pick wins and survives a workspace change, so the choice is never silently
+ * undone. Without a pick, the selection follows the workspace default. Values that are not
+ * in the organization's list (stale pick, unreadable workspace) fall back to the first
+ * Stylebook so the control is never blank.
+ */
+export function resolveStylebookSelection({
+  stylebooks,
+  workspaceStylebookId,
+  chosenStylebookId,
+}: StylebookSelectionInput): number | null {
+  const available = new Set(stylebooks.map((s) => s.id))
+  if (chosenStylebookId != null && available.has(chosenStylebookId)) {
+    return chosenStylebookId
+  }
+  if (workspaceStylebookId != null && available.has(workspaceStylebookId)) {
+    return workspaceStylebookId
+  }
+  return stylebooks[0]?.id ?? null
+}
+
+/**
+ * Value to send with a create request, or `null` to omit the field.
+ *
+ * Only a deliberate pick is sent. The displayed default is a hint drawn from data the client
+ * may have fetched a while ago, so sending it back would pin a possibly stale workspace
+ * default instead of the one the server resolves at creation time.
+ */
+export function stylebookIdForCreate({
+  stylebooks,
+  chosenStylebookId,
+}: StylebookSelectionInput): number | null {
+  if (chosenStylebookId == null) return null
+  return stylebooks.some((s) => s.id === chosenStylebookId) ? chosenStylebookId : null
+}

--- a/apps/agate-ui/src/lib/review/entities/location/reviewRow.test.ts
+++ b/apps/agate-ui/src/lib/review/entities/location/reviewRow.test.ts
@@ -72,7 +72,7 @@ describe('processedItemReviewRow', () => {
     ).toBe(77)
   })
 
-  it('prefers row stylebook_slug over workspace slug for links', () => {
+  it("prefers row stylebook_slug over the project's Stylebook for links", () => {
     const row = {
       stylebook_slug: 'illinois-stylebook',
       stylebook_location_canonical_id: 'uuid-1',

--- a/apps/agate-ui/src/lib/review/entities/location/reviewRow.ts
+++ b/apps/agate-ui/src/lib/review/entities/location/reviewRow.ts
@@ -79,7 +79,7 @@ export function getMergedRowStylebookCanonicalId(row: Record<string, unknown>): 
   return null
 }
 
-/** Stylebook that owns the linked canonical (preferred over project workspace slug). */
+/** Stylebook that owns the linked canonical (preferred over the project's Stylebook). */
 export function getMergedRowStylebookSlug(row: Record<string, unknown>): string | null {
   const raw = row.stylebook_slug
   if (typeof raw === 'string' && raw.trim()) {
@@ -88,12 +88,12 @@ export function getMergedRowStylebookSlug(row: Record<string, unknown>): string 
   return null
 }
 
-/** Slug for deep links to a linked canonical; row slug wins over workspace default. */
+/** Slug for deep links to a linked canonical; row slug wins over the project's Stylebook. */
 export function resolveStylebookSlugForLinkedRow(
   row: Record<string, unknown>,
-  workspaceStylebookSlug: string | null | undefined,
+  projectStylebookSlug: string | null | undefined,
 ): string | null {
-  return getMergedRowStylebookSlug(row) ?? (workspaceStylebookSlug?.trim() || null)
+  return getMergedRowStylebookSlug(row) ?? (projectStylebookSlug?.trim() || null)
 }
 
 export function getMergedRowStylebookLink(row: Record<string, unknown>): MergedRowStylebookLink | null {

--- a/apps/agate-ui/src/lib/review/entities/organization/reviewRow.ts
+++ b/apps/agate-ui/src/lib/review/entities/organization/reviewRow.ts
@@ -55,9 +55,9 @@ export function getMergedRowStylebookSlug(row: Record<string, unknown>): string 
 
 export function resolveStylebookSlugForLinkedRow(
   row: Record<string, unknown>,
-  workspaceStylebookSlug: string | null | undefined,
+  projectStylebookSlug: string | null | undefined,
 ): string | null {
-  return getMergedRowStylebookSlug(row) ?? (workspaceStylebookSlug?.trim() || null)
+  return getMergedRowStylebookSlug(row) ?? (projectStylebookSlug?.trim() || null)
 }
 
 export function isMergedRowLinkedToStylebook(row: Record<string, unknown>): boolean {

--- a/apps/agate-ui/src/lib/review/entities/person/reviewRow.ts
+++ b/apps/agate-ui/src/lib/review/entities/person/reviewRow.ts
@@ -43,7 +43,7 @@ export function getMergedRowCanonicalLinkStatus(row: Record<string, unknown>): s
   return null
 }
 
-/** Stylebook that owns the linked canonical (preferred over project workspace slug). */
+/** Stylebook that owns the linked canonical (preferred over the project's Stylebook). */
 export function getMergedRowStylebookSlug(row: Record<string, unknown>): string | null {
   const raw = row.stylebook_slug
   if (typeof raw === 'string' && raw.trim()) {
@@ -52,12 +52,12 @@ export function getMergedRowStylebookSlug(row: Record<string, unknown>): string 
   return null
 }
 
-/** Slug for deep links and substrate deletes; row slug wins over workspace default. */
+/** Slug for deep links and substrate deletes; row slug wins over the project's Stylebook. */
 export function resolveStylebookSlugForLinkedRow(
   row: Record<string, unknown>,
-  workspaceStylebookSlug: string | null | undefined,
+  projectStylebookSlug: string | null | undefined,
 ): string | null {
-  return getMergedRowStylebookSlug(row) ?? (workspaceStylebookSlug?.trim() || null)
+  return getMergedRowStylebookSlug(row) ?? (projectStylebookSlug?.trim() || null)
 }
 
 export function isMergedRowLinkedToStylebook(row: Record<string, unknown>): boolean {

--- a/apps/agate-ui/src/pages/GuidedFlowBuilder.tsx
+++ b/apps/agate-ui/src/pages/GuidedFlowBuilder.tsx
@@ -573,9 +573,6 @@ const GuidedFlowBuilder = forwardRef<GuidedFlowBuilderHandle, GuidedFlowBuilderP
       return {
         organizationId: null as number | null,
         projectId: null as number | null,
-        workspaceDefaultStylebookId: null as number | null,
-        workspaceStylebookName: null as string | null,
-        missingWorkspaceStylebook: false,
         flowProjectLoading: true,
       }
     }
@@ -584,21 +581,12 @@ const GuidedFlowBuilder = forwardRef<GuidedFlowBuilderHandle, GuidedFlowBuilderP
       return {
         organizationId: null as number | null,
         projectId: null as number | null,
-        workspaceDefaultStylebookId: null as number | null,
-        workspaceStylebookName: null as string | null,
-        missingWorkspaceStylebook: false,
         flowProjectLoading: false,
       }
     }
-    const sid = p.workspace_stylebook_id ?? null
-    const rawName = p.workspace_stylebook_name
-    const nm = typeof rawName === 'string' && rawName.trim() !== '' ? rawName.trim() : null
     return {
       organizationId: p.organization_id ?? null,
       projectId: p.id ?? null,
-      workspaceDefaultStylebookId: sid,
-      workspaceStylebookName: nm,
-      missingWorkspaceStylebook: sid == null && nm == null,
       flowProjectLoading: false,
       fetchProjectAiModels: flowProjectId != null ? fetchProjectAiModels : undefined,
       publicRunEnabled,

--- a/apps/agate-ui/src/pages/ProcessedItemDetail.tsx
+++ b/apps/agate-ui/src/pages/ProcessedItemDetail.tsx
@@ -18,6 +18,7 @@ import { s3OutputUploadsFromItemOutput, s3ObjectPublicHttpsUrl } from '@/lib/rev
 import { listMyWorkspaces, type WorkspaceWithProjects } from '@/lib/core-api'
 import { getVisualizationsForItem, type VisualizationDescriptor } from '@/lib/visualizations'
 import { processedItemDisplayTitle } from '@/lib/review/content/displayTitle'
+import { reviewStylebookSlug } from '@/lib/projectStylebook'
 import {
   PROCESSED_ITEM_DETAIL_TABS,
   isProcessedItemDetailTab,
@@ -738,7 +739,7 @@ export default function ProcessedItemDetail() {
               graph={graph}
               onItemUpdated={(next) => setItem({ ...next, synthetic: false })}
               onVerificationDirtyChange={handleVerificationDirtyChange}
-              catalogStylebookSlug={catalogProject?.workspace_stylebook_slug ?? null}
+              catalogStylebookSlug={reviewStylebookSlug(catalogProject)}
               catalogProjectSlug={catalogProject?.slug ?? null}
               reviewLocked={reviewLocked}
             />
@@ -760,7 +761,7 @@ export default function ProcessedItemDetail() {
               graph={graph}
               onItemUpdated={(next) => setItem({ ...next, synthetic: false })}
               onVerificationDirtyChange={handleVerificationDirtyChange}
-              catalogStylebookSlug={catalogProject?.workspace_stylebook_slug ?? null}
+              catalogStylebookSlug={reviewStylebookSlug(catalogProject)}
               catalogProjectSlug={catalogProject?.slug ?? null}
               reviewLocked={reviewLocked}
             />
@@ -782,7 +783,7 @@ export default function ProcessedItemDetail() {
               graph={graph}
               onItemUpdated={(next) => setItem({ ...next, synthetic: false })}
               onVerificationDirtyChange={handleVerificationDirtyChange}
-              catalogStylebookSlug={catalogProject?.workspace_stylebook_slug ?? null}
+              catalogStylebookSlug={reviewStylebookSlug(catalogProject)}
               catalogProjectSlug={catalogProject?.slug ?? null}
               reviewLocked={reviewLocked}
             />

--- a/docs/api/agate.md
+++ b/docs/api/agate.md
@@ -31,15 +31,23 @@ its organization, Stylebook, workspace, administrators, and curated model snapsh
 HTTP endpoint and does not change Agate API ownership of interactive project lifecycle operations.
 
 - List responses are filtered to visible projects.
-- Project creation requires `workspace_id` and copies that workspace's Stylebook into the
-  project's direct ownership field. Session users must belong to the workspace organization;
-  members need workspace membership, and org admins may assign any workspace in their org.
-  The required workspace is the explicit organization context for service-token callers; the
-  endpoint never falls back to a default organization.
+- Project creation requires `workspace_id`. Session users must belong to the workspace
+  organization; members need workspace membership, and org admins may assign any workspace in
+  their org. The required workspace is the explicit organization context for service-token
+  callers; the endpoint never falls back to a default organization.
+- Project creation accepts an optional `stylebook_id`. It must belong to the workspace's
+  organization, and any other value is rejected with `400`. When it is omitted, the workspace's
+  Stylebook is copied into the project's direct ownership field. Assigning a Stylebook does not
+  require Stylebook editor membership. There is no endpoint for changing a project's Stylebook
+  after creation.
 - Secret responses contain metadata, never secret values.
-- Project responses expose direct `stylebook_id`, `stylebook_name`, and `stylebook_slug` fields
-  while retaining the `workspace_stylebook_*` response fields for compatibility. The direct
-  project Stylebook is authoritative. A later workspace Stylebook change does not alter existing
+- Project responses expose the authoritative `stylebook_id`, `stylebook_name`, and
+  `stylebook_slug` fields. Use them for every read, write, and Stylebook UI route.
+- The `workspace_stylebook_*` response fields remain, but they now report the workspace's own
+  Stylebook rather than the project's. For a project created with an explicit choice the two
+  differ, so a caller that treats them as interchangeable will target the wrong Stylebook. They
+  are null when the workspace or its Stylebook cannot be resolved, which is logged and degraded
+  rather than failing the request. A later workspace Stylebook change does not alter existing
   projects.
 
 ### Flows and templates

--- a/docs/architecture/canonicalization.md
+++ b/docs/architecture/canonicalization.md
@@ -121,8 +121,9 @@ occurrence evidence; canonical identity is resolved through the substrate link a
 
 ## Catalog selection
 
-The project's direct Stylebook ownership is authoritative. Temporary explicit-id and slug
-parameters remain compatible only when they identify that same Stylebook; conflicting values are
-rejected. Backfield Output and GeocodeAgent inherit the project assignment. Graph writes persist
-that id on those nodes for rolling worker compatibility, while completed run snapshots remain
-unchanged.
+The project's direct Stylebook ownership is authoritative. It is set once when the project is
+created, either from an explicit same-organization choice or from the workspace default, and is
+not reassigned afterward. Temporary explicit-id and slug parameters remain compatible only when
+they identify that same Stylebook; conflicting values are rejected. Backfield Output and
+GeocodeAgent inherit the project assignment. Graph writes persist that id on those nodes for
+rolling worker compatibility, while completed run snapshots remain unchanged.

--- a/docs/architecture/database.md
+++ b/docs/architecture/database.md
@@ -23,10 +23,11 @@ All schema changes use the single Alembic chain under `packages/backfield-db/ale
 - Organizations, workspaces, projects, and users:
   `backfield_organization`, `backfield_workspace`, `backfield_project`, `backfield_user`.
   Projects store both their workspace and a direct Stylebook ownership reference. The direct
-  reference and workspace are required, indexed, and copied from the selected workspace when a
-  project is created. Composite foreign keys prevent projects and workspaces from retaining
-  cross-organization ownership references. Users created with provisioning temporary passwords
-  carry `must_change_password` until the password-change flow succeeds.
+  reference and workspace are required and indexed. The Stylebook is set once at creation, either
+  from an explicit same-organization choice or by copying the selected workspace's Stylebook.
+  Composite foreign keys prevent projects and workspaces from retaining cross-organization
+  ownership references. Users created with provisioning temporary passwords carry
+  `must_change_password` until the password-change flow succeeds.
 - Access grants and API keys: `backfield_organization_membership`,
   `backfield_workspace_membership`, `backfield_project_membership`,
   `backfield_api_credential`. Personal API credentials retain their owning `user_id` and are
@@ -104,8 +105,9 @@ shared entity rows are not trusted because sibling batch items may reuse the sam
 Canonical ids are UUID strings. Canonical slugs are unique within a Stylebook, and aliases are
 unique by canonical plus normalized alias. A Stylebook belongs to one organization. The project's
 direct `stylebook_id` is authoritative for project-scoped reads and runtime writes. Compatibility
-slug or node parameters are accepted only when they match that assignment. Changing a workspace's
-Stylebook affects future project creation but does not rewrite existing project ownership.
+slug or node parameters are accepted only when they match that assignment. A workspace's Stylebook
+is only the default offered at project creation; changing it does not rewrite existing project
+ownership.
 
 Deleting a Stylebook reassigns projects, workspaces, and graph Stylebook refs, resets linked
 substrate rows to pending, removes non-cascading dependents (activity, bundle jobs, cleanup and

--- a/docs/development/frontend/agate.md
+++ b/docs/development/frontend/agate.md
@@ -127,6 +127,16 @@ can sync reviewed S3 Output content back to its object.
 - Core session helpers are in `src/lib/core-api.ts`; Agate API helpers are in
   `src/lib/api.ts`.
 - Workspace and project navigation is sourced from Core access data.
+- The create-project dialog offers a Stylebook choice only when the organization has more than
+  one Stylebook, defaulting to the selected workspace's Stylebook. It lists them through
+  `listStylebookCatalogs` in `src/lib/stylebook-org-api.ts`, which any member of the
+  organization may call; the Core admin listing would hide the choice from non-admins. Only a
+  deliberate pick is submitted, so the server stays the source of truth for the workspace
+  default. Project settings then show the project's Stylebook read-only, because it cannot
+  change after creation.
+- Story review reads, writes, and deep-links using the project's own `stylebook_slug`. The
+  `workspace_stylebook_*` fields describe the workspace, not the project, and must not be used
+  as a catalog target.
 - Organization administrators use the Settings hub for AI models, integrations,
   users, and Stylebooks.
 - Current settings routes are `/settings/models` and `/settings/integrations`.

--- a/docs/development/frontend/stylebook.md
+++ b/docs/development/frontend/stylebook.md
@@ -172,7 +172,9 @@ flagged item links to its canonical detail page.
 ## Cross-app navigation
 
 Agate builds Stylebook links through `apps/agate-ui/src/lib/platformUrls.ts` and
-passes the selected workspace Stylebook slug plus optional project context.
+passes the project's own Stylebook slug plus optional project context. Never pass a
+workspace Stylebook slug: a workspace only supplies the default offered at project
+creation, so it points at the wrong Stylebook for any project created with a choice.
 Stylebook workspace and project links return to Agate through its own platform URL
 helpers. Leave origins unset for Backfield Cloud split hosts (sibling origins are
 derived from the current hostname) or same-origin local deploys; set the paired

--- a/docs/development/nodes.md
+++ b/docs/development/nodes.md
@@ -242,9 +242,10 @@ wiring is automatic.
 guidance, tab navigation, invalid-connection messaging, and lazy panel loading.
 Package panels render only inner content.
 
-`GraphPanelContext` provides organization and project IDs, workspace Stylebook
-defaults, and project AI-model loading. Reuse that context and existing helpers
-instead of calling Core directly from a package panel.
+`GraphPanelContext` provides organization and project IDs and project AI-model
+loading. Nodes inherit the project's Stylebook, so panels never select one. Reuse
+that context and existing helpers instead of calling Core directly from a package
+panel.
 
 Tab IDs and labels are centralized in `src/lib/nodePanelTabs.ts`. Current routing:
 

--- a/tests/agate_api/test_project_stylebook_ownership.py
+++ b/tests/agate_api/test_project_stylebook_ownership.py
@@ -1,4 +1,4 @@
-"""Project creation pins the selected workspace's Stylebook."""
+"""Project creation pins a chosen Stylebook, or the selected workspace's default."""
 
 from __future__ import annotations
 
@@ -8,9 +8,12 @@ from dataclasses import dataclass
 import pytest
 from api.deps import get_session
 from api.main import app
+from backfield_auth import create_session_token
 from backfield_db import (
     BackfieldOrganization,
+    BackfieldOrganizationMembership,
     BackfieldProject,
+    BackfieldUser,
     BackfieldWorkspace,
     Stylebook,
 )
@@ -90,6 +93,37 @@ def ownership_fixture(tmp_path) -> Generator[ProjectOwnershipFixture, None, None
         app.dependency_overrides.clear()
 
 
+def _session_client(
+    ownership_fixture: ProjectOwnershipFixture,
+    *,
+    org_role: str,
+) -> TestClient:
+    """Client for a browser session in the fixture's organization with no workspace grants."""
+    email = f"{org_role}@example.com"
+    with Session(ownership_fixture.engine) as session:
+        user = BackfieldUser(email=email, password_hash="unused")
+        session.add(user)
+        session.commit()
+        session.refresh(user)
+        user_id = int(user.id)
+        session.add(
+            BackfieldOrganizationMembership(
+                user_id=user_id,
+                organization_id=ownership_fixture.organization_id,
+                role=org_role,
+            )
+        )
+        session.commit()
+    token = create_session_token(
+        user_id=user_id,
+        email=email,
+        projects=[],
+        organization_id=ownership_fixture.organization_id,
+        org_role=org_role,
+    )
+    return TestClient(app, cookies={"session": token})
+
+
 def test_project_create_requires_workspace(
     ownership_fixture: ProjectOwnershipFixture,
 ) -> None:
@@ -150,9 +184,296 @@ def test_workspace_stylebook_change_does_not_mutate_existing_project(
     response = ownership_fixture.client.get(f"/projects/{project_id}")
     assert response.status_code == 200
     assert response.json()["stylebook_id"] == ownership_fixture.original_stylebook_id
-    assert response.json()["workspace_stylebook_id"] == ownership_fixture.original_stylebook_id
+    assert response.json()["workspace_stylebook_id"] == ownership_fixture.replacement_stylebook_id
     with Session(ownership_fixture.engine) as session:
         project = session.get(BackfieldProject, project_id)
+        assert project is not None
+        assert project.stylebook_id == ownership_fixture.original_stylebook_id
+
+
+def test_project_create_accepts_an_explicit_stylebook(
+    ownership_fixture: ProjectOwnershipFixture,
+) -> None:
+    response = ownership_fixture.client.post(
+        "/projects",
+        json={
+            "name": "Chosen project",
+            "slug": "chosen-project",
+            "workspace_id": ownership_fixture.workspace_id,
+            "stylebook_id": ownership_fixture.replacement_stylebook_id,
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["stylebook_id"] == ownership_fixture.replacement_stylebook_id
+    assert body["stylebook_name"] == "Replacement"
+    assert body["stylebook_slug"] == "replacement"
+    with Session(ownership_fixture.engine) as session:
+        project = session.get(BackfieldProject, int(body["id"]))
+        assert project is not None
+        assert project.stylebook_id == ownership_fixture.replacement_stylebook_id
+
+
+def test_workspace_stylebook_fields_report_the_workspace_not_the_project(
+    ownership_fixture: ProjectOwnershipFixture,
+) -> None:
+    body = ownership_fixture.client.post(
+        "/projects",
+        json={
+            "name": "Divergent project",
+            "slug": "divergent-project",
+            "workspace_id": ownership_fixture.workspace_id,
+            "stylebook_id": ownership_fixture.replacement_stylebook_id,
+        },
+    ).json()
+
+    response = ownership_fixture.client.get(f"/projects/{int(body['id'])}")
+
+    assert response.status_code == 200
+    project = response.json()
+    assert project["stylebook_id"] == ownership_fixture.replacement_stylebook_id
+    assert project["workspace_stylebook_id"] == ownership_fixture.original_stylebook_id
+    assert project["workspace_stylebook_name"] == "Original"
+    assert project["workspace_stylebook_slug"] == "original"
+
+
+def _foreign_stylebook_id(engine: Engine) -> int:
+    with Session(engine) as session:
+        other_org = BackfieldOrganization(name="Other Org", slug="other-org")
+        session.add(other_org)
+        session.flush()
+        foreign = Stylebook(
+            organization_id=int(other_org.id),
+            name="Foreign",
+            slug="foreign",
+            is_default=True,
+        )
+        session.add(foreign)
+        session.commit()
+        session.refresh(foreign)
+        return int(foreign.id)
+
+
+def test_service_token_cannot_assign_a_stylebook_from_another_organization(
+    ownership_fixture: ProjectOwnershipFixture,
+) -> None:
+    """Service tokens may omit an organization, so the workspace supplies the only scope."""
+    response = ownership_fixture.client.post(
+        "/projects",
+        json={
+            "name": "Cross org project",
+            "slug": "cross-org-project",
+            "workspace_id": ownership_fixture.workspace_id,
+            "stylebook_id": _foreign_stylebook_id(ownership_fixture.engine),
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Stylebook not found in this organization"
+
+
+def test_session_admin_cannot_assign_a_stylebook_from_another_organization(
+    ownership_fixture: ProjectOwnershipFixture,
+) -> None:
+    foreign_stylebook_id = _foreign_stylebook_id(ownership_fixture.engine)
+    client = _session_client(ownership_fixture, org_role="org_admin")
+
+    response = client.post(
+        "/projects",
+        json={
+            "name": "Cross org project",
+            "slug": "cross-org-project",
+            "workspace_id": ownership_fixture.workspace_id,
+            "stylebook_id": foreign_stylebook_id,
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Stylebook not found in this organization"
+
+
+def test_workspace_access_is_checked_before_the_requested_stylebook(
+    ownership_fixture: ProjectOwnershipFixture,
+) -> None:
+    """A member outside the workspace is refused without learning anything about Stylebooks."""
+    client = _session_client(ownership_fixture, org_role="member")
+
+    response = client.post(
+        "/projects",
+        json={
+            "name": "No membership",
+            "slug": "no-membership",
+            "workspace_id": ownership_fixture.workspace_id,
+            "stylebook_id": 99_999,
+        },
+    )
+
+    assert response.status_code == 403
+    assert "workspace" in response.json()["detail"].lower()
+
+
+def test_project_create_rejects_an_unknown_stylebook(
+    ownership_fixture: ProjectOwnershipFixture,
+) -> None:
+    response = ownership_fixture.client.post(
+        "/projects",
+        json={
+            "name": "Missing stylebook project",
+            "slug": "missing-stylebook-project",
+            "workspace_id": ownership_fixture.workspace_id,
+            "stylebook_id": 99_999,
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Stylebook not found in this organization"
+
+
+@pytest.mark.parametrize(
+    ("field_name", "body_extra"),
+    [
+        ("omitted", {}),
+        ("null", {"stylebook_id": None}),
+        ("workspace default", {"stylebook_id": "__workspace_default__"}),
+    ],
+)
+def test_project_create_falls_back_to_the_workspace_default(
+    ownership_fixture: ProjectOwnershipFixture,
+    field_name: str,
+    body_extra: dict[str, object],
+) -> None:
+    """Omitted, explicitly null, and explicitly-the-default all land on the workspace default."""
+    body: dict[str, object] = {
+        "name": f"Fallback {field_name}",
+        "slug": f"fallback-{field_name.replace(' ', '-')}",
+        "workspace_id": ownership_fixture.workspace_id,
+        **body_extra,
+    }
+    if body.get("stylebook_id") == "__workspace_default__":
+        body["stylebook_id"] = ownership_fixture.original_stylebook_id
+
+    response = ownership_fixture.client.post("/projects", json=body)
+
+    assert response.status_code == 200, response.text
+    assert response.json()["stylebook_id"] == ownership_fixture.original_stylebook_id
+
+
+def test_project_list_reports_the_workspace_stylebook_separately(
+    ownership_fixture: ProjectOwnershipFixture,
+) -> None:
+    """The list loop resolves both Stylebooks, not just the detail endpoint."""
+    ownership_fixture.client.post(
+        "/projects",
+        json={
+            "name": "Listed project",
+            "slug": "listed-project",
+            "workspace_id": ownership_fixture.workspace_id,
+            "stylebook_id": ownership_fixture.replacement_stylebook_id,
+        },
+    )
+
+    response = ownership_fixture.client.get("/projects")
+
+    assert response.status_code == 200
+    listed = [row for row in response.json() if row["slug"] == "listed-project"]
+    assert len(listed) == 1
+    assert listed[0]["stylebook_id"] == ownership_fixture.replacement_stylebook_id
+    assert listed[0]["workspace_stylebook_id"] == ownership_fixture.original_stylebook_id
+
+
+def test_project_list_survives_one_broken_workspace_stylebook(
+    ownership_fixture: ProjectOwnershipFixture,
+) -> None:
+    """Compatibility fields degrade to null; one bad row must not fail the whole list."""
+    healthy = ownership_fixture.client.post(
+        "/projects",
+        json={
+            "name": "Healthy project",
+            "slug": "healthy-project",
+            "workspace_id": ownership_fixture.workspace_id,
+        },
+    )
+    assert healthy.status_code == 200
+    broken = ownership_fixture.client.post(
+        "/projects",
+        json={
+            "name": "Broken workspace project",
+            "slug": "broken-workspace-project",
+            "workspace_id": ownership_fixture.workspace_id,
+        },
+    )
+    assert broken.status_code == 200
+    broken_id = int(broken.json()["id"])
+    missing = ownership_fixture.client.post(
+        "/projects",
+        json={
+            "name": "Missing workspace project",
+            "slug": "missing-workspace-project",
+            "workspace_id": ownership_fixture.workspace_id,
+        },
+    )
+    assert missing.status_code == 200
+    missing_id = int(missing.json()["id"])
+    with Session(ownership_fixture.engine) as session:
+        orphan = BackfieldWorkspace(
+            organization_id=ownership_fixture.organization_id,
+            stylebook_id=999_999,
+            name="Orphan",
+            slug="orphan",
+        )
+        session.add(orphan)
+        session.commit()
+        session.refresh(orphan)
+        project = session.get(BackfieldProject, broken_id)
+        assert project is not None
+        project.workspace_id = int(orphan.id)
+        session.add(project)
+        orphaned = session.get(BackfieldProject, missing_id)
+        assert orphaned is not None
+        orphaned.workspace_id = 999_999
+        session.add(orphaned)
+        session.commit()
+
+    response = ownership_fixture.client.get("/projects")
+
+    assert response.status_code == 200
+    rows = {row["slug"]: row for row in response.json()}
+    assert rows["healthy-project"]["workspace_stylebook_id"] == (
+        ownership_fixture.original_stylebook_id
+    )
+    assert rows["broken-workspace-project"]["workspace_stylebook_id"] is None
+    assert rows["broken-workspace-project"]["workspace_stylebook_name"] is None
+    assert rows["broken-workspace-project"]["workspace_stylebook_slug"] is None
+    assert rows["missing-workspace-project"]["workspace_stylebook_id"] is None
+    # The project's own Stylebook is unaffected by the broken workspace row.
+    assert rows["broken-workspace-project"]["stylebook_id"] == (
+        ownership_fixture.original_stylebook_id
+    )
+
+
+def test_project_patch_cannot_reassign_the_stylebook(
+    ownership_fixture: ProjectOwnershipFixture,
+) -> None:
+    """Reassignment is intentionally unsupported; an unknown field must not take effect."""
+    created = ownership_fixture.client.post(
+        "/projects",
+        json={
+            "name": "Fixed project",
+            "slug": "fixed-project",
+            "workspace_id": ownership_fixture.workspace_id,
+        },
+    ).json()
+
+    patched = ownership_fixture.client.patch(
+        f"/projects/{int(created['id'])}",
+        json={"stylebook_id": ownership_fixture.replacement_stylebook_id},
+    )
+
+    assert patched.status_code == 200
+    assert patched.json()["stylebook_id"] == ownership_fixture.original_stylebook_id
+    with Session(ownership_fixture.engine) as session:
+        project = session.get(BackfieldProject, int(created["id"]))
         assert project is not None
         assert project.stylebook_id == ownership_fixture.original_stylebook_id
 


### PR DESCRIPTION
## Summary

Closes a gap between the tenancy design and what shipped. The design said a project's Stylebook is chosen at creation, with the workspace supplying the default — but only the fallback was implemented, so the workspace default became the *only* input and there was no way to see or choose a project's Stylebook in the product.

- project creation accepts an optional Stylebook, validated to the same organization, still falling back to the workspace default when omitted
- the create dialog shows a Stylebook selector, pre-filled from the workspace and hidden entirely when the organization has one Stylebook
- project settings show, read-only, which Stylebook the project writes into

Reassignment after creation is still deliberately not exposed, and nodes still inherit the project's Stylebook.

### Bug found along the way

Story review was reading `workspace_stylebook_slug` as its catalog target. That only matched the project's Stylebook by accident, and diverges for exactly the projects this feature creates — it is a write target for geometry updates and substrate deletes, not just a deep link. Review now uses the project's own Stylebook, and the `workspace_stylebook_*` response fields report the workspace's real Stylebook instead of mirroring the project's.

## Test plan

- [x] `make lint`
- [x] `make test` (1980 passed)
- [x] `make ui-typecheck`, `make ui-test`, `make agate-ui-build`
- [x] explicit choice, workspace fallback, cross-organization rejection under both session and service auth, unknown Stylebook, non-member 403 before validation
- [x] workspace default changes leave existing projects untouched; `PATCH` with `stylebook_id` is a no-op
- [x] review targeting pinned to the project's Stylebook where it differs from the workspace's

Made with [Cursor](https://cursor.com)