### PR TITLE
Housekeeping: Help link, org chrome, and Stylebook review fixes

### DIFF
--- a/apps/agate-ui/src/components/AppSidebar.tsx
+++ b/apps/agate-ui/src/components/AppSidebar.tsx
@@ -260,27 +260,30 @@ export default function AppSidebar() {
         asideAriaLabel="Platform"
         headerLeading={
           <div className="flex min-w-0 flex-1 items-center gap-2">
-            <NavLink
-              to={headerTo}
-              title={organizationLabel}
-              aria-label={organizationLabel}
-              className={cn(
-                'flex min-w-0 flex-1 items-center rounded-md px-1 py-1 -ml-1',
-                'hover:bg-muted/35 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
-              )}
-            >
-              <span className="truncate text-sm font-semibold tracking-tight text-foreground">
-                {organizationLabel}
-              </span>
-            </NavLink>
-            <OrganizationSwitcher
-              organizations={organizations}
-              organizationId={organizationId}
-              onSwitch={async (nextOrganizationId) => {
-                const slug = await switchOrganization(nextOrganizationId)
-                navigate(`/org/${encodeURIComponent(slug)}/`, { replace: true })
-              }}
-            />
+            {organizations.length >= 2 ? (
+              <OrganizationSwitcher
+                organizations={organizations}
+                organizationId={organizationId}
+                onSwitch={async (nextOrganizationId) => {
+                  const slug = await switchOrganization(nextOrganizationId)
+                  navigate(`/org/${encodeURIComponent(slug)}/`, { replace: true })
+                }}
+              />
+            ) : (
+              <NavLink
+                to={headerTo}
+                title={organizationLabel}
+                aria-label={organizationLabel}
+                className={cn(
+                  'flex min-w-0 flex-1 items-center rounded-md px-1 py-1 -ml-1',
+                  'hover:bg-muted/35 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+                )}
+              >
+                <span className="truncate text-sm font-semibold tracking-tight text-foreground">
+                  {organizationLabel}
+                </span>
+              </NavLink>
+            )}
           </div>
         }
       >

--- a/apps/agate-ui/src/lib/platformUrls.ts
+++ b/apps/agate-ui/src/lib/platformUrls.ts
@@ -25,13 +25,13 @@ export function stylebookUiOrigin(): string {
   })
 }
 
-/** External docs or fallback to Agate `/help`. */
+/** Product docs (override with `VITE_HELP_URL`). */
 export function helpHref(): string {
   const raw = import.meta.env.VITE_HELP_URL
   if (typeof raw === 'string' && raw.trim() !== '') {
     return raw.trim()
   }
-  return `${agateUiOrigin()}/help`
+  return 'https://docs.backfield.org'
 }
 
 function tenantSlug(currentOrigin: string): string {

--- a/apps/agate-ui/src/nodes/article_metadata/presetOptions.ts
+++ b/apps/agate-ui/src/nodes/article_metadata/presetOptions.ts
@@ -2,13 +2,13 @@ export const ARTICLE_METADATA_DEFAULT_PRESET = 'subject' as const
 
 export const ARTICLE_METADATA_PRESET_OPTIONS = [
   { id: 'information_needs', label: 'Critical information need' },
-  { id: 'custom', label: 'Custom' },
   { id: 'format', label: 'Format' },
   { id: 'geographic_scope', label: 'Scope' },
   { id: 'subject', label: 'Subject' },
   { id: 'temporal_orientation', label: 'Timeframe' },
   { id: 'topic', label: 'Topic' },
   { id: 'user_need', label: 'User need' },
+  { id: 'custom', label: 'Custom' },
 ] as const
 
 export type ArticleMetadataPresetId = (typeof ARTICLE_METADATA_PRESET_OPTIONS)[number]['id']

--- a/apps/agate-ui/src/pages/ProcessedItemDetail.tsx
+++ b/apps/agate-ui/src/pages/ProcessedItemDetail.tsx
@@ -67,15 +67,18 @@ export default function ProcessedItemDetail() {
   const { runId, itemId } = useParams<{ runId: string; itemId: string }>()
   const navigate = useNavigate()
   const location = useLocation()
-  const [searchParams, setSearchParams] = useSearchParams()
+  const [searchParams] = useSearchParams()
   const verificationDirtyRef = useRef(false)
   /** Set once a rerun reaches pending/running; gates clearing ``rerunRequested``. */
   const rerunSawInFlightRef = useRef(false)
+  /** True after the first successful item load; avoids full-page spinner on soft reloads. */
+  const hasLoadedItemRef = useRef(false)
   const [reviewDirty, setReviewDirty] = useState(false)
   const [run, setRun] = useState<Run | null>(null)
   const [graph, setGraph] = useState<Graph | null>(null)
   const [item, setItem] = useState<ProcessedItem | null>(null)
   const [loading, setLoading] = useState(true)
+  const [tabContentLoading, setTabContentLoading] = useState(false)
   const [rerunning, setRerunning] = useState(false)
   /** True after the user confirms rerun until the item leaves pending/running. */
   const [rerunRequested, setRerunRequested] = useState(false)
@@ -120,8 +123,17 @@ export default function ProcessedItemDetail() {
     const hash = location.hash.replace(/^#/, '').trim()
     if (!hash) return
     const tab = parseProcessedItemDetailTab(hash, { synthetic: itemSynthetic })
-    navigate({ pathname: location.pathname, search: `?tab=${encodeURIComponent(tab)}` }, { replace: true })
-  }, [location.pathname, location.hash, searchParams, itemSynthetic, navigate])
+    // Use the real browser pathname: ``Routes`` in App.tsx rewrites ``useLocation().pathname``
+    // to drop ``/org/{slug}``, and navigating with that scoped path triggers an org redirect
+    // remount (full-page loading flash) on every tab change.
+    navigate(
+      {
+        pathname: window.location.pathname,
+        search: `?tab=${encodeURIComponent(tab)}`,
+      },
+      { replace: true },
+    )
+  }, [location.hash, searchParams, itemSynthetic, navigate])
 
   const handleTabChange = useCallback(
     async (next: string) => {
@@ -138,14 +150,24 @@ export default function ProcessedItemDetail() {
         )
         if (!leave) return
       }
-      setSearchParams({ tab: next }, { replace: true })
+      navigate(
+        {
+          pathname: window.location.pathname,
+          search: `?tab=${encodeURIComponent(next)}`,
+        },
+        { replace: true },
+      )
     },
-    [activeTab, setSearchParams, showConfirm],
+    [activeTab, navigate, showConfirm],
   )
 
   useEffect(() => {
+    hasLoadedItemRef.current = false
+    setItem(null)
+    setLoading(true)
+    setTabContentLoading(false)
     if (runId && itemId) {
-      loadItemData()
+      void loadItemData()
     }
   }, [runId, itemId])
 
@@ -269,12 +291,19 @@ export default function ProcessedItemDetail() {
     const parsedItemId = parseInt(itemId, 10)
     if (Number.isNaN(parsedItemId)) {
       setItem(null)
+      hasLoadedItemRef.current = false
       setLoading(false)
+      setTabContentLoading(false)
       return
     }
 
+    const softReload = hasLoadedItemRef.current
     try {
-      setLoading(true)
+      if (softReload) {
+        setTabContentLoading(true)
+      } else {
+        setLoading(true)
+      }
       const runData = await getRun(runId)
       const graphData = await getGraph(runData.graph_id)
       setRun(runData)
@@ -283,6 +312,7 @@ export default function ProcessedItemDetail() {
       try {
         const itemData = await getProcessedItem(runId, parsedItemId)
         setItem(itemData)
+        hasLoadedItemRef.current = true
       } catch {
         const syn = runData.items?.find((i) => i.id === parsedItemId && i.synthetic)
         if (syn) {
@@ -311,15 +341,19 @@ export default function ProcessedItemDetail() {
             estimated_ai_cost_incomplete: syn.estimated_ai_cost_incomplete,
             estimated_ai_cost_currency: syn.estimated_ai_cost_currency,
           })
+          hasLoadedItemRef.current = true
         } else {
           setItem(null)
+          hasLoadedItemRef.current = false
         }
       }
     } catch (error) {
       console.error('Failed to load item data:', error)
       setItem(null)
+      hasLoadedItemRef.current = false
     } finally {
       setLoading(false)
+      setTabContentLoading(false)
     }
   }
 
@@ -535,7 +569,7 @@ export default function ProcessedItemDetail() {
     })
   }, [item, graph])
 
-  if (loading) {
+  if (loading && !item) {
     return (
       <div className="flex items-center justify-center py-12">
         <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
@@ -689,6 +723,12 @@ export default function ProcessedItemDetail() {
           ))}
         </TabsList>
 
+        {tabContentLoading ? (
+          <div className="flex items-center justify-center py-12">
+            <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+          </div>
+        ) : (
+          <>
         <TabsContent value="info" className="space-y-4">
           <ProcessedItemInformationCard
             runId={runId!}
@@ -996,6 +1036,8 @@ export default function ProcessedItemDetail() {
             </Card>
           )}
         </TabsContent>
+          </>
+        )}
       </Tabs>
     </div>
   )

--- a/apps/api-playground/src/App.test.tsx
+++ b/apps/api-playground/src/App.test.tsx
@@ -56,7 +56,9 @@ function sessionResponse(input: RequestInfo | URL): Response | undefined {
         email: "developer@example.test",
         organization_id: 1,
         organization_name: "Newsroom",
+        organization_slug: "newsroom",
         org_role: "org_admin",
+        organizations: [{ id: 1, name: "Newsroom", slug: "newsroom" }],
       }),
       { status: 200, headers: { "Content-Type": "application/json" } },
     )

--- a/apps/api-playground/src/App.tsx
+++ b/apps/api-playground/src/App.tsx
@@ -9,6 +9,7 @@ import { fetchPublicSchema } from "./lib/api"
 import { listOperations, type OpenApiDocument, type PlaygroundOperation } from "./lib/openapi"
 import {
   deriveApiOrigin,
+  derivePlaygroundOrigin,
   deriveStylebookApiOrigin,
   deriveProductOrigin,
   isLocalPlaygroundHost,
@@ -21,6 +22,7 @@ import {
   fetchPlatformContext,
   logoutSession,
   SessionAuthRequiredError,
+  switchOrganization,
   type PlatformContext,
 } from "./lib/session"
 
@@ -301,6 +303,25 @@ function PlaygroundHome() {
     redirectToLogin()
   }
 
+  async function handleSwitchOrganization(nextOrganizationId: number) {
+    if (!sessionOrigin || !platformContext) {
+      throw new Error("Could not switch organizations.")
+    }
+    const selected = platformContext.user.organizations.find(
+      (organization) => organization.id === nextOrganizationId,
+    )
+    if (!selected) {
+      throw new Error("Could not switch organizations.")
+    }
+    await switchOrganization(sessionOrigin, nextOrganizationId)
+    clearApiKey()
+    if (localAvailable) {
+      window.location.reload()
+      return
+    }
+    window.location.assign(`${derivePlaygroundOrigin(selected.slug, parentDomain)}/`)
+  }
+
   function clearApiKey() {
     setApiKey("")
     setApiKeyDraft("")
@@ -346,6 +367,7 @@ function PlaygroundHome() {
             organizationSlug={organizationSlug}
             parentDomain={parentDomain}
             local={localAvailable}
+            onSwitchOrganization={handleSwitchOrganization}
           />
         ) : sessionLoading ? (
           <aside

--- a/apps/api-playground/src/components/PlatformSidebar.tsx
+++ b/apps/api-playground/src/components/PlatformSidebar.tsx
@@ -308,7 +308,7 @@ export default function PlatformSidebar({
               </a>
             ) : null}
             <a
-              href={`${agateOrigin}/help`}
+              href="https://docs.backfield.org"
               className={hubLinkClass}
               title={!expanded ? "Help" : undefined}
             >

--- a/apps/api-playground/src/components/PlatformSidebar.tsx
+++ b/apps/api-playground/src/components/PlatformSidebar.tsx
@@ -7,6 +7,7 @@ import {
   TerminalSquare,
 } from "lucide-react"
 import { AgateProductMark } from "@backfield/ui/AgateProductMark"
+import { OrganizationSwitcher } from "@backfield/ui/OrganizationSwitcher"
 import { StylebookProductMark } from "@backfield/ui/StylebookProductMark"
 import { ShellSidebar } from "@backfield/ui/ShellSidebar"
 import { cn } from "@backfield/ui/cn"
@@ -39,6 +40,7 @@ interface PlatformSidebarProps {
   organizationSlug: string
   parentDomain: ParentDomain
   local: boolean
+  onSwitchOrganization: (organizationId: number) => Promise<void>
 }
 
 export default function PlatformSidebar({
@@ -46,6 +48,7 @@ export default function PlatformSidebar({
   organizationSlug,
   parentDomain,
   local,
+  onSwitchOrganization,
 }: PlatformSidebarProps) {
   const [expandedWorkspaceSlugs, setExpandedWorkspaceSlugs] = useState<Set<string>>(
     readExpandedWorkspaceSlugs,
@@ -116,19 +119,29 @@ export default function PlatformSidebar({
       storageKey={STORAGE_EXPANDED}
       asideAriaLabel="Platform"
       headerLeading={
-        <a
-          href={agateOrigin}
-          title={context.user.organizationName}
-          aria-label={context.user.organizationName}
-          className={cn(
-            "flex min-w-0 flex-1 items-center rounded-md px-1 py-1 -ml-1",
-            "hover:bg-muted/35 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        <div className="flex min-w-0 flex-1 items-center gap-2">
+          {context.user.organizations.length >= 2 ? (
+            <OrganizationSwitcher
+              organizations={context.user.organizations}
+              organizationId={context.user.organizationId}
+              onSwitch={onSwitchOrganization}
+            />
+          ) : (
+            <a
+              href={agateOrigin}
+              title={context.user.organizationName}
+              aria-label={context.user.organizationName}
+              className={cn(
+                "flex min-w-0 flex-1 items-center rounded-md px-1 py-1 -ml-1",
+                "hover:bg-muted/35 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+              )}
+            >
+              <span className="truncate text-sm font-semibold tracking-tight text-foreground">
+                {context.user.organizationName}
+              </span>
+            </a>
           )}
-        >
-          <span className="truncate text-sm font-semibold tracking-tight text-foreground">
-            {context.user.organizationName}
-          </span>
-        </a>
+        </div>
       }
     >
       {(expanded: boolean, { expand }: { expand: () => void }) => (

--- a/apps/api-playground/src/lib/origin.test.ts
+++ b/apps/api-playground/src/lib/origin.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest"
 
 import {
   deriveApiOrigin,
+  derivePlaygroundOrigin,
   deriveProductOrigin,
   deriveStylebookApiOrigin,
   normalizeOrganizationSlug,
@@ -24,6 +25,9 @@ describe("organization API origin", () => {
     )
     expect(deriveStylebookApiOrigin("canary", "stg.backfield.news")).toBe(
       "https://stylebook.canary.stg.backfield.news/api/stylebook",
+    )
+    expect(derivePlaygroundOrigin("canary", "stg.backfield.news")).toBe(
+      "https://playground.canary.stg.backfield.news",
     )
   })
 

--- a/apps/api-playground/src/lib/origin.ts
+++ b/apps/api-playground/src/lib/origin.ts
@@ -59,6 +59,13 @@ export function deriveProductOrigin(
   return `https://${product}.${requireSlug(organizationSlug)}.${parentDomain}`
 }
 
+export function derivePlaygroundOrigin(
+  organizationSlug: string,
+  parentDomain: ParentDomain = "backfield.news",
+): string {
+  return `https://playground.${requireSlug(organizationSlug)}.${parentDomain}`
+}
+
 /**
  * Parse a tenant Playground hostname.
  *

--- a/apps/api-playground/src/lib/session.test.ts
+++ b/apps/api-playground/src/lib/session.test.ts
@@ -4,6 +4,7 @@ import {
   fetchPlatformContext,
   logoutSession,
   SessionAuthRequiredError,
+  switchOrganization,
 } from "./session"
 
 describe("Playground session", () => {
@@ -51,5 +52,28 @@ describe("Playground session", () => {
         "https://stylebook-api.newsroom.backfield.news",
       ),
     ).rejects.toBeInstanceOf(SessionAuthRequiredError)
+  })
+
+  it("switches the active organization through the tenant session host", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response(JSON.stringify({ success: true }), { status: 200 }))
+    vi.stubGlobal("fetch", fetchMock)
+
+    await switchOrganization("https://agate.newsroom.backfield.news", 2)
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://agate.newsroom.backfield.news/v1/auth/switch-organization",
+      {
+        method: "POST",
+        credentials: "include",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+        },
+        referrerPolicy: "no-referrer",
+        body: JSON.stringify({ organization_id: 2 }),
+      },
+    )
   })
 })

--- a/apps/api-playground/src/lib/session.ts
+++ b/apps/api-playground/src/lib/session.ts
@@ -1,9 +1,17 @@
+export interface SessionOrganization {
+  id: number
+  name: string
+  slug: string
+}
+
 export interface SessionUser {
   authenticated: boolean
   email: string
   organizationId: number
   organizationName: string
+  organizationSlug: string
   orgRole: string | null
+  organizations: SessionOrganization[]
 }
 
 export interface PlatformProject {
@@ -32,12 +40,20 @@ export interface PlatformContext {
   stylebooks: PlatformStylebook[]
 }
 
+interface MeOrganization {
+  id?: number
+  name?: string
+  slug?: string
+}
+
 interface MeResponse {
   authenticated?: boolean
   email?: string
   organization_id?: number
   organization_name?: string | null
+  organization_slug?: string | null
   org_role?: string | null
+  organizations?: MeOrganization[]
 }
 
 /** Thrown when the browser has no usable Backfield session; callers redirect to Agate login. */
@@ -75,6 +91,42 @@ export async function logoutSession(coreOrigin: string): Promise<void> {
   }
 }
 
+export async function switchOrganization(
+  coreOrigin: string,
+  organizationId: number,
+): Promise<void> {
+  const response = await fetch(`${coreOrigin}/v1/auth/switch-organization`, {
+    method: "POST",
+    credentials: "include",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+    referrerPolicy: "no-referrer",
+    body: JSON.stringify({ organization_id: organizationId }),
+  })
+  if (!response.ok) {
+    if (response.status === 401 || response.status === 403) {
+      throw new SessionAuthRequiredError()
+    }
+    throw new Error("Could not switch organizations.")
+  }
+}
+
+function parseOrganizations(raw: MeOrganization[] | undefined): SessionOrganization[] {
+  if (!Array.isArray(raw)) return []
+  return raw
+    .map((item) => {
+      if (item.id == null || !item.name?.trim() || !item.slug?.trim()) return null
+      return {
+        id: item.id,
+        name: item.name.trim(),
+        slug: item.slug.trim().toLowerCase(),
+      }
+    })
+    .filter((item): item is SessionOrganization => item != null)
+}
+
 export async function fetchPlatformContext(
   coreOrigin: string,
   stylebookApiOrigin: string,
@@ -98,7 +150,9 @@ export async function fetchPlatformContext(
       email: me.email,
       organizationId: me.organization_id,
       organizationName: me.organization_name?.trim() || "Backfield",
+      organizationSlug: me.organization_slug?.trim().toLowerCase() || "",
       orgRole: me.org_role ?? null,
+      organizations: parseOrganizations(me.organizations),
     },
     workspaces,
     stylebooks,

--- a/apps/stylebook-api/src/stylebook_api/routers/imports.py
+++ b/apps/stylebook-api/src/stylebook_api/routers/imports.py
@@ -8,11 +8,11 @@ from datetime import UTC, datetime
 from typing import Any
 
 from backfield_auth.gate import require_project_access
-from backfield_db import StylebookLocationMeta
+from backfield_db import BackfieldProject, StylebookLocationMeta
 from backfield_entities.entities.location.persist import create_standalone_canonical
 from fastapi import APIRouter, Body, Depends, HTTPException, Query, Request
 from pydantic import BaseModel, Field
-from sqlmodel import Session
+from sqlmodel import Session, select
 
 from stylebook_api.catalog_scope import StylebookSlugQuery
 from stylebook_api.deps import get_auth, get_session
@@ -169,6 +169,20 @@ def _meta_value_skipped_as_empty(raw: Any) -> bool:
     if isinstance(raw, str) and not raw.strip():
         return True
     return False
+
+
+def _stylebook_storage_project_id(session: Session, *, organization_id: int) -> int:
+    project_id = session.exec(
+        select(BackfieldProject.id)
+        .where(BackfieldProject.organization_id == organization_id)
+        .order_by(BackfieldProject.id.asc())
+    ).first()
+    if project_id is None:
+        raise HTTPException(
+            status_code=400,
+            detail="This stylebook needs at least one project before metadata can be imported.",
+        )
+    return int(project_id)
 
 
 class _GeoJsonLocationsImporter:
@@ -543,9 +557,14 @@ def import_geojson_stylebook(
     exploded_features = _explode_geometry_collections(features)
 
     allowed_prop_keys = _property_keys_union_from_features(exploded_features)
-    _ = _normalize_and_validate_meta_mappings_or_400(
+    normalized_meta = _normalize_and_validate_meta_mappings_or_400(
         payload.meta_property_mappings,
         allowed_keys=allowed_prop_keys,
+    )
+    metadata_project_id = (
+        _stylebook_storage_project_id(session, organization_id=int(sb.organization_id))
+        if normalized_meta
+        else None
     )
 
     mappings = payload.mappings
@@ -604,13 +623,38 @@ def import_geojson_stylebook(
                     provenance="stylebook_ui_import_geojson",
                 )
                 session.flush()
+                canon_id = str(canon.id)
+                for meta_type, property_key in normalized_meta:
+                    if metadata_project_id is None:
+                        raise RuntimeError("metadata storage project was not resolved")
+                    raw_value = props.get(property_key)
+                    if _meta_value_skipped_as_empty(raw_value):
+                        continue
+                    data_payload: dict[str, Any] = {property_key: raw_value}
+                    try:
+                        validate_meta_json(data_payload)
+                    except HTTPException as exc:
+                        raise _ImportMetaJsonError(str(exc.detail)) from exc
+                    session.add(
+                        StylebookLocationMeta(
+                            project_id=metadata_project_id,
+                            stylebook_location_canonical_id=canon_id,
+                            meta_type=meta_type,
+                            data_json=data_payload,
+                            added=True,
+                            created_at=datetime.now(UTC),
+                        )
+                    )
+                session.flush()
                 created.append(
                     ImportGeoJSONCreatedRow(
                         feature_index=i,
-                        canonical_id=str(canon.id),
+                        canonical_id=canon_id,
                         label=str(canon.label),
                     )
                 )
+        except _ImportMetaJsonError as e:
+            failed.append(ImportGeoJSONFailedRow(feature_index=i, error=e.message))
         except Exception as e:  # noqa: BLE001 - per-row boundary
             failed.append(ImportGeoJSONFailedRow(feature_index=i, error=str(e)))
 

--- a/apps/stylebook-ui/src/components/Layout.tsx
+++ b/apps/stylebook-ui/src/components/Layout.tsx
@@ -371,14 +371,6 @@ export default function Layout({ children, headerContent }: LayoutProps) {
           />
           <div className="flex items-center gap-2 flex-wrap justify-end flex-1 min-w-0">
             {headerContent}
-            <OrganizationSwitcher
-              organizations={organizations}
-              organizationId={organizationId}
-              onSwitch={async (nextOrganizationId) => {
-                const slug = await switchOrganization(nextOrganizationId)
-                navigate(`/org/${encodeURIComponent(slug)}/`, { replace: true })
-              }}
-            />
             {username ? (
               <UserAccountMenu
                 userLabel={username}
@@ -396,22 +388,35 @@ export default function Layout({ children, headerContent }: LayoutProps) {
           storageKey="stylebook-sidebar-expanded"
           asideAriaLabel="Platform"
           headerLeading={
-            <NavLink
-              to={indexPath}
-              title={organizationLabel}
-              aria-label={organizationLabel}
-              className={({ isActive }) =>
-                cn(
-                  "flex min-w-0 flex-1 items-center rounded-md px-1 py-1 -ml-1",
-                  "hover:bg-muted/35 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-                  isActive && "bg-transparent",
-                )
-              }
-            >
-              <span className="truncate text-sm font-semibold tracking-tight text-foreground">
-                {organizationLabel}
-              </span>
-            </NavLink>
+            <div className="flex min-w-0 flex-1 items-center gap-2">
+              {organizations.length >= 2 ? (
+                <OrganizationSwitcher
+                  organizations={organizations}
+                  organizationId={organizationId}
+                  onSwitch={async (nextOrganizationId) => {
+                    const slug = await switchOrganization(nextOrganizationId)
+                    navigate(`/org/${encodeURIComponent(slug)}/`, { replace: true })
+                  }}
+                />
+              ) : (
+                <NavLink
+                  to={indexPath}
+                  title={organizationLabel}
+                  aria-label={organizationLabel}
+                  className={({ isActive }) =>
+                    cn(
+                      "flex min-w-0 flex-1 items-center rounded-md px-1 py-1 -ml-1",
+                      "hover:bg-muted/35 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                      isActive && "bg-transparent",
+                    )
+                  }
+                >
+                  <span className="truncate text-sm font-semibold tracking-tight text-foreground">
+                    {organizationLabel}
+                  </span>
+                </NavLink>
+              )}
+            </div>
           }
         >
           {(expanded: boolean, { expand }: { expand: () => void }) => (

--- a/apps/stylebook-ui/src/lib/platformUrls.ts
+++ b/apps/stylebook-ui/src/lib/platformUrls.ts
@@ -25,12 +25,13 @@ export function stylebookUiOrigin(): string {
   })
 }
 
+/** Product docs (override with `VITE_HELP_URL`). */
 export function helpHref(): string {
   const raw = import.meta.env.VITE_HELP_URL
   if (typeof raw === "string" && raw.trim() !== "") {
     return raw.trim()
   }
-  return `${agateUiOrigin()}/help`
+  return "https://docs.backfield.org"
 }
 
 function tenantSlug(currentOrigin: string): string {

--- a/apps/stylebook-ui/src/pages/CleanupCheck.tsx
+++ b/apps/stylebook-ui/src/pages/CleanupCheck.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
-import { Link, useParams, useSearchParams } from "react-router-dom"
+import { Link, useNavigate, useParams, useSearchParams } from "react-router-dom"
 import { Breadcrumbs } from "@/components/Breadcrumbs"
 import { CleanupAiReviewDialog } from "@/components/CleanupAiReviewDialog"
 import { DuplicateClusterList } from "@/components/DuplicateClusterList"
@@ -122,7 +122,8 @@ export default function CleanupCheck() {
   /** Cleanup APIs key runs by `project`; use filter when set, else workflow scope. */
   const cleanupProjectSlug = projectFilterSlug || projectScopeSlug || undefined
   const crumbRoot = useScopeBreadcrumbRoot()
-  const [searchParams, setSearchParams] = useSearchParams()
+  const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
   const urlQuery = searchParams.get("q") ?? ""
   const [searchQuery, setSearchQuery] = useState(() => urlQuery)
   const [loading, setLoading] = useState(true)
@@ -216,16 +217,24 @@ export default function CleanupCheck() {
 
   useEffect(() => {
     const handle = window.setTimeout(() => {
-      setSearchParams((prev) => {
-        const next = new URLSearchParams(prev)
-        const trimmed = searchQuery.trim()
-        if (trimmed) next.set("q", trimmed)
-        else next.delete("q")
-        return next
-      })
+      const trimmed = searchQuery.trim()
+      if (trimmed === urlQuery) return
+      const next = new URLSearchParams(searchParams)
+      if (trimmed) next.set("q", trimmed)
+      else next.delete("q")
+      const query = next.toString()
+      navigate(
+        {
+          // App routing exposes the path without ``/org/{slug}``; keep the real browser
+          // path so changing the search query does not trigger an organization redirect.
+          pathname: window.location.pathname,
+          search: query ? `?${query}` : "",
+        },
+        { replace: true },
+      )
     }, 300)
     return () => window.clearTimeout(handle)
-  }, [searchQuery, setSearchParams])
+  }, [navigate, searchParams, searchQuery, urlQuery])
 
   const loadResults = useCallback(async () => {
     if (!stylebookSlug || !config) return

--- a/docs/operations/runtime-configuration.md
+++ b/docs/operations/runtime-configuration.md
@@ -33,8 +33,9 @@ Health endpoints are `GET /health` on Agate API, Stylebook API, and Core API.
 
 Frontend cross-app destinations are build-time Vite settings. `VITE_AGATE_UI_ORIGIN` and
 `VITE_STYLEBOOK_UI_ORIGIN` override tenant sibling-app discovery, `VITE_HELP_URL` overrides the Help
-destination, and `VITE_PLAYGROUND_URL` overrides the hosted API Playground destination. Local
-Agate and Stylebook builds otherwise link to `http://localhost:5176`; production builds derive
+destination (default `https://docs.backfield.org`), and `VITE_PLAYGROUND_URL` overrides the hosted
+API Playground destination. Local Agate and Stylebook builds otherwise link to
+`http://localhost:5176`; production builds derive
 `https://playground.{organization-slug}.backfield.news`. A custom `VITE_PLAYGROUND_URL` may contain
 the literal `{organization_slug}` placeholder or identify a fixed tenant deployment.
 

--- a/packages/backfield-agate/src/agate_nodes/article_metadata/ui/presetOptions.ts
+++ b/packages/backfield-agate/src/agate_nodes/article_metadata/ui/presetOptions.ts
@@ -2,13 +2,13 @@ export const ARTICLE_METADATA_DEFAULT_PRESET = 'subject' as const
 
 export const ARTICLE_METADATA_PRESET_OPTIONS = [
   { id: 'information_needs', label: 'Critical information need' },
-  { id: 'custom', label: 'Custom' },
   { id: 'format', label: 'Format' },
   { id: 'geographic_scope', label: 'Scope' },
   { id: 'subject', label: 'Subject' },
   { id: 'temporal_orientation', label: 'Timeframe' },
   { id: 'topic', label: 'Topic' },
   { id: 'user_need', label: 'User need' },
+  { id: 'custom', label: 'Custom' },
 ] as const
 
 export type ArticleMetadataPresetId = (typeof ARTICLE_METADATA_PRESET_OPTIONS)[number]['id']

--- a/packages/backfield-ui/package.json
+++ b/packages/backfield-ui/package.json
@@ -17,6 +17,7 @@
     "./axisAlignedRectangle": "./src/axisAlignedRectangle.ts",
     "./ShellSidebar": "./src/ShellSidebar.tsx",
     "./UserAccountMenu": "./src/UserAccountMenu.tsx",
+    "./OrganizationSwitcher": "./src/OrganizationSwitcher.tsx",
     "./tenantSession": "./src/tenantSession.ts",
     "./passwordChangeGate": "./src/passwordChangeGate.ts",
     "./AgateProductMark": "./src/AgateProductMark.tsx",

--- a/tests/smoke/smoke_stylebook_import_export.py
+++ b/tests/smoke/smoke_stylebook_import_export.py
@@ -70,6 +70,7 @@ def main() -> int:
                     "name": label,
                     "type": "city",
                     "formatted_address": f"{label}, IL, USA",
+                    "import_details": {"source": "stylebook-import-smoke"},
                 },
             }
         ],
@@ -94,6 +95,12 @@ def main() -> int:
                             "location_type_property": "type",
                             "formatted_address_property": "formatted_address",
                         },
+                        "meta_property_mappings": [
+                            {
+                                "property_key": "import_details",
+                                "meta_type": "import_details",
+                            }
+                        ],
                     },
                 ),
                 "import geojson",
@@ -111,6 +118,12 @@ def main() -> int:
                 ),
                 "get imported canonical",
             )
+            fetched_meta = assert_object(
+                client.get(
+                    f"/v1/stylebooks/{stylebook_slug}/canonical-locations/{canonical_id}/meta"
+                ),
+                "get imported canonical metadata",
+            )
 
         if int(analyzed.get("feature_count", -1)) != 1:
             raise RuntimeError(f"Unexpected analyze payload: {analyzed}")
@@ -121,6 +134,19 @@ def main() -> int:
             raise RuntimeError(f"Unexpected import payload: {imported}")
         if fetched.get("label") != label:
             raise RuntimeError(f"Imported canonical label mismatch: {fetched}")
+        meta_rows = fetched_meta.get("meta")
+        if not isinstance(meta_rows, list) or len(meta_rows) != 1:
+            raise RuntimeError(f"Imported canonical metadata mismatch: {fetched_meta}")
+        imported_meta = meta_rows[0]
+        if (
+            not isinstance(imported_meta, dict)
+            or imported_meta.get("meta_type") != "import_details"
+        ):
+            raise RuntimeError(f"Imported canonical metadata type mismatch: {fetched_meta}")
+        if imported_meta.get("data") != {
+            "import_details": {"source": "stylebook-import-smoke"}
+        }:
+            raise RuntimeError(f"Imported canonical metadata payload mismatch: {fetched_meta}")
 
         log("Smoke stylebook import passed.")
         log(f"Stylebook: {stylebook_slug!r}")

--- a/tests/stylebook_api/test_stylebook_api.py
+++ b/tests/stylebook_api/test_stylebook_api.py
@@ -717,6 +717,56 @@ def test_stylebook_scoped_import_requires_editor(member_client: TestClient) -> N
     assert r.status_code == 403
 
 
+def test_stylebook_scoped_import_persists_canonical_metadata(
+    editor_client: TestClient, stylebook_test_engine: Engine
+) -> None:
+    response = editor_client.post(
+        "/v1/stylebooks/default/import/geojson",
+        json={
+            "geojson": {
+                "type": "FeatureCollection",
+                "features": [
+                    {
+                        "type": "Feature",
+                        "geometry": {"type": "Point", "coordinates": [-87.62, 41.88]},
+                        "properties": {
+                            "name": "Import metadata test",
+                            "type": "place",
+                            "details": {"agency": "parks", "priority": 2},
+                        },
+                    }
+                ],
+            },
+            "mappings": {
+                "label_property": "name",
+                "location_type_property": "type",
+            },
+            "meta_property_mappings": [
+                {"property_key": "details", "meta_type": "import_details"}
+            ],
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["created_count"] == 1
+    canonical_id = body["created"][0]["canonical_id"]
+
+    with Session(stylebook_test_engine) as session:
+        metadata_rows = session.exec(
+            select(StylebookLocationMeta).where(
+                StylebookLocationMeta.stylebook_location_canonical_id == canonical_id
+            )
+        ).all()
+
+    assert len(metadata_rows) == 1
+    assert metadata_rows[0].meta_type == "import_details"
+    assert metadata_rows[0].data_json == {
+        "details": {"agency": "parks", "priority": 2}
+    }
+    assert metadata_rows[0].added is True
+
+
 def test_list_stylebooks_service(client: TestClient) -> None:
     r = client.get(
         "/v1/organizations/1/stylebooks",


### PR DESCRIPTION
## Summary

- Point Help at `docs.backfield.org` (still overridable via `VITE_HELP_URL`) and keep runtime-config docs in sync.
- Fix Agate processed-item tab switches remounting the whole page, and stop Stylebook cleanup search updates from looping through org redirects.
- Keep multi-org switching in the left rail across Agate, Stylebook, and API Playground; show only the dropdown (not truncated name + switcher) when multiple orgs are available.
- Persist mapped GeoJSON metadata on Stylebook location imports (the UI-used endpoint) and put Article Metadata’s Custom preset last.

## Project scope check

- [x] This change targets local development / source inspection (production self-hosting is unsupported in this repo)
- [x] Docs under `docs/` updated if behavior, architecture, or operations changed
- [x] First-admin provisioning still uses `backfield init` / `backfield seed` only (no HTTP/env bootstrap paths)

## Test plan

- [ ] `make lint`
- [ ] `make test`
- [ ] `make ui-typecheck ui-test` (if UI/TypeScript changed)
- [ ] `make smoke-fast` (if live-stack behavior changed)
- [ ] `make smoke` (if golden-path / provider-dependent runtime changed; configure **Settings → AI models**)
- [ ] Confirm Help opens docs.backfield.org from Agate / Stylebook / Playground
- [ ] Multi-org: switcher appears at top of left rail in Agate, Stylebook, and Playground; single-org still shows org name
- [ ] Processed-item detail: change tabs without a full-page spinner remount
- [ ] Cleanup review: typing in search does not remount / redirect-loop
- [ ] Stylebook GeoJSON import with meta property mappings creates location meta on canonicals

## Notes for reviewers

Mostly UI/chrome consistency plus two navigation bugs (org-stripped paths causing remounts) and one Stylebook import correctness fix for metadata mappings on the stylebook-scoped GeoJSON endpoint.

Made with [Cursor](https://cursor.com)