### PR TITLE
Add Document Chunker for long-document extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,28 @@
-<div align="center">
+<p align="center">
+  <a href="https://localangle.co">
+    <img src="docs/assets/local-angle-icon.svg" alt="Local Angle" width="56" />
+  </a>
+</p>
 
-# Backfield
+<h3 align="center">
+  Backfield
+</h3>
 
-**Turn journalism into durable, structured knowledge**
+<p align="center">
+  An open platform for turning journalism into durable, structured knowledge
+</p>
 
-[Docs](https://docs.backfield.news) ·
-[Self-Hosting](https://github.com/localangle/backfield-hosting) ·
-[More info](https://localangle.co)
+<p align="center">
+  <a href="https://docs.backfield.news">Docs</a> &bull;
+  <a href="https://github.com/localangle/backfield-hosting">Self-Hosting</a> &bull;
+  <a href="https://localangle.co">More info</a>
+</p>
 
-[![CI](https://github.com/localangle/backfield/actions/workflows/ci.yml/badge.svg)](https://github.com/localangle/backfield/actions/workflows/ci.yml)
-
-</div>
+<p align="center">
+  <a href="https://github.com/localangle/backfield/actions/workflows/ci.yml">
+    <img src="https://github.com/localangle/backfield/actions/workflows/ci.yml/badge.svg" alt="CI" />
+  </a>
+</p>
 
 Backfield turns unstructured news stories into structured data at scale. Among other things, it extracts and geocodes the locations of news events; organizes people and their quotes; and connect people, places and organizations into a knowledge graph based on your coverage.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,14 @@
+<div align="center">
+
 # Backfield
+
+[Docs](https://docs.backfield.news) ·
+[Self-Hosting](https://github.com/localangle/backfield-hosting) ·
+[More info](https://localangle.co)
+
+[![CI](https://github.com/localangle/backfield/actions/workflows/ci.yml/badge.svg)](https://github.com/localangle/backfield/actions/workflows/ci.yml)
+
+</div>
 
 > **Turn journalism into durable, structured knowledge**
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 # Backfield
 
+**Turn journalism into durable, structured knowledge**
+
 [Docs](https://docs.backfield.news) ·
 [Self-Hosting](https://github.com/localangle/backfield-hosting) ·
 [More info](https://localangle.co)
@@ -9,8 +11,6 @@
 [![CI](https://github.com/localangle/backfield/actions/workflows/ci.yml/badge.svg)](https://github.com/localangle/backfield/actions/workflows/ci.yml)
 
 </div>
-
-> **Turn journalism into durable, structured knowledge**
 
 Backfield turns unstructured news stories into structured data at scale. Among other things, it extracts and geocodes the locations of news events; organizes people and their quotes; and connect people, places and organizations into a knowledge graph based on your coverage.
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
   </a>
 </p>
 
-<h3 align="center">
+<h1 align="center">
   Backfield
-</h3>
+</h1>
 
 <p align="center">
   An open platform for turning journalism into durable, structured knowledge

--- a/apps/agate-api/src/api/routers/graphs.py
+++ b/apps/agate-api/src/api/routers/graphs.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from typing import Any
 
 from agate_runtime import GraphSpec
+from agate_runtime.graph_validation import GraphInvariantError, validate_graph_invariants
 from api.deps import get_auth, get_session
 from backfield_auth.gate import require_project_access, visible_project_ids
 from backfield_db import (
@@ -115,6 +116,10 @@ def create_graph(
     p = session.get(BackfieldProject, body.project_id)
     if not p:
         raise HTTPException(404, "Project not found")
+    try:
+        validate_graph_invariants(body.spec)
+    except GraphInvariantError as exc:
+        raise HTTPException(400, str(exc)) from exc
     prepared_spec = _prepare_spec_stylebook_refs(session, body.project_id, body.spec)
     g = AgateGraph(
         name=body.name,
@@ -184,6 +189,10 @@ def update_graph(
     p = session.get(BackfieldProject, body.project_id)
     if not p:
         raise HTTPException(404, "Project not found")
+    try:
+        validate_graph_invariants(body.spec)
+    except GraphInvariantError as exc:
+        raise HTTPException(400, str(exc)) from exc
     prepared_spec = _prepare_spec_stylebook_refs(session, body.project_id, body.spec)
     g.name = body.name
     g.description = (body.description or "").strip()

--- a/apps/agate-ui/src/components/ProjectAccessKeysPanel.tsx
+++ b/apps/agate-ui/src/components/ProjectAccessKeysPanel.tsx
@@ -253,6 +253,8 @@ const ProjectAccessKeysPanel = forwardRef<
     openCreateDialog,
   }))
 
+  const activeRows = rows.filter((row) => !row.revoked_at)
+
   return (
     <div className="w-full min-w-0 space-y-4 mb-10">
       <div>
@@ -291,7 +293,7 @@ const ProjectAccessKeysPanel = forwardRef<
 
       {loading ? (
         <div className="text-sm text-muted-foreground py-4">Loading keys…</div>
-      ) : rows.length === 0 ? (
+      ) : activeRows.length === 0 ? (
         <Card>
           <CardContent className="text-center py-8">
             <Key className="h-10 w-10 mx-auto text-muted-foreground mb-3" />
@@ -303,7 +305,7 @@ const ProjectAccessKeysPanel = forwardRef<
         </Card>
       ) : (
         <div className="space-y-3">
-          {rows.map((row) => (
+          {activeRows.map((row) => (
             <Card key={row.id}>
               <CardContent className="p-4">
                 <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
@@ -315,11 +317,6 @@ const ProjectAccessKeysPanel = forwardRef<
                       <Badge variant="secondary" className="text-xs">
                         {row.credential_type}
                       </Badge>
-                      {row.revoked_at ? (
-                        <Badge variant="outline" className="text-xs">
-                          Revoked
-                        </Badge>
-                      ) : null}
                       {row.credential_type === "user" &&
                       userId != null &&
                       row.user_id === userId ? (
@@ -340,9 +337,6 @@ const ProjectAccessKeysPanel = forwardRef<
                     </div>
                     <p className="text-xs text-muted-foreground">
                       Created {format(new Date(row.created_at), "MMM d, yyyy HH:mm")}
-                      {row.revoked_at
-                        ? ` · Revoked ${format(new Date(row.revoked_at), "MMM d, yyyy HH:mm")}`
-                        : ""}
                     </p>
                   </div>
                   <div className="flex gap-1 shrink-0">

--- a/apps/agate-ui/src/components/flow-builder/AddNodeChooser.tsx
+++ b/apps/agate-ui/src/components/flow-builder/AddNodeChooser.tsx
@@ -55,6 +55,7 @@ const NODE_CHOOSER_BLURBS: Record<string, string> = {
   CustomExtract: 'Extract custom data',
   EmbedImages: 'Describe and semantically embed images',
   EmbedText: 'Semantically embed article text',
+  DocumentChunker: 'Split a long document into smaller pieces for extraction',
   Gather: 'Consolidate output from upstream nodes',
   GeocodeAgent: 'Assign coordinates to extracted places',
   OrganizationExtract: 'Extract and standardize organizations',

--- a/apps/agate-ui/src/lib/flowGraphModel.test.ts
+++ b/apps/agate-ui/src/lib/flowGraphModel.test.ts
@@ -18,6 +18,7 @@ import {
   insertAfter,
   insertBetween,
   insertConvergingBeforeOutput,
+  insertInputAdjacentNode,
   isMiddleNodeId,
   LAYOUT_NODE_WIDTH,
   TIDY_LAYOUT_X_STEP,
@@ -179,6 +180,70 @@ describe('flowGraphModel serial chain', () => {
       ]),
     )
     expect(getInvalidFlowNodeIds(model)).toEqual(new Set())
+  })
+
+  it('inserts Document Chunker between input and all first-hop children', () => {
+    const place: FlowGraphNode = { id: 'place-1', type: 'PlaceExtract', data: {} }
+    const place2: FlowGraphNode = { id: 'place-2', type: 'PlaceExtract', data: {} }
+    const chunker: FlowGraphNode = { id: 'chunk-1', type: 'DocumentChunker', data: {} }
+    let model = addSiblingBranch(bookends(), 'input-1', place)
+    model = addSiblingBranch(model, 'input-1', place2)
+
+    model = insertInputAdjacentNode(model, chunker)
+
+    expect(model.branchChildren['input-1']).toEqual(['chunk-1'])
+    expect(model.branchChildren['chunk-1']).toEqual(['place-1', 'place-2'])
+    expect(edgeSet(model)).toEqual(
+      new Set([
+        'input-1->chunk-1:branch',
+        'chunk-1->place-1:branch',
+        'chunk-1->place-2:branch',
+        'place-1->output-1:tip',
+        'place-2->output-1:tip',
+      ]),
+    )
+    expect(getInvalidFlowNodeIds(model)).toEqual(new Set())
+  })
+
+  it('restores parallel branches when Document Chunker is deleted', () => {
+    const place: FlowGraphNode = { id: 'place-1', type: 'PlaceExtract', data: {} }
+    const place2: FlowGraphNode = { id: 'place-2', type: 'PlaceExtract', data: {} }
+    const chunker: FlowGraphNode = { id: 'chunk-1', type: 'DocumentChunker', data: {} }
+    let model = addSiblingBranch(bookends(), 'input-1', place)
+    model = addSiblingBranch(model, 'input-1', place2)
+    model = insertInputAdjacentNode(model, chunker)
+
+    model = deleteMiddleNode(model, 'chunk-1')
+
+    expect(model.branchChildren['input-1']).toEqual(['place-1', 'place-2'])
+    expect(model.middleNodes.map((node) => node.id)).toEqual(['place-1', 'place-2'])
+    expect(edgeSet(model)).toEqual(
+      new Set([
+        'input-1->place-1:branch',
+        'input-1->place-2:branch',
+        'place-1->output-1:tip',
+        'place-2->output-1:tip',
+      ]),
+    )
+  })
+
+  it('marks Document Chunker invalid when not directly after input', () => {
+    const place: FlowGraphNode = { id: 'place-1', type: 'PlaceExtract', data: {} }
+    const chunker: FlowGraphNode = { id: 'chunk-1', type: 'DocumentChunker', data: {} }
+    let model = addSiblingBranch(bookends(), 'input-1', place)
+    model = insertAfter(model, 'place-1', chunker)
+
+    expect(getInvalidFlowNodeIds(model).has('chunk-1')).toBe(true)
+  })
+
+  it('marks Document Chunker invalid when a bypass branch skips it', () => {
+    const place: FlowGraphNode = { id: 'place-1', type: 'PlaceExtract', data: {} }
+    const chunker: FlowGraphNode = { id: 'chunk-1', type: 'DocumentChunker', data: {} }
+    let model = insertInputAdjacentNode(bookends(), chunker)
+    model = addSiblingBranch(model, 'input-1', place)
+
+    expect(model.branchChildren['input-1']).toEqual(['chunk-1', 'place-1'])
+    expect(getInvalidFlowNodeIds(model).has('chunk-1')).toBe(true)
   })
 })
 

--- a/apps/agate-ui/src/lib/flowGraphModel.ts
+++ b/apps/agate-ui/src/lib/flowGraphModel.ts
@@ -5,7 +5,12 @@ import {
   BOOKEND_LAYOUT_X_STEP,
   BOOKEND_OUTPUT_POSITION,
 } from '@/lib/flowBuilderLayout'
-import { resolveEdgeHandles, SAME_TYPE_CHAIN_EXEMPT_NODE_TYPES, SYNC_BARRIER_NODE_TYPES } from '@/lib/nodeCompatibility'
+import {
+  DOCUMENT_CHUNKER_TYPE,
+  resolveEdgeHandles,
+  SAME_TYPE_CHAIN_EXEMPT_NODE_TYPES,
+  SYNC_BARRIER_NODE_TYPES,
+} from '@/lib/nodeCompatibility'
 
 export type FlowGraphNode = {
   id: string
@@ -113,6 +118,37 @@ export function getBranchTipIds(model: FlowGraphModel): string[] {
   return allIds.filter((id) => getMiddleSuccessors(model, id).length === 0)
 }
 
+function inputFirstHopChildIds(model: FlowGraphModel): string[] {
+  const inputId = model.inputNode.id
+  const kids = [...(model.branchChildren[inputId] ?? [])]
+  const serial = model.serialLinks[inputId]
+  if (serial && !kids.includes(serial)) {
+    kids.push(serial)
+  }
+  return kids
+}
+
+function markInvalidDocumentChunkerPlacement(model: FlowGraphModel, invalid: Set<string>): void {
+  const chunkers = model.middleNodes.filter((node) => node.type === DOCUMENT_CHUNKER_TYPE)
+  if (chunkers.length === 0) return
+
+  if (chunkers.length > 1) {
+    for (const chunker of chunkers) {
+      invalid.add(chunker.id)
+    }
+    return
+  }
+
+  const chunker = chunkers[0]
+  const firstHop = inputFirstHopChildIds(model)
+  const directlyAfterInput = firstHop.includes(chunker.id)
+  const hasBypass = firstHop.some((id) => id !== chunker.id)
+
+  if (!directlyAfterInput || hasBypass) {
+    invalid.add(chunker.id)
+  }
+}
+
 export function getInvalidFlowNodeIds(model: FlowGraphModel): Set<string> {
   const invalid = new Set<string>()
 
@@ -141,6 +177,8 @@ export function getInvalidFlowNodeIds(model: FlowGraphModel): Set<string> {
       invalid.add(node.id)
     }
   }
+
+  markInvalidDocumentChunkerPlacement(model, invalid)
 
   return invalid
 }
@@ -289,6 +327,77 @@ export function insertAfter(
     ...model,
     outputNode: outputAfterNodes(model.outputNode, [positionedNewNode, ...downstreamNodes]),
     middleNodes: [...middleNodes, positionedNewNode],
+    serialLinks,
+  })
+}
+
+/**
+ * Insert a node directly after the content source, rewiring every current first-hop
+ * child to hang off the new node (Document Chunker placement).
+ */
+export function insertInputAdjacentNode(
+  model: FlowGraphModel,
+  newNode: FlowGraphNode,
+): FlowGraphModel {
+  const inputId = model.inputNode.id
+  const existingBranchChildren = [...(model.branchChildren[inputId] ?? [])]
+  const existingSerial = model.serialLinks[inputId]
+  const firstHopIds: string[] = []
+  if (existingSerial) {
+    firstHopIds.push(existingSerial)
+  }
+  for (const childId of existingBranchChildren) {
+    if (!firstHopIds.includes(childId)) {
+      firstHopIds.push(childId)
+    }
+  }
+
+  const positionedNewNode = {
+    ...newNode,
+    position: newNode.position ?? positionForNewSerialNode(model, inputId),
+  }
+
+  const shiftedIds = new Set<string>()
+  for (const childId of firstHopIds) {
+    for (const id of collectDownstreamMiddleNodeIds(model, childId)) {
+      shiftedIds.add(id)
+    }
+  }
+  const firstDownstreamNode = firstHopIds[0] ? getNodeById(model, firstHopIds[0]) : null
+  const downstreamShift = shiftNeededAfterNode(positionedNewNode, firstDownstreamNode)
+  const middleNodes = model.middleNodes.map((node) =>
+    shiftedIds.has(node.id)
+      ? {
+          ...node,
+          position: {
+            x: (node.position?.x ?? 0) + downstreamShift,
+            y: node.position?.y ?? LAYOUT_INPUT_Y,
+          },
+        }
+      : node,
+  )
+
+  const branchChildren: Record<string, string[]> = { ...model.branchChildren }
+  const serialLinks: Record<string, string> = { ...model.serialLinks }
+  delete serialLinks[inputId]
+  branchChildren[inputId] = [positionedNewNode.id]
+
+  if (existingSerial && existingBranchChildren.length === 0) {
+    serialLinks[positionedNewNode.id] = existingSerial
+  } else if (firstHopIds.length > 0) {
+    branchChildren[positionedNewNode.id] = firstHopIds
+  }
+
+  const shiftedNodesById = new Map(middleNodes.map((node) => [node.id, node]))
+  const downstreamNodes = [...shiftedIds]
+    .map((id) => shiftedNodesById.get(id))
+    .filter((node): node is FlowGraphNode => node != null)
+
+  return applyLayoutToModel({
+    ...model,
+    outputNode: outputAfterNodes(model.outputNode, [positionedNewNode, ...downstreamNodes]),
+    middleNodes: [...middleNodes, positionedNewNode],
+    branchChildren,
     serialLinks,
   })
 }

--- a/apps/agate-ui/src/lib/flowValidation.test.ts
+++ b/apps/agate-ui/src/lib/flowValidation.test.ts
@@ -3,6 +3,7 @@ import {
   paramsForGraphSave,
   sanitizeNodeStylebookRef,
   validateCustomExtractRecordTypes,
+  validateDocumentChunkerPlacement,
   validateFlowInputOutputRules,
   validateGraphForSave,
   validateInputConnections,
@@ -279,6 +280,100 @@ describe('validateCustomExtractRecordTypes', () => {
   })
 })
 
+describe('validateDocumentChunkerPlacement', () => {
+  it('passes when Document Chunker sits directly after the content source', () => {
+    const result = validateDocumentChunkerPlacement(
+      graph({
+        nodes: [
+          { id: 'in', type: 'TextInput' },
+          { id: 'chunk', type: 'DocumentChunker' },
+          { id: 'pe', type: 'PlaceExtract' },
+          { id: 'out', type: 'Output' },
+        ],
+        edges: [
+          { source: 'in', target: 'chunk' },
+          { source: 'chunk', target: 'pe' },
+          { source: 'pe', target: 'out' },
+        ],
+      }),
+    )
+    expect(result.ok).toBe(true)
+  })
+
+  it('rejects more than one Document Chunker', () => {
+    const result = validateDocumentChunkerPlacement(
+      graph({
+        nodes: [
+          { id: 'in', type: 'TextInput' },
+          { id: 'c1', type: 'DocumentChunker' },
+          { id: 'c2', type: 'DocumentChunker' },
+          { id: 'out', type: 'Output' },
+        ],
+        edges: [
+          { source: 'in', target: 'c1' },
+          { source: 'c1', target: 'c2' },
+          { source: 'c2', target: 'out' },
+        ],
+      }),
+    )
+    expect(result).toMatchObject({
+      ok: false,
+      title: 'Too many Document Chunkers',
+      severity: 'error',
+    })
+  })
+
+  it('rejects a bypass branch that skips Document Chunker', () => {
+    const result = validateDocumentChunkerPlacement(
+      graph({
+        nodes: [
+          { id: 'in', type: 'TextInput' },
+          { id: 'chunk', type: 'DocumentChunker' },
+          { id: 'pe', type: 'PlaceExtract' },
+          { id: 'out', type: 'Output' },
+        ],
+        edges: [
+          { source: 'in', target: 'chunk' },
+          { source: 'in', target: 'pe' },
+          { source: 'chunk', target: 'out' },
+          { source: 'pe', target: 'out' },
+        ],
+      }),
+    )
+    expect(result).toMatchObject({
+      ok: false,
+      title: 'Document Chunker placement',
+      severity: 'error',
+    })
+    if (!result.ok) {
+      expect(result.description).toMatch(/every step after the content source/i)
+    }
+  })
+
+  it('rejects Document Chunker not connected from the content source', () => {
+    const result = validateDocumentChunkerPlacement(
+      graph({
+        nodes: [
+          { id: 'in', type: 'TextInput' },
+          { id: 'pe', type: 'PlaceExtract' },
+          { id: 'chunk', type: 'DocumentChunker' },
+          { id: 'out', type: 'Output' },
+        ],
+        edges: [
+          { source: 'in', target: 'pe' },
+          { source: 'pe', target: 'chunk' },
+          { source: 'chunk', target: 'out' },
+        ],
+      }),
+    )
+    expect(result).toMatchObject({
+      ok: false,
+      title: 'Document Chunker placement',
+      severity: 'error',
+    })
+  })
+})
+
 describe('validateGraphForSave', () => {
   it('passes for a valid single-bookend starter graph', () => {
     const result = validateGraphForSave(
@@ -295,6 +390,30 @@ describe('validateGraphForSave', () => {
       }),
     )
     expect(result.ok).toBe(true)
+  })
+
+  it('fails save when Document Chunker placement is invalid', () => {
+    const result = validateGraphForSave(
+      graph({
+        nodes: [
+          { id: 'in', type: 'TextInput' },
+          { id: 'chunk', type: 'DocumentChunker' },
+          { id: 'pe', type: 'PlaceExtract' },
+          { id: 'out', type: 'Output' },
+        ],
+        edges: [
+          { source: 'in', target: 'chunk' },
+          { source: 'in', target: 'pe' },
+          { source: 'chunk', target: 'out' },
+          { source: 'pe', target: 'out' },
+        ],
+      }),
+    )
+    expect(result).toMatchObject({
+      ok: false,
+      title: 'Document Chunker placement',
+      severity: 'error',
+    })
   })
 
   it('passes for S3 Input when the bucket name includes s3://', () => {

--- a/apps/agate-ui/src/lib/flowValidation.ts
+++ b/apps/agate-ui/src/lib/flowValidation.ts
@@ -343,12 +343,81 @@ export function validateInputConnections(graph: FlowGraph): FlowValidationResult
   }
 }
 
+const DOCUMENT_CHUNKER_TYPE = 'DocumentChunker'
+
+/** Document Chunker must sit directly after the content source with no bypass branches. */
+export function validateDocumentChunkerPlacement(graph: FlowGraph): FlowValidationResult {
+  const chunkers = graph.nodes.filter((n) => n.type === DOCUMENT_CHUNKER_TYPE)
+  if (chunkers.length === 0) {
+    return { ok: true }
+  }
+  if (chunkers.length > 1) {
+    return {
+      ok: false,
+      title: 'Too many Document Chunkers',
+      description: 'Your flow can include only one Document Chunker.',
+      severity: 'error',
+    }
+  }
+
+  const chunker = chunkers[0]
+  const nodeIds = new Set(graph.nodes.map((n) => n.id))
+  const byId = new Map(graph.nodes.map((n) => [n.id, n]))
+  const incoming = graph.edges.filter(
+    (e) => e.target === chunker.id && nodeIds.has(e.source),
+  )
+  if (incoming.length !== 1) {
+    return {
+      ok: false,
+      title: 'Document Chunker placement',
+      description:
+        'Document Chunker must connect directly from the content source (Text Input, JSON Input, or S3 Input).',
+      severity: 'error',
+    }
+  }
+
+  const source = byId.get(incoming[0].source)
+  if (!source || !isInputBookendType(source.type)) {
+    return {
+      ok: false,
+      title: 'Document Chunker placement',
+      description:
+        'Document Chunker must be placed directly after Text Input, JSON Input, or S3 Input.',
+      severity: 'error',
+    }
+  }
+
+  const inputChildren = graph.edges
+    .filter((e) => e.source === source.id && nodeIds.has(e.target))
+    .map((e) => e.target)
+  if (inputChildren.length === 0) {
+    return {
+      ok: false,
+      title: 'Document Chunker placement',
+      description: 'Document Chunker must be connected from the content source.',
+      severity: 'error',
+    }
+  }
+  if (inputChildren.some((childId) => childId !== chunker.id)) {
+    return {
+      ok: false,
+      title: 'Document Chunker placement',
+      description:
+        'When a Document Chunker is present, every step after the content source must go through the Document Chunker.',
+      severity: 'error',
+    }
+  }
+
+  return { ok: true }
+}
+
 /** Run all graph save validations; returns the first failure or success. */
 export function validateGraphForSave(graph: FlowGraph): FlowValidationResult {
   const checks: Array<(g: FlowGraph) => FlowValidationResult> = [
     validateFlowInputOutputRules,
     validateNoOrphans,
     validateInputConnections,
+    validateDocumentChunkerPlacement,
     validateCustomExtractRecordTypes,
     (g) => validateJsonInputNodes(g.nodes),
     (g) => validateS3InputBuckets(g.nodes),

--- a/apps/agate-ui/src/lib/nodeColors.ts
+++ b/apps/agate-ui/src/lib/nodeColors.ts
@@ -50,7 +50,7 @@ export const organizationTypes = new Set([
 ])
 export const workTypes = new Set(['WorksExtract'])
 export const formattingTypes = new Set(['LLMFormat'])
-export const controlTypes = new Set(['ArraySplitter', 'ArrayGather', 'Gather'])
+export const controlTypes = new Set(['ArraySplitter', 'ArrayGather', 'Gather', 'DocumentChunker'])
 
 type MetadataCategory =
   | 'input'

--- a/apps/agate-ui/src/lib/nodeCompatibility.test.ts
+++ b/apps/agate-ui/src/lib/nodeCompatibility.test.ts
@@ -114,6 +114,31 @@ describe('getCompatibleNextNodes', () => {
     })
     expect(withModels.enabled.map((e) => e.type)).toContain('ArticleMetadata')
   })
+
+  it('enables Document Chunker from an input bookend when none exists yet', () => {
+    const result = getCompatibleNextNodes('TextInput', ['TextInput'], {
+      existingNodeTypes: ['TextInput', 'Output'],
+    })
+    expect(result.enabled.map((e) => e.type)).toContain('DocumentChunker')
+  })
+
+  it('disables Document Chunker after a middle step', () => {
+    const result = getCompatibleNextNodes('PlaceExtract', ['TextInput', 'PlaceExtract'], {
+      existingNodeTypes: ['TextInput', 'PlaceExtract', 'Output'],
+    })
+    expect(result.enabled.map((e) => e.type)).not.toContain('DocumentChunker')
+    const chunker = result.disabled.find((e) => e.type === 'DocumentChunker')
+    expect(chunker?.reason).toMatch(/directly after the content source/i)
+  })
+
+  it('disables Document Chunker when one already exists in the graph', () => {
+    const result = getCompatibleNextNodes('TextInput', ['TextInput'], {
+      existingNodeTypes: ['TextInput', 'DocumentChunker', 'Output'],
+    })
+    expect(result.enabled.map((e) => e.type)).not.toContain('DocumentChunker')
+    const chunker = result.disabled.find((e) => e.type === 'DocumentChunker')
+    expect(chunker?.reason).toMatch(/already has a Document Chunker/i)
+  })
 })
 
 describe('getCompatibleInsertNodes', () => {
@@ -143,6 +168,25 @@ describe('getCompatibleInsertNodes', () => {
   it('enables Gather before Backfield Output', () => {
     const result = getCompatibleInsertNodes('TextInput', 'DBOutput', ['TextInput'])
     expect(result.enabled.map((e) => e.type)).toContain('Gather')
+  })
+
+  it('enables Document Chunker between content source and a middle step', () => {
+    const result = getCompatibleInsertNodes('TextInput', 'PlaceExtract', ['TextInput'], {
+      existingNodeTypes: ['TextInput', 'PlaceExtract', 'Output'],
+    })
+    expect(result.enabled.map((e) => e.type)).toContain('DocumentChunker')
+  })
+
+  it('disables inserting Document Chunker after a middle step', () => {
+    const result = getCompatibleInsertNodes(
+      'PlaceExtract',
+      'GeocodeAgent',
+      ['TextInput', 'PlaceExtract'],
+      { existingNodeTypes: ['TextInput', 'PlaceExtract', 'GeocodeAgent', 'Output'] },
+    )
+    expect(result.enabled.map((e) => e.type)).not.toContain('DocumentChunker')
+    const chunker = result.disabled.find((e) => e.type === 'DocumentChunker')
+    expect(chunker?.reason).toMatch(/directly after the content source/i)
   })
 })
 

--- a/apps/agate-ui/src/lib/nodeCompatibility.ts
+++ b/apps/agate-ui/src/lib/nodeCompatibility.ts
@@ -24,7 +24,14 @@ export type CompatibleNextNodesResult = {
 export type CompatibleNodesOptions = {
   /** Capability name → true when at least one project model is enabled (e.g. embedding). */
   projectModelCapabilities?: Record<string, boolean>
+  /** Node types already present in the flow (including bookends). */
+  existingNodeTypes?: readonly string[]
+  /** When true, Document Chunker is already in the graph. */
+  hasDocumentChunker?: boolean
 }
+
+/** Must sit directly after the content source; at most one per flow. */
+export const DOCUMENT_CHUNKER_TYPE = 'DocumentChunker'
 
 function requiredProjectModelCapabilities(meta: NodeMetadataEntry): string[] {
   const caps = (meta as { requiredProjectModelCapabilities?: string[] })
@@ -219,6 +226,30 @@ function sameTypeChainFailureReason(meta: NodeMetadataEntry): string {
   return `${label} cannot follow another ${label} step.`
 }
 
+function graphHasDocumentChunker(options?: CompatibleNodesOptions): boolean {
+  if (options?.hasDocumentChunker === true) return true
+  return (options?.existingNodeTypes ?? []).includes(DOCUMENT_CHUNKER_TYPE)
+}
+
+function documentChunkerAvailability(
+  sourceType: string,
+  options?: CompatibleNodesOptions,
+): { ok: true } | { ok: false; reason: string } {
+  if (graphHasDocumentChunker(options)) {
+    return {
+      ok: false,
+      reason: 'This flow already has a Document Chunker.',
+    }
+  }
+  if (!isInputBookendType(sourceType)) {
+    return {
+      ok: false,
+      reason: 'Document Chunker must be placed directly after the content source.',
+    }
+  }
+  return { ok: true }
+}
+
 // Each instance classifies/extracts a different dimension or record type, so
 // serial chains of the same step are intentional.
 export const SAME_TYPE_CHAIN_EXEMPT_NODE_TYPES = new Set(['ArticleMetadata', 'CustomExtract'])
@@ -268,6 +299,14 @@ export function getCompatibleNextNodes(
     const ancestryWithParent = branchAncestryTypes.includes(parentType)
       ? branchAncestryTypes
       : [...branchAncestryTypes, parentType]
+
+    if (meta.type === DOCUMENT_CHUNKER_TYPE) {
+      const chunkerCheck = documentChunkerAvailability(parentType, options)
+      if (!chunkerCheck.ok) {
+        disabled.push(toEntry(meta, false, chunkerCheck.reason))
+        continue
+      }
+    }
 
     const required = meta.requiredUpstreamNodes ?? []
     if (!upstreamRequirementsMet(required, ancestryWithParent)) {
@@ -321,6 +360,14 @@ export function getCompatibleInsertNodes(
   for (const meta of nodeMetadata) {
     if (isBookendType(meta.type)) continue
     if ((meta as { enabled?: boolean }).enabled === false) continue
+
+    if (meta.type === DOCUMENT_CHUNKER_TYPE) {
+      const chunkerCheck = documentChunkerAvailability(sourceType, options)
+      if (!chunkerCheck.ok) {
+        disabled.push(toEntry(meta, false, chunkerCheck.reason))
+        continue
+      }
+    }
 
     const candidateRequired = meta.requiredUpstreamNodes ?? []
     if (!upstreamRequirementsMet(candidateRequired, ancestryWithSource)) {

--- a/apps/agate-ui/src/lib/nodePanelTabs.test.ts
+++ b/apps/agate-ui/src/lib/nodePanelTabs.test.ts
@@ -63,6 +63,15 @@ describe('getNodePanelTabs', () => {
     ])
   })
 
+  it('shows settings, info, and outputs for document chunker when a run exists', () => {
+    expect(getNodePanelTabs('DocumentChunker')).toEqual(['settings', 'info'])
+    expect(getNodePanelTabs('DocumentChunker', { hasRunOutput: true })).toEqual([
+      'settings',
+      'info',
+      'outputs',
+    ])
+  })
+
   it('splits article metadata configuration across settings, prompt, output, and info', () => {
     expect(getNodePanelTabs('ArticleMetadata')).toEqual(['settings', 'prompts', 'outputs', 'info'])
   })

--- a/apps/agate-ui/src/lib/nodePanelTabs.ts
+++ b/apps/agate-ui/src/lib/nodePanelTabs.ts
@@ -35,6 +35,8 @@ export function getNodePanelTabs(
       return ['settings', 'info']
     case 'Gather':
       return hasRunOutput ? ['settings', 'info', 'outputs'] : ['settings', 'info']
+    case 'DocumentChunker':
+      return hasRunOutput ? ['settings', 'info', 'outputs'] : ['settings', 'info']
     case 'ArticleMetadata':
       return ['settings', 'prompts', 'outputs', 'info']
     case 'Output':

--- a/apps/agate-ui/src/lib/platformUrls.ts
+++ b/apps/agate-ui/src/lib/platformUrls.ts
@@ -31,7 +31,7 @@ export function helpHref(): string {
   if (typeof raw === 'string' && raw.trim() !== '') {
     return raw.trim()
   }
-  return 'https://docs.backfield.org'
+  return 'https://docs.backfield.news'
 }
 
 function tenantSlug(currentOrigin: string): string {

--- a/apps/agate-ui/src/nodes/document_chunker/NodeComponent.tsx
+++ b/apps/agate-ui/src/nodes/document_chunker/NodeComponent.tsx
@@ -1,0 +1,88 @@
+// Auto-injected metadata for DocumentChunker
+const nodeMetadata = {
+  "type": "DocumentChunker",
+  "name": "DocumentChunker",
+  "label": "Document Chunker",
+  "description": "Optionally split a long document into overlapping pieces so extraction can handle larger content while keeping one story for review.",
+  "category": "other",
+  "icon": "Split",
+  "color": "bg-cyan-500",
+  "requiredUpstreamNodes": [],
+  "dependencyHelperText": "Place this directly after Text Input, JSON Input, or S3 Input. Extraction nodes after it process each piece and combine the results.",
+  "inputs": [
+    {
+      "id": "text",
+      "label": "Text",
+      "type": "string",
+      "required": true
+    }
+  ],
+  "outputs": [
+    {
+      "id": "text",
+      "label": "Text",
+      "type": "string"
+    },
+    {
+      "id": "chunking_summary",
+      "label": "Chunking summary",
+      "type": "object"
+    }
+  ],
+  "defaultParams": {
+    "target_tokens": 4000,
+    "overlap_tokens": 250
+  }
+};
+
+import { memo } from 'react'
+import { Handle, Position, NodeProps } from 'reactflow'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { getNodeIcon, getNodeBgColor } from '@/lib/nodeUtils'
+
+function DocumentChunkerNode({ data, selected }: NodeProps) {
+  const dependencyHelperText = nodeMetadata?.dependencyHelperText || ''
+  const icon = getNodeIcon('DocumentChunker', 'h-4 w-4')
+  const bgColor = getNodeBgColor('DocumentChunker')
+  const targetTokens =
+    typeof data?.target_tokens === 'number'
+      ? data.target_tokens
+      : typeof data?.target_tokens === 'string' && data.target_tokens.trim()
+        ? data.target_tokens
+        : 4000
+
+  return (
+    <Card className={`w-[280px] ${selected ? 'ring-2 ring-primary' : ''}`}>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-sm font-medium flex items-center gap-2">
+          <div className={`flex items-center justify-center w-6 h-6 rounded-full ${bgColor}`}>
+            {icon}
+          </div>
+          Document Chunker
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <Handle
+          type="target"
+          position={Position.Left}
+          id="text"
+          className="w-3 h-3 bg-gray-700"
+        />
+        <p className="text-xs text-muted-foreground">
+          Splits long documents into pieces of about {targetTokens} tokens.
+        </p>
+        {dependencyHelperText ? (
+          <p className="text-xs text-muted-foreground">{dependencyHelperText}</p>
+        ) : null}
+        <Handle
+          type="source"
+          position={Position.Right}
+          id="text"
+          className="w-3 h-3 bg-gray-700"
+        />
+      </CardContent>
+    </Card>
+  )
+}
+
+export default memo(DocumentChunkerNode)

--- a/apps/agate-ui/src/nodes/document_chunker/PanelComponent.tsx
+++ b/apps/agate-ui/src/nodes/document_chunker/PanelComponent.tsx
@@ -1,0 +1,201 @@
+// Auto-injected metadata for DocumentChunker
+const nodeMetadata = {
+  "type": "DocumentChunker",
+  "name": "DocumentChunker",
+  "label": "Document Chunker",
+  "description": "Optionally split a long document into overlapping pieces so extraction can handle larger content while keeping one story for review.",
+  "category": "other",
+  "icon": "Split",
+  "color": "bg-cyan-500",
+  "requiredUpstreamNodes": [],
+  "dependencyHelperText": "Place this directly after Text Input, JSON Input, or S3 Input. Extraction nodes after it process each piece and combine the results.",
+  "inputs": [
+    {
+      "id": "text",
+      "label": "Text",
+      "type": "string",
+      "required": true
+    }
+  ],
+  "outputs": [
+    {
+      "id": "text",
+      "label": "Text",
+      "type": "string"
+    },
+    {
+      "id": "chunking_summary",
+      "label": "Chunking summary",
+      "type": "object"
+    }
+  ],
+  "defaultParams": {
+    "target_tokens": 4000,
+    "overlap_tokens": 250
+  }
+};
+
+import { NodePanelTabGate } from '@/components/node-panel/NodePanelTabContext'
+import { FieldLabel } from '@/components/node-panel/FieldLabel'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { getNodeOutputById } from '@backfield/ui/nodeOutputs'
+import type { Dispatch, SetStateAction } from 'react'
+import type { Node } from 'reactflow'
+
+interface DocumentChunkerPanelProps {
+  node: { id: string; data?: Record<string, unknown> }
+  editMode?: boolean
+  setNodes?: Dispatch<SetStateAction<Node[]>>
+  currentRun?: { node_outputs?: Record<string, unknown> | null } | null
+}
+
+type ChunkPreview = {
+  index?: number
+  approximate_tokens?: number
+  preview?: string
+}
+
+function asPositiveInt(raw: unknown, fallback: number): number {
+  if (typeof raw === 'number' && Number.isFinite(raw)) return Math.trunc(raw)
+  if (typeof raw === 'string' && raw.trim() !== '' && !Number.isNaN(Number(raw))) {
+    return Math.trunc(Number(raw))
+  }
+  return fallback
+}
+
+export default function DocumentChunkerPanel({
+  node,
+  editMode = false,
+  setNodes,
+  currentRun,
+}: DocumentChunkerPanelProps) {
+  const defaults = (nodeMetadata?.defaultParams || {}) as Record<string, unknown>
+  const data = { ...defaults, ...(node.data || {}) }
+  const targetTokens = asPositiveInt(data.target_tokens, 4000)
+  const overlapTokens = asPositiveInt(data.overlap_tokens, 250)
+
+  const patch = (patchData: Record<string, unknown>) => {
+    if (!editMode || !setNodes) return
+    setNodes((nodes) =>
+      nodes.map((entry) =>
+        entry.id === node.id
+          ? { ...entry, data: { ...(entry.data || {}), ...patchData } }
+          : entry,
+      ),
+    )
+  }
+
+  const nodeOutput = getNodeOutputById(
+    currentRun?.node_outputs as Record<string, unknown> | undefined,
+    node.id,
+  )
+  const summary =
+    nodeOutput && typeof nodeOutput === 'object' && nodeOutput !== null
+      ? ((nodeOutput as Record<string, unknown>).chunking_summary as
+          | Record<string, unknown>
+          | undefined)
+      : undefined
+  const chunkPreviews = Array.isArray(summary?.chunks)
+    ? (summary?.chunks as ChunkPreview[]).slice(0, 12)
+    : []
+
+  return (
+    <>
+      <NodePanelTabGate tab="settings">
+        <div className="space-y-4">
+          <p className="text-sm text-muted-foreground leading-relaxed">
+            Use this when a document is too long for extraction on its own. Backfield keeps one
+            story for review and combines results from each piece.
+          </p>
+          <div className="space-y-2">
+            <FieldLabel htmlFor="chunk-target-tokens" required>
+              Target piece size
+            </FieldLabel>
+            <Input
+              id="chunk-target-tokens"
+              value={String(targetTokens)}
+              disabled={!editMode}
+              onChange={(event) => {
+                const next = event.target.value.replace(/[^\d]/g, '')
+                patch({ target_tokens: next === '' ? '' : Number(next) })
+              }}
+            />
+            <p className="text-xs text-muted-foreground">
+              Approximate tokens per piece. Larger pieces mean fewer model calls.
+            </p>
+          </div>
+          <div className="space-y-2">
+            <FieldLabel htmlFor="chunk-overlap-tokens" required>
+              Overlap
+            </FieldLabel>
+            <Input
+              id="chunk-overlap-tokens"
+              value={String(overlapTokens)}
+              disabled={!editMode}
+              onChange={(event) => {
+                const next = event.target.value.replace(/[^\d]/g, '')
+                patch({ overlap_tokens: next === '' ? '' : Number(next) })
+              }}
+            />
+            <p className="text-xs text-muted-foreground">
+              Shared text between neighboring pieces so names and places near boundaries are not
+              missed. Must be smaller than the target piece size.
+            </p>
+          </div>
+        </div>
+      </NodePanelTabGate>
+
+      <NodePanelTabGate tab="info">
+        {nodeMetadata.dependencyHelperText ? (
+          <p className="text-sm text-muted-foreground leading-relaxed">
+            {nodeMetadata.dependencyHelperText}
+          </p>
+        ) : null}
+      </NodePanelTabGate>
+
+      <NodePanelTabGate tab="outputs">
+        {summary ? (
+          <div className="space-y-3">
+            <div>
+              <Label className="text-xs font-medium text-muted-foreground">Summary</Label>
+              <p className="text-sm mt-1">
+                {String(summary.chunk_count ?? 0)} piece
+                {Number(summary.chunk_count) === 1 ? '' : 's'}
+                {summary.split_required ? '' : ' (document did not need splitting)'}
+              </p>
+              <p className="text-xs text-muted-foreground mt-1">
+                About {String(summary.approximate_document_tokens ?? '—')} tokens in the full
+                document.
+              </p>
+            </div>
+            <div className="space-y-2">
+              <Label className="text-xs font-medium text-muted-foreground">Piece previews</Label>
+              {chunkPreviews.length === 0 ? (
+                <p className="text-sm text-muted-foreground">No piece previews available.</p>
+              ) : (
+                chunkPreviews.map((chunk) => (
+                  <div key={String(chunk.index)} className="rounded bg-muted p-2 space-y-1">
+                    <p className="text-xs font-medium">
+                      Piece {(chunk.index ?? 0) + 1}
+                      {typeof chunk.approximate_tokens === 'number'
+                        ? ` · ~${chunk.approximate_tokens} tokens`
+                        : ''}
+                    </p>
+                    <p className="text-xs text-muted-foreground break-words">
+                      {chunk.preview || '—'}
+                    </p>
+                  </div>
+                ))
+              )}
+            </div>
+          </div>
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            Run the flow to preview how this document was split.
+          </p>
+        )}
+      </NodePanelTabGate>
+    </>
+  )
+}

--- a/apps/agate-ui/src/pages/GuidedFlowBuilder.tsx
+++ b/apps/agate-ui/src/pages/GuidedFlowBuilder.tsx
@@ -40,6 +40,7 @@ import {
   getNodeById,
   hydrateFromSpec,
   insertBetween,
+  insertInputAdjacentNode,
   modelToGraphSpec,
   TIDY_LAYOUT_X_STEP,
   updateMiddleNode,
@@ -57,7 +58,11 @@ import {
   type FlowBuilderStep,
 } from '@/lib/flowBuilderSteps'
 import { isJsonInputInvalidNodeData } from '@/lib/jsonInputValidation'
-import { getCompatibleInsertNodes, getCompatibleNextNodes } from '@/lib/nodeCompatibility'
+import {
+  DOCUMENT_CHUNKER_TYPE,
+  getCompatibleInsertNodes,
+  getCompatibleNextNodes,
+} from '@/lib/nodeCompatibility'
 import { getGuidedFlowCapabilities } from '@/lib/guidedFlowCapabilities'
 import { captureGuidedFlowSnapshot, type GuidedFlowSnapshot } from '@/lib/guidedFlowSnapshot'
 import { nodeOutputLookupFromReactFlow } from '@/lib/nodeOutputs'
@@ -1481,9 +1486,22 @@ const GuidedFlowBuilder = forwardRef<GuidedFlowBuilderHandle, GuidedFlowBuilderP
     [exitingNodeIds, scaffoldModel],
   )
 
+  const existingNodeTypes = useMemo(() => {
+    if (!scaffoldModel) return [] as string[]
+    return [
+      scaffoldModel.inputNode.type,
+      scaffoldModel.outputNode.type,
+      ...scaffoldModel.middleNodes.map((node) => node.type),
+    ].filter((type): type is string => typeof type === 'string' && type.length > 0)
+  }, [scaffoldModel])
+
   const addNodeCompatibility = useMemo(() => {
     if (!scaffoldModel) {
       return { enabled: [], disabled: [] }
+    }
+    const compatibilityOptions = {
+      projectModelCapabilities,
+      existingNodeTypes,
     }
     if (addIntoEdge) {
       const source = getNodeById(scaffoldModel, addIntoEdge.sourceId)
@@ -1493,7 +1511,7 @@ const GuidedFlowBuilder = forwardRef<GuidedFlowBuilderHandle, GuidedFlowBuilderP
         source.type,
         target.type,
         getBranchAncestry(scaffoldModel, addIntoEdge.sourceId),
-        { projectModelCapabilities },
+        compatibilityOptions,
       )
     }
     const parentId = addFromParentId
@@ -1502,10 +1520,18 @@ const GuidedFlowBuilder = forwardRef<GuidedFlowBuilderHandle, GuidedFlowBuilderP
     }
     const parent = getNodeById(scaffoldModel, parentId)
     if (!parent?.type) return { enabled: [], disabled: [] }
-    return getCompatibleNextNodes(parent.type, getBranchAncestry(scaffoldModel, parentId), {
-      projectModelCapabilities,
-    })
-  }, [addFromParentId, addIntoEdge, scaffoldModel, projectModelCapabilities])
+    return getCompatibleNextNodes(
+      parent.type,
+      getBranchAncestry(scaffoldModel, parentId),
+      compatibilityOptions,
+    )
+  }, [
+    addFromParentId,
+    addIntoEdge,
+    existingNodeTypes,
+    scaffoldModel,
+    projectModelCapabilities,
+  ])
 
   const handleAddNodeTypeSelect = useCallback(
     (type: string) => {
@@ -1529,7 +1555,9 @@ const GuidedFlowBuilder = forwardRef<GuidedFlowBuilderHandle, GuidedFlowBuilderP
       setScaffoldModel((model) => {
         if (!model) return model
         let next = model
-        if (addIntoEdge) {
+        if (type === DOCUMENT_CHUNKER_TYPE) {
+          next = insertInputAdjacentNode(model, newNode)
+        } else if (addIntoEdge) {
           next = insertBetween(model, addIntoEdge.sourceId, addIntoEdge.targetId, newNode)
         } else if (addFromParentId) {
           next = addSiblingBranch(model, addFromParentId, newNode)

--- a/apps/api-playground/src/components/PlatformSidebar.tsx
+++ b/apps/api-playground/src/components/PlatformSidebar.tsx
@@ -321,7 +321,7 @@ export default function PlatformSidebar({
               </a>
             ) : null}
             <a
-              href="https://docs.backfield.org"
+              href="https://docs.backfield.news"
               className={hubLinkClass}
               title={!expanded ? "Help" : undefined}
             >

--- a/apps/stylebook-ui/src/lib/platformUrls.ts
+++ b/apps/stylebook-ui/src/lib/platformUrls.ts
@@ -31,7 +31,7 @@ export function helpHref(): string {
   if (typeof raw === "string" && raw.trim() !== "") {
     return raw.trim()
   }
-  return "https://docs.backfield.org"
+  return "https://docs.backfield.news"
 }
 
 function tenantSlug(currentOrigin: string): string {

--- a/docs/api/processed-item-review.md
+++ b/docs/api/processed-item-review.md
@@ -17,6 +17,10 @@ Routes are under `/runs/{run_id}/items/{item_id}` and require access to the run'
 - article metadata rows;
 - semantic indexing, article embedding, and automatic connection summaries.
 
+Document chunks from `DocumentChunker` are not a separate review surface. Review continues to
+show one story body and one merged entity set. Chunk texts and internal offsets are not part of
+durable processed-item output; node diagnostics may include a bounded chunking summary only.
+
 Synthetic `items/1` views are available for whole-flow runs without a stored processed-item row. Review mutations require a real processed item and return `404` for a synthetic view.
 
 ## Overlay writes and concurrency

--- a/docs/architecture/runtime.md
+++ b/docs/architecture/runtime.md
@@ -70,6 +70,12 @@ Public result keys are stable snake_case names derived from node type and topolo
 `Output` maps to `json_output`, Backfield Output maps to `stylebook_output`, and repeated node
 types receive deterministic suffixes.
 
+Optional `DocumentChunker` keeps one processed item and one canonical article text per source
+document. Chunks are execution units inside extract nodes (bounded concurrency, ownership
+ranges, cross-chunk stitching). The transient chunk envelope is stripped from consolidated /
+exported bodies; only a bounded `chunking_summary` appears in projected run JSON. Replay
+regenerates chunks from the original `input_json` and pinned graph.
+
 ## Backfield Output
 
 Backfield Output consolidates article content and supported domains, then persists them through

--- a/docs/assets/local-angle-icon.svg
+++ b/docs/assets/local-angle-icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 327 271">
+  <path fill="#2b8987" stroke="#2b8987" stroke-width="6" stroke-linejoin="round" d="M105 96 L162 188 L106 268 L6 268 Z"/>
+  <path fill="#fe6962" stroke="#fe6962" stroke-width="6" stroke-linejoin="round" d="M164 4 L322 268 L219 268 L107 93 Z"/>
+</svg>

--- a/docs/development/nodes.md
+++ b/docs/development/nodes.md
@@ -18,15 +18,16 @@ Use `.cursor/skills/add-agate-node/SKILL.md` for a new pipeline node.
 | Extract | Produce grounded structured records | `PlaceExtract`, `PersonExtract`, `OrganizationExtract`, `CustomExtract` | Entity tabs or Custom |
 | Enrich | Transform or resolve upstream values | `GeocodeAgent`, `ArticleMetadata` | Existing entity tab or Meta |
 | Embed | Produce semantic vectors | `EmbedText`, `EmbedImages` | Info/Images plus JSON |
-| Other | Gather or reshape graph data | `Gather` | Panel output and JSON |
+| Other | Gather or reshape graph data | `Gather`, `DocumentChunker` | Panel output and JSON |
 
 The package currently contains these metadata-backed folders:
 
 ```text
-article_metadata  custom_extract  db_output       embed_images
-embed_text        gather          geocode_agent   json_input
-organization_extract              output          person_extract
-place_extract     s3_input        s3_output        text_input
+article_metadata  custom_extract  db_output       document_chunker
+embed_images      embed_text      gather          geocode_agent
+json_input        organization_extract            output
+person_extract    place_extract   s3_input        s3_output
+text_input
 ```
 
 ## End-to-end layer map
@@ -44,8 +45,14 @@ place_extract     s3_input        s3_output        text_input
 | Panel tabs | `apps/agate-ui/src/lib/nodePanelTabs.ts` |
 | Compatibility | `apps/agate-ui/src/lib/nodeCompatibility.ts` |
 | Bookend validation | `apps/agate-ui/src/lib/flowValidation.ts` |
+| Graph invariants | `packages/backfield-agate/src/agate_runtime/graph_validation.py` |
 | Icons and colors | `apps/agate-ui/src/lib/nodeUtils.ts`, `nodeColors.ts` |
 | Processed-item review | `apps/agate-api/src/api/processed_item/`, `apps/agate-ui/src/lib/review/` |
+
+`DocumentChunker` is optional and input-adjacent: at most one per flow, placed
+directly after Text/JSON/S3 Input, with no bypass branches from the content source.
+The guided builder inserts it with `insertInputAdjacentNode`; save/run/execute paths
+enforce the same rules via `validate_graph_invariants`.
 
 Most nodes emit JSON only. Durable entity writes normally flow through Backfield
 Output to `worker/substrate/orchestration.py`, which dispatches consolidated keys
@@ -223,6 +230,29 @@ The worker records node ID and type for AI usage. Agate resolves display names f
 the current graph and metadata label, with node type as a fallback, so every node
 needs a useful product label.
 
+### Document Chunker
+
+`DocumentChunker` is an optional middle node that must sit directly after the input
+bookend. At most one Chunker is allowed per flow, and every first-hop branch must go
+through it when present (enforced in guided UI, Agate API graph create/update, run
+trigger, and `execute_graph`).
+
+Defaults are approximately 4,000-token pieces with 250-token overlap. Splitting prefers
+paragraph boundaries, then sentence boundaries, then a hard cut. Short documents emit
+one chunk with `split_required=false`. Flows reject documents that would exceed 50
+chunks.
+
+The Chunker preserves the original `text` and carries a reserved transient envelope
+(`__document_chunk_envelope`) for downstream extractors. Public run JSON only includes
+a bounded `chunking_summary` (counts, offsets, short previews). Place, Person,
+Organization, and Custom Extract consume the envelope when present: they process chunks
+with concurrency 3, all-or-nothing failure, ownership-range grounding, and
+document-level named/abbreviated stitching (Custom Extract exact-merges only). Without
+a Chunker, those extractors preflight the composed prompt against the selected model's
+context window (8,000-token fallback when metadata is unknown) and fail with guidance
+to add Document Chunker. Article Metadata and Embed Text keep whole-document outputs
+but truncate prompt/embedding body input safely.
+
 ## Canvas components
 
 `ui/NodeComponent.tsx` uses React Flow `NodeProps`, normally wrapped in `memo`.
@@ -258,6 +288,8 @@ Tab IDs and labels are centralized in `src/lib/nodePanelTabs.ts`. Current routin
 | Geocode Agent | Settings, Models |
 | Embed Text, Embed Images | Settings, Info |
 | Gather | Settings, Info; Output when run output exists |
+| Document Chunker | Settings, Info; Output when run output exists |
+| Document Chunker | Settings, Info; Output when run output exists |
 | JSON Output | Output only when run output exists |
 | Backfield Output | Settings, Stylebook |
 | S3 Output | Settings; Output when run output exists |

--- a/docs/operations/runtime-configuration.md
+++ b/docs/operations/runtime-configuration.md
@@ -33,7 +33,7 @@ Health endpoints are `GET /health` on Agate API, Stylebook API, and Core API.
 
 Frontend cross-app destinations are build-time Vite settings. `VITE_AGATE_UI_ORIGIN` and
 `VITE_STYLEBOOK_UI_ORIGIN` override tenant sibling-app discovery, `VITE_HELP_URL` overrides the Help
-destination (default `https://docs.backfield.org`), and `VITE_PLAYGROUND_URL` overrides the hosted
+destination (default `https://docs.backfield.news`), and `VITE_PLAYGROUND_URL` overrides the hosted
 API Playground destination. Local Agate and Stylebook builds otherwise link to
 `http://localhost:5176`; production builds derive
 `https://playground.{organization-slug}.backfield.news`. A custom `VITE_PLAYGROUND_URL` may contain

--- a/packages/backfield-agate/src/agate_nodes/article_metadata/node_port.py
+++ b/packages/backfield-agate/src/agate_nodes/article_metadata/node_port.py
@@ -11,6 +11,10 @@ from typing import Any
 
 from agate_runtime.context import AgateEnvContext
 from agate_utils.llm import call_llm
+from agate_utils.text_chunking import (
+    ARTICLE_METADATA_PROMPT_TOKENS,
+    TRANSIENT_CHUNK_ENVELOPE_KEY,
+)
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from agate_nodes.article_metadata.category_labels import (
@@ -36,6 +40,7 @@ from agate_nodes.article_metadata.presets import (
     preset_prompt_relpath,
     resolve_meta_type,
 )
+from agate_nodes.extraction.prompt_text import truncate_flattened_for_prompt
 
 logger = logging.getLogger(__name__)
 
@@ -160,6 +165,10 @@ class ArticleMetadataNode:
         input_dict = inp.model_dump()
         flattened = flatten_input(input_dict)
         text = resolve_text(flattened)
+        prompt_flattened, _truncated = truncate_flattened_for_prompt(
+            flattened,
+            max_tokens=ARTICLE_METADATA_PROMPT_TOKENS,
+        )
 
         preset_id, prompt_template = self._resolve_prompt_template(params)
         resolved_meta_type = resolve_meta_type(
@@ -169,7 +178,7 @@ class ArticleMetadataNode:
         output_format = load_package_file(preset_output_format_relpath(preset_id))
         prompt, allowed_categories = compose_article_metadata_prompt(
             prompt_template=prompt_template,
-            flattened=flattened,
+            flattened=prompt_flattened,
             output_format_json=output_format,
             preset_id=preset_id,
         )
@@ -298,6 +307,7 @@ class ArticleMetadataNode:
                 article_metadata = build_metadata(fallback_to_other=True)
 
         output_data: dict[str, Any] = dict(flattened)
+        output_data.pop(TRANSIENT_CHUNK_ENVELOPE_KEY, None)
         output_data["text"] = text
         output_data["article_metadata"] = article_metadata
 

--- a/packages/backfield-agate/src/agate_nodes/custom_extract/composer.py
+++ b/packages/backfield-agate/src/agate_nodes/custom_extract/composer.py
@@ -81,9 +81,9 @@ def compose_custom_extract_prompt(
         'and optionally "confidence".\n'
         '- "fields" holds the field values listed above; use null when a value is not '
         "stated in the article. Never guess.\n"
-        '- "mentions" must contain at least one object with "text" (a verbatim snippet '
-        "from the article that supports this record). Records without supporting text in "
-        "the article must be omitted.\n"
+        '- "mentions" must contain at least one object with "text": prefer the first '
+        "verbatim mention from the article that grounds this record (an evidence anchor). "
+        "Records without supporting text in the article must be omitted.\n"
         '- "confidence" is a number from 0.0 to 1.0.\n'
         "- Return an empty array when no records of this type appear in the article.\n\n"
         "Example shape:\n"

--- a/packages/backfield-agate/src/agate_nodes/custom_extract/node_port.py
+++ b/packages/backfield-agate/src/agate_nodes/custom_extract/node_port.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-import os
 import time
 from typing import Any
 
 from agate_runtime.context import AgateEnvContext
 from agate_utils.llm import call_llm
 from agate_utils.prompt_placeholders import substitute_prompt_placeholders
+from agate_utils.text_chunking import DocumentChunk, envelope_from_payload
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from agate_nodes.custom_extract.composer import (
@@ -20,12 +20,25 @@ from agate_nodes.custom_extract.composer import (
     resolve_text,
 )
 from agate_nodes.custom_extract.parse import parse_custom_extract_response
+from agate_nodes.custom_extract.reconcile import stitch_custom_candidates
 from agate_nodes.custom_extract.schema import CustomFieldSpec, CustomRecordSchema
+from agate_nodes.extraction.chunked_entity_extract import (
+    extract_entities_over_chunks,
+    strip_transient_chunk_keys,
+)
+from agate_nodes.extraction.grounding import (
+    ChunkCandidate,
+    locate_evidence_span,
+    mark_ownership,
+)
+from agate_nodes.extraction.shared_llm import (
+    effective_llm_timeout,
+    model_config_id_from_params,
+    preflight_unchunked_prompt,
+    resolve_extract_litellm_model,
+)
 
 logger = logging.getLogger(__name__)
-
-TASK_SOFT_TIME_LIMIT = int(os.getenv("TASK_SOFT_TIME_LIMIT", "3600"))
-CELERY_TIMEOUT_BUFFER = 300
 
 
 class CustomExtractInput(BaseModel):
@@ -71,6 +84,68 @@ class CustomExtractNode:
     Output = CustomExtractOutput
     Params = CustomExtractParams
 
+    def _parse_chunk_candidates(
+        self,
+        response_data: Any,
+        chunk: DocumentChunk,
+        source_text: str,
+        *,
+        record_schema: CustomRecordSchema,
+    ) -> list[ChunkCandidate[dict[str, Any]]]:
+        result = parse_custom_extract_response(
+            response_data,
+            record_schema=record_schema,
+        )
+        candidates: list[ChunkCandidate[dict[str, Any]]] = []
+        for record in result.records:
+            payload = record.model_dump()
+            evidence_text = ""
+            mentions = payload.get("mentions") or []
+            if isinstance(mentions, list) and mentions:
+                first = mentions[0]
+                if isinstance(first, dict) and isinstance(first.get("text"), str):
+                    evidence_text = first["text"].strip()
+            if not evidence_text:
+                fields = payload.get("fields")
+                if isinstance(fields, dict):
+                    for value in fields.values():
+                        if isinstance(value, str) and value.strip():
+                            evidence_text = value.strip()
+                            break
+            span = locate_evidence_span(
+                source_text=source_text,
+                chunk=chunk,
+                evidence_text=evidence_text,
+                prefer_owned=True,
+            )
+            candidate = ChunkCandidate(
+                payload=payload,
+                chunk_index=chunk.index,
+                evidence=span,
+            )
+            candidates.append(mark_ownership(candidate, chunk=chunk))
+        return candidates
+
+    def _merge_custom_records(
+        self,
+        *,
+        flattened: dict[str, Any],
+        record_schema: CustomRecordSchema,
+        records: list[dict[str, Any]],
+        dropped_ungrounded: int,
+    ) -> dict[str, Any]:
+        upstream_records = flattened.get("custom_records")
+        merged_records: dict[str, Any] = (
+            dict(upstream_records) if isinstance(upstream_records, dict) else {}
+        )
+        merged_records[record_schema.record_type] = {
+            "label": record_schema.label,
+            "schema": [spec.model_dump() for spec in record_schema.fields],
+            "records": records,
+            "dropped_ungrounded": dropped_ungrounded,
+        }
+        return merged_records
+
     async def run(
         self,
         inp: CustomExtractInput,
@@ -81,51 +156,87 @@ class CustomExtractNode:
         input_dict = inp.model_dump()
         flattened = flatten_input(input_dict)
         text = resolve_text(flattened)
-
+        envelope = envelope_from_payload(flattened)
         record_schema = params.record_schema()
+        resolved_model = resolve_extract_litellm_model(params, log_label="CustomExtract")
+        system_message = (
+            "You are a specialized AI assistant for extracting structured records "
+            "from news text. Return only valid JSON."
+        )
+
+        if envelope is not None:
+
+            def build_prompt(state: dict[str, Any]) -> str:
+                chunk_text = resolve_text(state)
+                instructions = substitute_prompt_placeholders(params.instructions, state)
+                return compose_custom_extract_prompt(
+                    record_schema=record_schema,
+                    instructions=instructions,
+                    text=chunk_text,
+                )
+
+            def parse_chunk(
+                response_data: Any,
+                chunk: DocumentChunk,
+                source_text: str,
+            ) -> list[ChunkCandidate[dict[str, Any]]]:
+                return self._parse_chunk_candidates(
+                    response_data,
+                    chunk,
+                    source_text,
+                    record_schema=record_schema,
+                )
+
+            def stitch(
+                candidates: list[ChunkCandidate[dict[str, Any]]],
+            ) -> tuple[list[dict[str, Any]], int]:
+                # stitch_custom_candidates returns the merged list only.
+                return stitch_custom_candidates(
+                    candidates,
+                    record_type=record_schema.record_type,
+                ), 0
+
+            records, diagnostics = await extract_entities_over_chunks(
+                envelope=envelope,
+                flattened=flattened,
+                params=params,
+                ctx=ctx,
+                start_time=start_time,
+                system_message=system_message,
+                log_label="CustomExtract",
+                build_prompt=build_prompt,
+                parse_chunk_response=parse_chunk,
+                stitch=stitch,
+                resolved_model=resolved_model,
+            )
+            output_data: dict[str, Any] = dict(flattened)
+            output_data["text"] = envelope.text
+            output_data["custom_records"] = self._merge_custom_records(
+                flattened=flattened,
+                record_schema=record_schema,
+                records=records,
+                dropped_ungrounded=0,
+            )
+            output_data["extraction_diagnostics"] = diagnostics
+            return CustomExtractOutput(**strip_transient_chunk_keys(output_data))
+
         instructions = substitute_prompt_placeholders(params.instructions, flattened)
         prompt = compose_custom_extract_prompt(
             record_schema=record_schema,
             instructions=instructions,
             text=text,
         )
-
-        elapsed_time = time.time() - start_time
-        max_safe_runtime = TASK_SOFT_TIME_LIMIT - CELERY_TIMEOUT_BUFFER
-        if elapsed_time > max_safe_runtime:
-            raise TimeoutError(
-                f"Node exceeded safe runtime limit ({max_safe_runtime}s) before LLM call"
-            )
-        remaining_safe_time = max_safe_runtime - elapsed_time
-        effective_timeout = min(params.llmTimeout, remaining_safe_time)
-        if effective_timeout < 60:
-            raise TimeoutError(
-                "Insufficient time remaining "
-                f"({effective_timeout:.1f}s) for Custom Extract LLM call"
-            )
-
-        resolved_model = params.model
-        raw_pid = os.getenv("BACKFIELD_PROJECT_ID")
-        if raw_pid:
-            try:
-                from backfield_ai.model_resolve import resolve_place_extract_litellm_model
-                from backfield_db.session import get_engine
-                from sqlmodel import Session
-
-                with Session(get_engine()) as res_sess:
-                    resolved_model = resolve_place_extract_litellm_model(
-                        res_sess,
-                        int(raw_pid),
-                        params,
-                    )
-            except Exception as exc:
-                logger.warning(
-                    "[CustomExtract] could not resolve catalog AI model; using legacy id: %s",
-                    exc,
-                )
-
-        raw_mc = getattr(params, "aiModelConfigId", None)
-        model_config_id = str(raw_mc).strip() if raw_mc else None
+        effective_timeout = effective_llm_timeout(
+            start_time=start_time,
+            llm_timeout=params.llmTimeout,
+        )
+        preflight_unchunked_prompt(
+            litellm_model=resolved_model,
+            system_message=system_message,
+            user_prompt=prompt,
+            project_system_prompt=ctx.project_system_prompt,
+        )
+        model_config_id = model_config_id_from_params(params)
 
         try:
             response_text = await asyncio.wait_for(
@@ -133,10 +244,7 @@ class CustomExtractNode:
                     call_llm,
                     prompt=prompt,
                     model=resolved_model,
-                    system_message=(
-                        "You are a specialized AI assistant for extracting structured records "
-                        "from news text. Return only valid JSON."
-                    ),
+                    system_message=system_message,
                     force_json=True,
                     temperature=0.0,
                     timeout=effective_timeout,
@@ -169,19 +277,12 @@ class CustomExtractNode:
             record_schema=record_schema,
         )
 
-        output_data: dict[str, Any] = dict(flattened)
+        output_data = dict(flattened)
         output_data["text"] = text
-
-        # Serial chains of Custom Extract accumulate record types instead of clobbering.
-        upstream_records = flattened.get("custom_records")
-        merged_records: dict[str, Any] = (
-            dict(upstream_records) if isinstance(upstream_records, dict) else {}
+        output_data["custom_records"] = self._merge_custom_records(
+            flattened=flattened,
+            record_schema=record_schema,
+            records=[record.model_dump() for record in result.records],
+            dropped_ungrounded=result.dropped_ungrounded,
         )
-        merged_records[record_schema.record_type] = {
-            "label": record_schema.label,
-            "schema": [spec.model_dump() for spec in record_schema.fields],
-            "records": [record.model_dump() for record in result.records],
-            "dropped_ungrounded": result.dropped_ungrounded,
-        }
-        output_data["custom_records"] = merged_records
-        return CustomExtractOutput(**output_data)
+        return CustomExtractOutput(**strip_transient_chunk_keys(output_data))

--- a/packages/backfield-agate/src/agate_nodes/custom_extract/reconcile.py
+++ b/packages/backfield-agate/src/agate_nodes/custom_extract/reconcile.py
@@ -1,0 +1,78 @@
+"""Ownership filtering and exact-field merge for chunked Custom Extract."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+from agate_nodes.extraction.grounding import ChunkCandidate, union_mention_texts
+
+
+def _fields_fingerprint(fields: dict[str, Any]) -> str:
+    return json.dumps(fields, sort_keys=True, default=str)
+
+
+def _mention_texts(record: dict[str, Any]) -> list[str]:
+    out: list[str] = []
+    for mention in record.get("mentions") or []:
+        if isinstance(mention, dict):
+            text = mention.get("text")
+            if isinstance(text, str) and text.strip():
+                out.append(text.strip())
+    return out
+
+
+def _merge_records(base: dict[str, Any], other: dict[str, Any]) -> dict[str, Any]:
+    merged = dict(base)
+    mention_texts = union_mention_texts(_mention_texts(merged), _mention_texts(other))
+    merged["mentions"] = [{"text": text} for text in mention_texts]
+    left_conf = merged.get("confidence")
+    right_conf = other.get("confidence")
+    if isinstance(left_conf, (int, float)) and isinstance(right_conf, (int, float)):
+        merged["confidence"] = max(float(left_conf), float(right_conf))
+    elif right_conf is not None and left_conf is None:
+        merged["confidence"] = right_conf
+    return merged
+
+
+def stitch_custom_candidates(
+    candidates: list[ChunkCandidate[dict[str, Any]]],
+    *,
+    record_type: str,
+) -> list[dict[str, Any]]:
+    """Exact normalized-field merge for owned custom records; regenerate stable keys."""
+    owned = [c for c in candidates if c.owned and isinstance(c.payload, dict)]
+    clusters: list[dict[str, Any]] = []
+    by_fingerprint: dict[str, int] = {}
+
+    for candidate in sorted(owned, key=lambda c: (c.evidence.start if c.evidence else 0)):
+        record = dict(candidate.payload)
+        fields = record.get("fields")
+        if not isinstance(fields, dict):
+            continue
+        fingerprint = _fields_fingerprint(fields)
+        existing = by_fingerprint.get(fingerprint)
+        if existing is not None:
+            clusters[existing] = _merge_records(clusters[existing], record)
+            continue
+        by_fingerprint[fingerprint] = len(clusters)
+        clusters.append(record)
+
+    used_keys: set[str] = set()
+    finalized: list[dict[str, Any]] = []
+    for record in clusters:
+        fields = record.get("fields") if isinstance(record.get("fields"), dict) else {}
+        digest = hashlib.sha1(
+            f"{record_type}:{_fields_fingerprint(fields)}".encode()
+        ).hexdigest()[:12]
+        key = f"{record_type}_{digest}"
+        suffix = 2
+        while key in used_keys:
+            key = f"{record_type}_{digest}_{suffix}"
+            suffix += 1
+        used_keys.add(key)
+        out = dict(record)
+        out["key"] = key
+        finalized.append(out)
+    return finalized

--- a/packages/backfield-agate/src/agate_nodes/document_chunker/__init__.py
+++ b/packages/backfield-agate/src/agate_nodes/document_chunker/__init__.py
@@ -1,0 +1,1 @@
+"""Document Chunker Agate node."""

--- a/packages/backfield-agate/src/agate_nodes/document_chunker/metadata.json
+++ b/packages/backfield-agate/src/agate_nodes/document_chunker/metadata.json
@@ -1,0 +1,35 @@
+{
+  "type": "DocumentChunker",
+  "name": "DocumentChunker",
+  "label": "Document Chunker",
+  "description": "Optionally split a long document into overlapping pieces so extraction can handle larger content while keeping one story for review.",
+  "category": "other",
+  "icon": "Split",
+  "color": "bg-cyan-500",
+  "requiredUpstreamNodes": [],
+  "dependencyHelperText": "Place this directly after Text Input, JSON Input, or S3 Input. Extraction nodes after it process each piece and combine the results.",
+  "inputs": [
+    {
+      "id": "text",
+      "label": "Text",
+      "type": "string",
+      "required": true
+    }
+  ],
+  "outputs": [
+    {
+      "id": "text",
+      "label": "Text",
+      "type": "string"
+    },
+    {
+      "id": "chunking_summary",
+      "label": "Chunking summary",
+      "type": "object"
+    }
+  ],
+  "defaultParams": {
+    "target_tokens": 4000,
+    "overlap_tokens": 250
+  }
+}

--- a/packages/backfield-agate/src/agate_nodes/document_chunker/node.py
+++ b/packages/backfield-agate/src/agate_nodes/document_chunker/node.py
@@ -1,0 +1,59 @@
+"""DocumentChunker — split long documents into overlapping owned chunks."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agate_utils.text_chunking import (
+    CHUNKING_SUMMARY_KEY,
+    DEFAULT_OVERLAP_TOKENS,
+    DEFAULT_TARGET_TOKENS,
+    TRANSIENT_CHUNK_ENVELOPE_KEY,
+    build_chunking_summary,
+    split_document_text,
+)
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+
+class DocumentChunkerParams(BaseModel):
+    target_tokens: int = Field(default=DEFAULT_TARGET_TOKENS, ge=100, le=32000)
+    overlap_tokens: int = Field(default=DEFAULT_OVERLAP_TOKENS, ge=0, le=8000)
+
+    @field_validator("target_tokens", "overlap_tokens", mode="before")
+    @classmethod
+    def _coerce_int(cls, value: object) -> object:
+        if isinstance(value, str) and value.strip().isdigit():
+            return int(value.strip())
+        return value
+
+    @model_validator(mode="after")
+    def _overlap_lt_target(self) -> DocumentChunkerParams:
+        if self.overlap_tokens >= self.target_tokens:
+            raise ValueError("Overlap must be smaller than the target chunk size.")
+        return self
+
+
+def run_document_chunker(params: dict[str, Any], inputs: dict[str, Any]) -> dict[str, Any]:
+    # Local import avoids agate_runtime package init → NODE_RUNNERS → this module.
+    from agate_runtime.upstream_input import flatten_upstream_inputs
+
+    flattened = flatten_upstream_inputs(inputs if isinstance(inputs, dict) else {})
+    text = flattened.get("text")
+    if not isinstance(text, str) or not text.strip():
+        raise ValueError(
+            "Document Chunker requires non-empty upstream text from Text Input, "
+            "JSON Input, or S3 Input."
+        )
+
+    parsed = DocumentChunkerParams.model_validate(params if isinstance(params, dict) else {})
+    envelope = split_document_text(
+        text,
+        target_tokens=parsed.target_tokens,
+        overlap_tokens=parsed.overlap_tokens,
+    )
+
+    output = dict(flattened)
+    output["text"] = envelope.text
+    output[TRANSIENT_CHUNK_ENVELOPE_KEY] = envelope.model_dump()
+    output[CHUNKING_SUMMARY_KEY] = build_chunking_summary(envelope)
+    return output

--- a/packages/backfield-agate/src/agate_nodes/document_chunker/ui/NodeComponent.tsx
+++ b/packages/backfield-agate/src/agate_nodes/document_chunker/ui/NodeComponent.tsx
@@ -1,0 +1,51 @@
+import { memo } from 'react'
+import { Handle, Position, NodeProps } from 'reactflow'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { getNodeIcon, getNodeBgColor } from '@/lib/nodeUtils'
+
+function DocumentChunkerNode({ data, selected }: NodeProps) {
+  const dependencyHelperText = nodeMetadata?.dependencyHelperText || ''
+  const icon = getNodeIcon('DocumentChunker', 'h-4 w-4')
+  const bgColor = getNodeBgColor('DocumentChunker')
+  const targetTokens =
+    typeof data?.target_tokens === 'number'
+      ? data.target_tokens
+      : typeof data?.target_tokens === 'string' && data.target_tokens.trim()
+        ? data.target_tokens
+        : 4000
+
+  return (
+    <Card className={`w-[280px] ${selected ? 'ring-2 ring-primary' : ''}`}>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-sm font-medium flex items-center gap-2">
+          <div className={`flex items-center justify-center w-6 h-6 rounded-full ${bgColor}`}>
+            {icon}
+          </div>
+          Document Chunker
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <Handle
+          type="target"
+          position={Position.Left}
+          id="text"
+          className="w-3 h-3 bg-gray-700"
+        />
+        <p className="text-xs text-muted-foreground">
+          Splits long documents into pieces of about {targetTokens} tokens.
+        </p>
+        {dependencyHelperText ? (
+          <p className="text-xs text-muted-foreground">{dependencyHelperText}</p>
+        ) : null}
+        <Handle
+          type="source"
+          position={Position.Right}
+          id="text"
+          className="w-3 h-3 bg-gray-700"
+        />
+      </CardContent>
+    </Card>
+  )
+}
+
+export default memo(DocumentChunkerNode)

--- a/packages/backfield-agate/src/agate_nodes/document_chunker/ui/PanelComponent.tsx
+++ b/packages/backfield-agate/src/agate_nodes/document_chunker/ui/PanelComponent.tsx
@@ -1,0 +1,164 @@
+import { NodePanelTabGate } from '@/components/node-panel/NodePanelTabContext'
+import { FieldLabel } from '@/components/node-panel/FieldLabel'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { getNodeOutputById } from '@backfield/ui/nodeOutputs'
+import type { Dispatch, SetStateAction } from 'react'
+import type { Node } from 'reactflow'
+
+interface DocumentChunkerPanelProps {
+  node: { id: string; data?: Record<string, unknown> }
+  editMode?: boolean
+  setNodes?: Dispatch<SetStateAction<Node[]>>
+  currentRun?: { node_outputs?: Record<string, unknown> | null } | null
+}
+
+type ChunkPreview = {
+  index?: number
+  approximate_tokens?: number
+  preview?: string
+}
+
+function asPositiveInt(raw: unknown, fallback: number): number {
+  if (typeof raw === 'number' && Number.isFinite(raw)) return Math.trunc(raw)
+  if (typeof raw === 'string' && raw.trim() !== '' && !Number.isNaN(Number(raw))) {
+    return Math.trunc(Number(raw))
+  }
+  return fallback
+}
+
+export default function DocumentChunkerPanel({
+  node,
+  editMode = false,
+  setNodes,
+  currentRun,
+}: DocumentChunkerPanelProps) {
+  const defaults = (nodeMetadata?.defaultParams || {}) as Record<string, unknown>
+  const data = { ...defaults, ...(node.data || {}) }
+  const targetTokens = asPositiveInt(data.target_tokens, 4000)
+  const overlapTokens = asPositiveInt(data.overlap_tokens, 250)
+
+  const patch = (patchData: Record<string, unknown>) => {
+    if (!editMode || !setNodes) return
+    setNodes((nodes) =>
+      nodes.map((entry) =>
+        entry.id === node.id
+          ? { ...entry, data: { ...(entry.data || {}), ...patchData } }
+          : entry,
+      ),
+    )
+  }
+
+  const nodeOutput = getNodeOutputById(
+    currentRun?.node_outputs as Record<string, unknown> | undefined,
+    node.id,
+  )
+  const summary =
+    nodeOutput && typeof nodeOutput === 'object' && nodeOutput !== null
+      ? ((nodeOutput as Record<string, unknown>).chunking_summary as
+          | Record<string, unknown>
+          | undefined)
+      : undefined
+  const chunkPreviews = Array.isArray(summary?.chunks)
+    ? (summary?.chunks as ChunkPreview[]).slice(0, 12)
+    : []
+
+  return (
+    <>
+      <NodePanelTabGate tab="settings">
+        <div className="space-y-4">
+          <p className="text-sm text-muted-foreground leading-relaxed">
+            Use this when a document is too long for extraction on its own. Backfield keeps one
+            story for review and combines results from each piece.
+          </p>
+          <div className="space-y-2">
+            <FieldLabel htmlFor="chunk-target-tokens" required>
+              Target piece size
+            </FieldLabel>
+            <Input
+              id="chunk-target-tokens"
+              value={String(targetTokens)}
+              disabled={!editMode}
+              onChange={(event) => {
+                const next = event.target.value.replace(/[^\d]/g, '')
+                patch({ target_tokens: next === '' ? '' : Number(next) })
+              }}
+            />
+            <p className="text-xs text-muted-foreground">
+              Approximate tokens per piece. Larger pieces mean fewer model calls.
+            </p>
+          </div>
+          <div className="space-y-2">
+            <FieldLabel htmlFor="chunk-overlap-tokens" required>
+              Overlap
+            </FieldLabel>
+            <Input
+              id="chunk-overlap-tokens"
+              value={String(overlapTokens)}
+              disabled={!editMode}
+              onChange={(event) => {
+                const next = event.target.value.replace(/[^\d]/g, '')
+                patch({ overlap_tokens: next === '' ? '' : Number(next) })
+              }}
+            />
+            <p className="text-xs text-muted-foreground">
+              Shared text between neighboring pieces so names and places near boundaries are not
+              missed. Must be smaller than the target piece size.
+            </p>
+          </div>
+        </div>
+      </NodePanelTabGate>
+
+      <NodePanelTabGate tab="info">
+        {nodeMetadata.dependencyHelperText ? (
+          <p className="text-sm text-muted-foreground leading-relaxed">
+            {nodeMetadata.dependencyHelperText}
+          </p>
+        ) : null}
+      </NodePanelTabGate>
+
+      <NodePanelTabGate tab="outputs">
+        {summary ? (
+          <div className="space-y-3">
+            <div>
+              <Label className="text-xs font-medium text-muted-foreground">Summary</Label>
+              <p className="text-sm mt-1">
+                {String(summary.chunk_count ?? 0)} piece
+                {Number(summary.chunk_count) === 1 ? '' : 's'}
+                {summary.split_required ? '' : ' (document did not need splitting)'}
+              </p>
+              <p className="text-xs text-muted-foreground mt-1">
+                About {String(summary.approximate_document_tokens ?? '—')} tokens in the full
+                document.
+              </p>
+            </div>
+            <div className="space-y-2">
+              <Label className="text-xs font-medium text-muted-foreground">Piece previews</Label>
+              {chunkPreviews.length === 0 ? (
+                <p className="text-sm text-muted-foreground">No piece previews available.</p>
+              ) : (
+                chunkPreviews.map((chunk) => (
+                  <div key={String(chunk.index)} className="rounded bg-muted p-2 space-y-1">
+                    <p className="text-xs font-medium">
+                      Piece {(chunk.index ?? 0) + 1}
+                      {typeof chunk.approximate_tokens === 'number'
+                        ? ` · ~${chunk.approximate_tokens} tokens`
+                        : ''}
+                    </p>
+                    <p className="text-xs text-muted-foreground break-words">
+                      {chunk.preview || '—'}
+                    </p>
+                  </div>
+                ))
+              )}
+            </div>
+          </div>
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            Run the flow to preview how this document was split.
+          </p>
+        )}
+      </NodePanelTabGate>
+    </>
+  )
+}

--- a/packages/backfield-agate/src/agate_nodes/embed_text/composer.py
+++ b/packages/backfield-agate/src/agate_nodes/embed_text/composer.py
@@ -4,12 +4,25 @@ from __future__ import annotations
 
 from typing import Any
 
+from agate_utils.text_chunking import truncate_text_to_tokens
+
 # Top-level string fields included after ``text`` and ``headline`` when non-empty.
 _SUPPORTING_STRING_FIELDS: tuple[str, ...] = ("url", "author", "byline", "publication")
 
+# Conservative body budget for one article-level embedding input.
+DEFAULT_EMBED_BODY_TOKEN_BUDGET = 6000
 
-def compose_article_embed_text(flattened: dict[str, Any]) -> str:
-    """Build one embedding input from upstream article-shaped payload."""
+
+def compose_article_embed_text(
+    flattened: dict[str, Any],
+    *,
+    body_token_budget: int = DEFAULT_EMBED_BODY_TOKEN_BUDGET,
+) -> tuple[str, bool]:
+    """Build one embedding input from upstream article-shaped payload.
+
+    Returns ``(embedded_text, truncated)``. Body text is truncated to
+    ``body_token_budget`` approximate tokens while headline/metadata are kept.
+    """
     text = flattened.get("text")
     if not isinstance(text, str) or not text.strip():
         raise ValueError(
@@ -17,13 +30,15 @@ def compose_article_embed_text(flattened: dict[str, Any]) -> str:
             "Connect a node that provides a text field."
         )
 
+    body, truncated = truncate_text_to_tokens(text.strip(), body_token_budget)
+
     parts: list[str] = []
 
     headline = flattened.get("headline")
     if isinstance(headline, str) and headline.strip():
         parts.append(headline.strip())
 
-    parts.append(text.strip())
+    parts.append(body)
 
     for key in _SUPPORTING_STRING_FIELDS:
         value = flattened.get(key)
@@ -40,4 +55,4 @@ def compose_article_embed_text(flattened: dict[str, Any]) -> str:
                 if isinstance(nested, str) and nested.strip():
                     parts.append(nested.strip())
 
-    return "\n\n".join(parts)
+    return "\n\n".join(parts), truncated

--- a/packages/backfield-agate/src/agate_nodes/embed_text/node.py
+++ b/packages/backfield-agate/src/agate_nodes/embed_text/node.py
@@ -32,12 +32,12 @@ def _resolve_model_config_id(params: dict[str, Any]) -> str:
 
 def run_embed_text(params: dict[str, Any], inputs: dict[str, Any]) -> dict[str, Any]:
     flattened = _flatten_input(inputs if isinstance(inputs, dict) else {})
-    embedded_text = compose_article_embed_text(flattened)
+    embedded_text, truncated = compose_article_embed_text(flattened)
 
     project_id_raw = os.getenv("BACKFIELD_PROJECT_ID", "").strip()
     if not project_id_raw.isdigit():
         raise RuntimeError(
-            "Embed Text requires BACKFIELD_PROJECT_ID (run inside the Agate worker with a project)."
+            "EmbedText requires BACKFIELD_PROJECT_ID (run inside the Agate worker with a project)."
         )
     project_id = int(project_id_raw)
     model_config_id = _resolve_model_config_id(params if isinstance(params, dict) else {})
@@ -65,5 +65,6 @@ def run_embed_text(params: dict[str, Any], inputs: dict[str, Any]) -> dict[str, 
             "embedding_model": batch.provider_model_id,
             "embedding_dimensions": dimensions,
             "embedding_ai_model_config_id": model_config_id,
+            "truncated": truncated,
         }
     }

--- a/packages/backfield-agate/src/agate_nodes/extraction/__init__.py
+++ b/packages/backfield-agate/src/agate_nodes/extraction/__init__.py
@@ -1,0 +1,28 @@
+"""Shared helpers for chunk-aware Agate extraction nodes."""
+
+from agate_nodes.extraction.chunk_runner import CHUNK_CALL_CONCURRENCY, run_chunked_extraction
+from agate_nodes.extraction.grounding import (
+    ChunkCandidate,
+    GroundedSpan,
+    filter_owned_candidates,
+    locate_evidence_span,
+)
+from agate_nodes.extraction.prompt_text import (
+    BODY_ALIAS_KEYS,
+    apply_chunk_text_to_flattened,
+    build_chunk_analysis_text,
+    sanitize_body_aliases_for_prompt,
+)
+
+__all__ = [
+    "BODY_ALIAS_KEYS",
+    "CHUNK_CALL_CONCURRENCY",
+    "ChunkCandidate",
+    "GroundedSpan",
+    "apply_chunk_text_to_flattened",
+    "build_chunk_analysis_text",
+    "filter_owned_candidates",
+    "locate_evidence_span",
+    "run_chunked_extraction",
+    "sanitize_body_aliases_for_prompt",
+]

--- a/packages/backfield-agate/src/agate_nodes/extraction/chunk_runner.py
+++ b/packages/backfield-agate/src/agate_nodes/extraction/chunk_runner.py
@@ -1,0 +1,79 @@
+"""Bounded concurrent chunk extraction with all-or-nothing failure semantics."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections.abc import Awaitable, Callable
+from typing import TypeVar
+
+from agate_utils.text_chunking import DocumentChunk, DocumentChunkEnvelope
+
+logger = logging.getLogger(__name__)
+
+CHUNK_CALL_CONCURRENCY = 3
+
+T = TypeVar("T")
+
+ChunkWorker = Callable[[DocumentChunk, int], Awaitable[T]]
+
+
+async def run_chunked_extraction(
+    envelope: DocumentChunkEnvelope,
+    worker: ChunkWorker[T],
+    *,
+    concurrency: int = CHUNK_CALL_CONCURRENCY,
+    deadline_monotonic: float | None = None,
+) -> list[T]:
+    """Run ``worker`` for every chunk with bounded concurrency.
+
+    Results are returned in chunk-index order. If any chunk fails, the error is
+    raised and no partial result list is returned to the caller.
+    """
+    chunks = list(envelope.chunks)
+    if not chunks:
+        raise ValueError("Document chunk envelope contains no chunks.")
+
+    limit = max(1, int(concurrency))
+    semaphore = asyncio.Semaphore(limit)
+    results: list[T | None] = [None] * len(chunks)
+    errors: list[BaseException] = []
+
+    async def _run_one(chunk: DocumentChunk) -> None:
+        if deadline_monotonic is not None and time.monotonic() >= deadline_monotonic:
+            raise TimeoutError(
+                f"Chunk {chunk.index + 1}/{len(chunks)} missed the node deadline before starting."
+            )
+        async with semaphore:
+            if deadline_monotonic is not None and time.monotonic() >= deadline_monotonic:
+                raise TimeoutError(
+                    f"Chunk {chunk.index + 1}/{len(chunks)} missed the node deadline."
+                )
+            results[chunk.index] = await worker(chunk, len(chunks))
+
+    tasks = [asyncio.create_task(_run_one(chunk)) for chunk in chunks]
+    done = await asyncio.gather(*tasks, return_exceptions=True)
+    for item in done:
+        if isinstance(item, BaseException):
+            errors.append(item)
+
+    if errors:
+        # Prefer the first non-cancellation failure for a clearer node error.
+        primary = next(
+            (err for err in errors if not isinstance(err, asyncio.CancelledError)),
+            errors[0],
+        )
+        logger.warning(
+            "Chunked extraction failed after %s chunk error(s); first=%s",
+            len(errors),
+            type(primary).__name__,
+        )
+        raise primary
+
+    ordered: list[T] = []
+    for index, value in enumerate(results):
+        if value is None:
+            raise RuntimeError(f"Missing result for chunk index {index}.")
+        ordered.append(value)
+    return ordered

--- a/packages/backfield-agate/src/agate_nodes/extraction/chunked_entity_extract.py
+++ b/packages/backfield-agate/src/agate_nodes/extraction/chunked_entity_extract.py
@@ -1,0 +1,202 @@
+"""Generic chunked extraction loop used by person/org/place/custom extract nodes."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from collections.abc import Callable
+from typing import Any
+
+from agate_runtime.context import AgateEnvContext
+from agate_utils.llm import call_llm
+from agate_utils.text_chunking import (
+    TRANSIENT_CHUNK_ENVELOPE_KEY,
+    DocumentChunk,
+    DocumentChunkEnvelope,
+)
+from backfield_ai.prompt_budget import assert_prompt_fits
+
+from agate_nodes.extraction.chunk_runner import run_chunked_extraction
+from agate_nodes.extraction.grounding import (
+    ChunkCandidate,
+    locate_evidence_span,
+    mark_ownership,
+)
+from agate_nodes.extraction.prompt_text import (
+    apply_chunk_text_to_flattened,
+    build_chunk_analysis_text,
+)
+from agate_nodes.extraction.shared_llm import (
+    model_config_id_from_params,
+    node_deadline_monotonic,
+)
+
+logger = logging.getLogger(__name__)
+
+ParseChunkFn = Callable[[Any, DocumentChunk, str], list[ChunkCandidate[dict[str, Any]]]]
+BuildPromptFn = Callable[[dict[str, Any]], str]
+StitchFn = Callable[
+    [list[ChunkCandidate[dict[str, Any]]]],
+    tuple[list[dict[str, Any]], int],
+]
+
+
+async def extract_entities_over_chunks(
+    *,
+    envelope: DocumentChunkEnvelope,
+    flattened: dict[str, Any],
+    params: Any,
+    ctx: AgateEnvContext,
+    start_time: float,
+    system_message: str,
+    log_label: str,
+    build_prompt: BuildPromptFn,
+    parse_chunk_response: ParseChunkFn,
+    stitch: StitchFn,
+    resolved_model: str,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Run bounded concurrent chunk extraction and stitch owned candidates."""
+    model_config_id = model_config_id_from_params(params)
+    deadline = node_deadline_monotonic(start_time)
+    llm_timeout_cap = float(getattr(params, "llmTimeout", 600) or 600)
+
+    async def worker(
+        chunk: DocumentChunk,
+        chunk_count: int,
+    ) -> list[ChunkCandidate[dict[str, Any]]]:
+        remaining = max(60.0, deadline - time.monotonic())
+        timeout = min(llm_timeout_cap, remaining)
+        chunk_text = build_chunk_analysis_text(chunk, envelope.text)
+        prompt_state = apply_chunk_text_to_flattened(flattened, chunk_text=chunk_text)
+        # Keep original full text available only via envelope; prompts use chunk text.
+        prompt = build_prompt(prompt_state)
+        merged_system = system_message
+        if ctx.project_system_prompt:
+            merged_system = f"{system_message}\n\n{ctx.project_system_prompt}"
+        assert_prompt_fits(
+            litellm_model=resolved_model,
+            system_message=merged_system,
+            user_prompt=prompt,
+            chunker_guidance=False,
+        )
+        logger.info(
+            "[%s] chunk LLM call index=%s/%s timeout_s=%.1f prompt_chars=%d",
+            log_label,
+            chunk.index + 1,
+            chunk_count,
+            timeout,
+            len(prompt),
+        )
+        try:
+            response_text = await asyncio.wait_for(
+                asyncio.to_thread(
+                    call_llm,
+                    prompt=prompt,
+                    model=resolved_model,
+                    system_message=system_message,
+                    force_json=True,
+                    temperature=0.0,
+                    timeout=timeout,
+                    openai_api_key=ctx.get_api_key("OPENAI_API_KEY"),
+                    anthropic_api_key=ctx.get_api_key("ANTHROPIC_API_KEY"),
+                    gemini_api_key=ctx.get_api_key("GEMINI_API_KEY"),
+                    openrouter_api_key=ctx.get_api_key("OPENROUTER_API_KEY"),
+                    azure_api_key=ctx.get_api_key("AZURE_API_KEY"),
+                    azure_api_base=ctx.get_api_key("AZURE_API_BASE"),
+                    project_system_prompt=ctx.project_system_prompt,
+                    model_config_id=model_config_id,
+                ),
+                timeout=timeout,
+            )
+        except TimeoutError as exc:
+            raise TimeoutError(
+                f"{log_label} chunk {chunk.index + 1}/{chunk_count} exceeded timeout "
+                f"of {timeout:.0f}s"
+            ) from exc
+
+        try:
+            response_data = json.loads(response_text)
+        except json.JSONDecodeError as exc:
+            preview = (response_text or "")[:800]
+            raise ValueError(
+                f"{log_label} chunk {chunk.index + 1} returned invalid JSON: {exc}. "
+                f"Preview: {preview!r}"
+            ) from exc
+
+        return parse_chunk_response(response_data, chunk, envelope.text)
+
+    per_chunk = await run_chunked_extraction(
+        envelope,
+        worker,
+        deadline_monotonic=deadline,
+    )
+    candidates: list[ChunkCandidate[dict[str, Any]]] = []
+    for group in per_chunk:
+        candidates.extend(group)
+
+    entities, unresolved = stitch(candidates)
+    diagnostics = {
+        "chunk_count": len(envelope.chunks),
+        "candidate_count": len(candidates),
+        "owned_candidate_count": sum(1 for c in candidates if c.owned),
+        "unresolved_abbreviations": unresolved,
+    }
+    return entities, diagnostics
+
+
+def strip_transient_chunk_keys(payload: dict[str, Any]) -> dict[str, Any]:
+    """Remove transient chunk envelope keys from a node output dict."""
+    out = dict(payload)
+    out.pop(TRANSIENT_CHUNK_ENVELOPE_KEY, None)
+    return out
+
+
+def evidence_from_person_or_org(
+    entry: dict[str, Any],
+    *,
+    source_text: str,
+    chunk: DocumentChunk,
+) -> ChunkCandidate[dict[str, Any]]:
+    """Build a grounded candidate using extras.ea, first mention, or name."""
+    extras = entry.get("extras") if isinstance(entry.get("extras"), dict) else {}
+    evidence_text = ""
+    if isinstance(extras, dict):
+        raw_ea = extras.get("ea") or extras.get("evidence_anchor")
+        if isinstance(raw_ea, str):
+            evidence_text = raw_ea.strip()
+    if not evidence_text:
+        mentions = entry.get("mentions") or []
+        if isinstance(mentions, list) and mentions:
+            first = mentions[0]
+            if isinstance(first, dict) and isinstance(first.get("text"), str):
+                evidence_text = first["text"].strip()
+            elif isinstance(first, list) and first:
+                evidence_text = str(first[0]).strip()
+    if not evidence_text:
+        evidence_text = str(entry.get("name") or entry.get("location") or "").strip()
+
+    span = locate_evidence_span(
+        source_text=source_text,
+        chunk=chunk,
+        evidence_text=evidence_text,
+        prefer_owned=True,
+    )
+    # Drop internal extras from public payload copies when present.
+    payload = {k: v for k, v in entry.items() if k != "extras"}
+    if "extras" in entry and isinstance(entry["extras"], dict):
+        cleaned_extras = {
+            k: v
+            for k, v in entry["extras"].items()
+            if k not in {"ea", "evidence_anchor"}
+        }
+        if cleaned_extras:
+            # Keep non-evidence extras by folding known fields already expanded elsewhere.
+            pass
+    candidate = ChunkCandidate(
+        payload=payload,
+        chunk_index=chunk.index,
+        evidence=span,
+    )
+    return mark_ownership(candidate, chunk=chunk)

--- a/packages/backfield-agate/src/agate_nodes/extraction/grounding.py
+++ b/packages/backfield-agate/src/agate_nodes/extraction/grounding.py
@@ -1,0 +1,108 @@
+"""Ground extraction candidates in chunk ownership ranges."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Generic, TypeVar
+
+from agate_utils.text_chunking import DocumentChunk
+
+T = TypeVar("T")
+
+
+@dataclass(frozen=True)
+class GroundedSpan:
+    start: int
+    end: int
+    text: str
+
+
+@dataclass
+class ChunkCandidate(Generic[T]):
+    """Internal candidate produced from one chunk before document-level merge."""
+
+    payload: T
+    chunk_index: int
+    evidence: GroundedSpan | None
+    owned: bool = False
+    mention_spans: list[GroundedSpan] = field(default_factory=list)
+    extras: dict[str, Any] = field(default_factory=dict)
+
+
+def locate_evidence_span(
+    *,
+    source_text: str,
+    chunk: DocumentChunk,
+    evidence_text: str,
+    prefer_owned: bool = True,
+) -> GroundedSpan | None:
+    """Locate ``evidence_text`` inside the chunk context; prefer ownership when possible."""
+    needle = (evidence_text or "").strip()
+    if not needle:
+        return None
+
+    context = source_text[chunk.context_start : chunk.context_end]
+    search_from = 0
+    owned_hit: GroundedSpan | None = None
+    any_hit: GroundedSpan | None = None
+
+    while True:
+        local = context.find(needle, search_from)
+        if local < 0:
+            break
+        global_start = chunk.context_start + local
+        global_end = global_start + len(needle)
+        span = GroundedSpan(
+            start=global_start,
+            end=global_end,
+            text=source_text[global_start:global_end],
+        )
+        if any_hit is None:
+            any_hit = span
+        if chunk.ownership_start <= global_start < chunk.ownership_end:
+            owned_hit = span
+            break
+        search_from = local + 1
+
+    if prefer_owned and owned_hit is not None:
+        return owned_hit
+    return owned_hit or any_hit
+
+
+def filter_owned_candidates(candidates: list[ChunkCandidate[T]]) -> list[ChunkCandidate[T]]:
+    """Keep candidates whose evidence starts inside their chunk ownership range."""
+    owned: list[ChunkCandidate[T]] = []
+    for candidate in candidates:
+        if candidate.evidence is None:
+            continue
+        if candidate.owned:
+            owned.append(candidate)
+    return owned
+
+
+def mark_ownership(
+    candidate: ChunkCandidate[T],
+    *,
+    chunk: DocumentChunk,
+) -> ChunkCandidate[T]:
+    """Set ``owned`` when primary evidence begins inside the ownership range."""
+    if candidate.evidence is None:
+        candidate.owned = False
+        return candidate
+    start = candidate.evidence.start
+    candidate.owned = chunk.ownership_start <= start < chunk.ownership_end
+    return candidate
+
+
+def union_mention_texts(*groups: list[str]) -> list[str]:
+    """Preserve first-seen mention order while dropping exact duplicates."""
+    out: list[str] = []
+    seen: set[str] = set()
+    for group in groups:
+        for text in group:
+            cleaned = text.strip()
+            if not cleaned or cleaned in seen:
+                continue
+            seen.add(cleaned)
+            out.append(cleaned)
+    return out

--- a/packages/backfield-agate/src/agate_nodes/extraction/prompt_text.py
+++ b/packages/backfield-agate/src/agate_nodes/extraction/prompt_text.py
@@ -1,0 +1,83 @@
+"""Prompt helpers for chunk-aware extraction and whole-document truncation guards."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agate_utils.text_chunking import DocumentChunk, truncate_text_to_tokens
+
+# Alternate body fields that can reintroduce the full document into prompts.
+BODY_ALIAS_KEYS: frozenset[str] = frozenset(
+    {
+        "article_text",
+        "articleBody",
+        "article_body",
+        "richTextBody",
+        "rich_text",
+        "body",
+        "content",
+        "story",
+        "full_text",
+        "html",
+    }
+)
+
+
+def sanitize_body_aliases_for_prompt(
+    flattened: dict[str, Any],
+    *,
+    prompt_text: str,
+) -> dict[str, Any]:
+    """Copy flattened state with body aliases replaced by the prompt-facing text."""
+    out = dict(flattened)
+    out["text"] = prompt_text
+    for key in BODY_ALIAS_KEYS:
+        if key in out and isinstance(out[key], str) and out[key].strip():
+            out[key] = prompt_text
+    return out
+
+
+def apply_chunk_text_to_flattened(
+    flattened: dict[str, Any],
+    *,
+    chunk_text: str,
+) -> dict[str, Any]:
+    """Return flattened state where ``text`` and body aliases are the chunk text."""
+    return sanitize_body_aliases_for_prompt(flattened, prompt_text=chunk_text)
+
+
+def build_chunk_analysis_text(chunk: DocumentChunk, source_text: str) -> str:
+    """Format owned text with labeled overlap context for the model."""
+    owned = source_text[chunk.ownership_start : chunk.ownership_end]
+    before = source_text[chunk.context_start : chunk.ownership_start]
+    after = source_text[chunk.ownership_end : chunk.context_end]
+
+    sections: list[str] = []
+    if before.strip():
+        sections.append(
+            "## Preceding context (for disambiguation only; do not extract solely from here)\n\n"
+            + before.rstrip()
+        )
+    sections.append(
+        "## Text to analyze (owned segment — every extracted record must be grounded here)\n\n"
+        + owned
+    )
+    if after.strip():
+        sections.append(
+            "## Following context (for disambiguation only; do not extract solely from here)\n\n"
+            + after.lstrip()
+        )
+    return "\n\n".join(sections)
+
+
+def truncate_flattened_for_prompt(
+    flattened: dict[str, Any],
+    *,
+    max_tokens: int,
+) -> tuple[dict[str, Any], bool]:
+    """Truncate canonical text (and body aliases) for whole-document prompt-only use."""
+    text = flattened.get("text")
+    if not isinstance(text, str):
+        text = ""
+    truncated, was_truncated = truncate_text_to_tokens(text, max_tokens)
+    return sanitize_body_aliases_for_prompt(flattened, prompt_text=truncated), was_truncated

--- a/packages/backfield-agate/src/agate_nodes/extraction/shared_llm.py
+++ b/packages/backfield-agate/src/agate_nodes/extraction/shared_llm.py
@@ -1,0 +1,87 @@
+"""Shared LLM timing, model resolution, and prompt-budget helpers for extract nodes."""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Any
+
+from backfield_ai.prompt_budget import assert_prompt_fits
+
+logger = logging.getLogger(__name__)
+
+TASK_SOFT_TIME_LIMIT = int(os.getenv("TASK_SOFT_TIME_LIMIT", "3600"))
+CELERY_TIMEOUT_BUFFER = 300
+
+
+def node_deadline_monotonic(start_time: float) -> float:
+    return start_time + max(60.0, TASK_SOFT_TIME_LIMIT - CELERY_TIMEOUT_BUFFER)
+
+
+def effective_llm_timeout(*, start_time: float, llm_timeout: int) -> float:
+    max_safe_runtime = TASK_SOFT_TIME_LIMIT - CELERY_TIMEOUT_BUFFER
+    elapsed = time.time() - start_time
+    if elapsed > max_safe_runtime:
+        raise TimeoutError(
+            f"Node exceeded safe runtime limit ({max_safe_runtime}s) before LLM call"
+        )
+    remaining = max_safe_runtime - elapsed
+    timeout = min(float(llm_timeout), remaining)
+    if timeout < 60:
+        raise TimeoutError(
+            f"Insufficient time remaining ({timeout:.1f}s) for LLM call"
+        )
+    return timeout
+
+
+def resolve_extract_litellm_model(params: Any, *, log_label: str) -> str:
+    model = str(getattr(params, "model", "") or "gpt-4o-mini")
+    raw_pid = os.getenv("BACKFIELD_PROJECT_ID")
+    if not raw_pid:
+        return model
+    try:
+        from backfield_ai.model_resolve import resolve_place_extract_litellm_model
+        from backfield_db.session import get_engine
+        from sqlmodel import Session
+
+        with Session(get_engine()) as res_sess:
+            return resolve_place_extract_litellm_model(
+                res_sess,
+                int(raw_pid),
+                params,
+            )
+    except Exception as exc:  # noqa: BLE001 - catalog optional in unit tests
+        logger.warning(
+            "[%s] could not resolve catalog AI model; using legacy id: %s",
+            log_label,
+            exc,
+        )
+        return model
+
+
+def model_config_id_from_params(params: Any) -> str | None:
+    raw_mc = getattr(params, "aiModelConfigId", None)
+    if raw_mc is None:
+        return None
+    value = str(raw_mc).strip()
+    return value or None
+
+
+def preflight_unchunked_prompt(
+    *,
+    litellm_model: str,
+    system_message: str,
+    user_prompt: str,
+    project_system_prompt: str | None,
+) -> None:
+    merged_system = system_message
+    overlay = (project_system_prompt or "").strip()
+    if overlay:
+        merged_system = f"{system_message}\n\n{overlay}"
+    assert_prompt_fits(
+        litellm_model=litellm_model,
+        system_message=merged_system,
+        user_prompt=user_prompt,
+        chunker_guidance=True,
+    )

--- a/packages/backfield-agate/src/agate_nodes/organization_extract/compact_expand.py
+++ b/packages/backfield-agate/src/agate_nodes/organization_extract/compact_expand.py
@@ -72,6 +72,7 @@ nature (column 3):
 extras (optional trailing object; omit when empty):
   b — boundary short name: brand_platform, work_title, place_business, event_competition
   st — array of nature codes for nature_secondary_tags
+  ea — short exact evidence quote from the owned analysis segment
 """
 
 

--- a/packages/backfield-agate/src/agate_nodes/organization_extract/compact_prompt.py
+++ b/packages/backfield-agate/src/agate_nodes/organization_extract/compact_prompt.py
@@ -33,6 +33,8 @@ Rules for compact output:
 - Do NOT emit nature_secondary_tags or organization_boundary in the core array.
 - Put organization_boundary in extras.b only for borderline cousin mentions.
 - Put nature_secondary_tags in extras.st only when non-empty.
+- Put extras.ea with a short exact evidence quote from the owned analysis segment
+  for every row (required when the prompt includes an owned segment).
 - If no organizations qualify, return {"organizations": []}.
 
 """ + ORG_COMPACT_LEGEND

--- a/packages/backfield-agate/src/agate_nodes/organization_extract/node_port.py
+++ b/packages/backfield-agate/src/agate_nodes/organization_extract/node_port.py
@@ -12,8 +12,21 @@ from typing import Any
 from agate_runtime.context import AgateEnvContext
 from agate_runtime.upstream_input import flatten_upstream_inputs
 from agate_utils.llm import call_llm
+from agate_utils.text_chunking import DocumentChunk, envelope_from_payload
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from agate_nodes.extraction.chunked_entity_extract import (
+    evidence_from_person_or_org,
+    extract_entities_over_chunks,
+    strip_transient_chunk_keys,
+)
+from agate_nodes.extraction.grounding import ChunkCandidate
+from agate_nodes.extraction.shared_llm import (
+    effective_llm_timeout,
+    model_config_id_from_params,
+    preflight_unchunked_prompt,
+    resolve_extract_litellm_model,
+)
 from agate_nodes.organization_extract.compact_expand import (
     expand_compact_organization_row,
     is_skippable_compact_row_error,
@@ -25,11 +38,9 @@ from agate_nodes.organization_extract.prompt_template import (
     resolve_organization_extract_prompt,
     substitute_prompt_placeholders,
 )
+from agate_nodes.organization_extract.reconcile import stitch_organization_candidates
 
 logger = logging.getLogger(__name__)
-
-TASK_SOFT_TIME_LIMIT = int(os.getenv("TASK_SOFT_TIME_LIMIT", "3600"))
-CELERY_TIMEOUT_BUFFER = 300
 
 
 class OrganizationExtractInput(BaseModel):
@@ -140,17 +151,11 @@ class OrganizationExtractNode:
             )
         return str(text)
 
-    async def run(
+    def _compose_prompt(
         self,
-        inp: OrganizationExtractInput,
+        flattened_input: dict[str, Any],
         params: OrganizationExtractParams,
-        ctx: AgateEnvContext,
-    ) -> OrganizationExtractOutput:
-        start_time = time.time()
-        input_dict = inp.model_dump()
-        flattened_input = self._flatten_input(input_dict)
-        text = self._resolve_text(input_dict, flattened_input)
-
+    ) -> tuple[str, bool]:
         bundled_prompt = self._load_prompt_template(params.prompt_file)
         prompt_template = resolve_organization_extract_prompt(
             bundled=bundled_prompt,
@@ -166,44 +171,256 @@ class OrganizationExtractNode:
             output_instructions = (
                 "The results should be returned in a JSON that looks like the following."
             )
-        prompt = f"{prompt}\n\n{output_instructions}\n\n{output_format}"
+        return f"{prompt}\n\n{output_instructions}\n\n{output_format}", use_compact
 
-        elapsed_time = time.time() - start_time
-        max_safe_runtime = TASK_SOFT_TIME_LIMIT - CELERY_TIMEOUT_BUFFER
-        if elapsed_time > max_safe_runtime:
-            raise TimeoutError(
-                f"Node exceeded safe runtime limit ({max_safe_runtime}s) before LLM call"
+    def _parse_organizations_payload(
+        self,
+        response_data: Any,
+        *,
+        use_compact: bool,
+    ) -> list[ExtractedOrganization]:
+        organizations_data: list[Any]
+        if isinstance(response_data, list):
+            organizations_data = response_data
+        elif isinstance(response_data, dict) and "organizations" in response_data:
+            raw_organizations = response_data["organizations"]
+            if raw_organizations is None:
+                organizations_data = []
+            elif isinstance(raw_organizations, list):
+                organizations_data = raw_organizations
+            else:
+                raise ValueError("'organizations' must be an array")
+        else:
+            raise ValueError(
+                "Expected a list of organizations or an object with 'organizations' field"
             )
-        remaining_safe_time = max_safe_runtime - elapsed_time
-        effective_timeout = min(params.llmTimeout, remaining_safe_time)
-        if effective_timeout < 60:
-            raise TimeoutError(
-                f"Insufficient time remaining ({effective_timeout:.1f}s) for "
-                "OrganizationExtract LLM call"
-            )
 
-        resolved_model = params.model
-        raw_pid = os.getenv("BACKFIELD_PROJECT_ID")
-        if raw_pid:
-            try:
-                from backfield_ai.model_resolve import resolve_place_extract_litellm_model
-                from backfield_db.session import get_engine
-                from sqlmodel import Session
-
-                with Session(get_engine()) as res_sess:
-                    resolved_model = resolve_place_extract_litellm_model(
-                        res_sess,
-                        int(raw_pid),
-                        params,
+        organizations: list[ExtractedOrganization] = []
+        if not organizations_data:
+            return organizations
+        parse_errors: list[str] = []
+        for raw_entry in organizations_data:
+            entry: dict[str, Any]
+            if use_compact:
+                if isinstance(raw_entry, list) and not raw_entry:
+                    logger.warning(
+                        "[OrganizationExtract] skipping empty compact organization row"
                     )
-            except Exception as exc:
+                    continue
+                if isinstance(raw_entry, list):
+                    try:
+                        entry = expand_compact_organization_row(raw_entry)
+                    except (ValueError, TypeError) as expand_err:
+                        msg = str(expand_err)
+                        if is_skippable_compact_row_error(msg):
+                            logger.warning(
+                                "[OrganizationExtract] skipping placeholder compact "
+                                "organization row: %s",
+                                msg,
+                            )
+                            continue
+                        parse_errors.append(msg)
+                        logger.warning(
+                            "[OrganizationExtract] skipping invalid compact "
+                            "organization row: %s",
+                            msg,
+                        )
+                        continue
+                elif isinstance(raw_entry, dict):
+                    logger.warning(
+                        "[OrganizationExtract] compact mode received object entry; "
+                        "using full dict parse fallback"
+                    )
+                    entry = raw_entry
+                else:
+                    parse_errors.append("organization entry must be an array or object")
+                    continue
+            else:
+                if not isinstance(raw_entry, dict):
+                    parse_errors.append("organization entry must be an object")
+                    continue
+                entry = raw_entry
+            try:
+                organizations.append(organization_from_llm_entry(entry))
+            except (ValueError, TypeError) as entry_err:
+                msg = str(entry_err)
+                if is_skippable_compact_row_error(msg):
+                    logger.warning(
+                        "[OrganizationExtract] skipping placeholder organization entry: %s",
+                        msg,
+                    )
+                    continue
+                parse_errors.append(msg)
                 logger.warning(
-                    "[OrganizationExtract] could not resolve catalog AI model; using legacy id: %s",
-                    exc,
+                    "[OrganizationExtract] skipping invalid LLM organization entry: %s",
+                    msg,
+                )
+        if not organizations and parse_errors:
+            detail = parse_errors[0] if len(parse_errors) == 1 else "; ".join(parse_errors[:5])
+            raise ValueError(
+                "Failed to parse LLM response as organizations data: "
+                f"no valid organizations. {detail}"
+            )
+        if not organizations and organizations_data:
+            logger.info(
+                "[OrganizationExtract] LLM returned no qualifying organizations after "
+                "skipping placeholder rows"
+            )
+        return organizations
+
+    def _parse_chunk_candidates(
+        self,
+        response_data: Any,
+        chunk: DocumentChunk,
+        source_text: str,
+        *,
+        use_compact: bool,
+    ) -> list[ChunkCandidate[dict[str, Any]]]:
+        organizations = self._parse_organizations_payload(
+            response_data, use_compact=use_compact
+        )
+        raw_organizations: list[Any]
+        if isinstance(response_data, list):
+            raw_organizations = response_data
+        elif isinstance(response_data, dict):
+            raw_organizations = response_data.get("organizations") or []
+        else:
+            raw_organizations = []
+
+        candidates: list[ChunkCandidate[dict[str, Any]]] = []
+        for org, raw_entry in zip(organizations, raw_organizations, strict=False):
+            payload = org.model_dump()
+            if (
+                isinstance(raw_entry, list)
+                and len(raw_entry) > 5
+                and isinstance(raw_entry[5], dict)
+            ):
+                payload["extras"] = raw_entry[5]
+            elif isinstance(raw_entry, dict) and isinstance(raw_entry.get("extras"), dict):
+                payload["extras"] = raw_entry["extras"]
+            candidates.append(
+                evidence_from_person_or_org(
+                    payload,
+                    source_text=source_text,
+                    chunk=chunk,
+                )
+            )
+        return candidates
+
+    def _passthrough_output(
+        self,
+        *,
+        text: str,
+        organizations: list[dict[str, Any]],
+        flattened_input: dict[str, Any],
+        input_dict: dict[str, Any],
+        response_data: Any = None,
+        diagnostics: dict[str, Any] | None = None,
+    ) -> OrganizationExtractOutput:
+        output_data: dict[str, Any] = {
+            "text": text,
+            "organizations": organizations,
+        }
+        if diagnostics is not None:
+            output_data["extraction_diagnostics"] = diagnostics
+
+        llm_top_level_fields: dict[str, Any] = {}
+        if isinstance(response_data, dict):
+            for key, value in response_data.items():
+                if key != "organizations":
+                    llm_top_level_fields[key] = value
+
+        for key, value in flattened_input.items():
+            if key == "text":
+                continue
+            if key.startswith("meta_"):
+                output_data[key] = value
+            elif key not in output_data:
+                output_data[key] = value
+
+        for key, value in llm_top_level_fields.items():
+            meta_key = f"meta_{key}"
+            if meta_key not in flattened_input and key not in output_data:
+                output_data[key] = value
+
+        for node_data in input_dict.values():
+            if isinstance(node_data, dict):
+                for key, value in node_data.items():
+                    if key != "text" and key not in output_data:
+                        output_data[key] = value
+        return OrganizationExtractOutput(**strip_transient_chunk_keys(output_data))
+
+    async def run(
+        self,
+        inp: OrganizationExtractInput,
+        params: OrganizationExtractParams,
+        ctx: AgateEnvContext,
+    ) -> OrganizationExtractOutput:
+        start_time = time.time()
+        input_dict = inp.model_dump()
+        flattened_input = self._flatten_input(input_dict)
+        text = self._resolve_text(input_dict, flattened_input)
+        envelope = envelope_from_payload(flattened_input)
+        resolved_model = resolve_extract_litellm_model(
+            params, log_label="OrganizationExtract"
+        )
+        system_message = (
+            "You are a specialized AI assistant for extracting editorially relevant "
+            "organizations from news text. Return only valid JSON."
+        )
+
+        if envelope is not None:
+            use_compact = params.output_mode == "compact"
+
+            def build_prompt(state: dict[str, Any]) -> str:
+                prompt, _ = self._compose_prompt(state, params)
+                return prompt
+
+            def parse_chunk(
+                response_data: Any,
+                chunk: DocumentChunk,
+                source_text: str,
+            ) -> list[ChunkCandidate[dict[str, Any]]]:
+                return self._parse_chunk_candidates(
+                    response_data,
+                    chunk,
+                    source_text,
+                    use_compact=use_compact,
                 )
 
-        raw_mc = getattr(params, "aiModelConfigId", None)
-        model_config_id = str(raw_mc).strip() if raw_mc else None
+            organizations, diagnostics = await extract_entities_over_chunks(
+                envelope=envelope,
+                flattened=flattened_input,
+                params=params,
+                ctx=ctx,
+                start_time=start_time,
+                system_message=system_message,
+                log_label="OrganizationExtract",
+                build_prompt=build_prompt,
+                parse_chunk_response=parse_chunk,
+                stitch=stitch_organization_candidates,
+                resolved_model=resolved_model,
+            )
+            return self._passthrough_output(
+                text=envelope.text,
+                organizations=organizations,
+                flattened_input=flattened_input,
+                input_dict=input_dict,
+                diagnostics=diagnostics,
+            )
+
+        prompt, use_compact = self._compose_prompt(flattened_input, params)
+        effective_timeout = effective_llm_timeout(
+            start_time=start_time,
+            llm_timeout=params.llmTimeout,
+        )
+        preflight_unchunked_prompt(
+            litellm_model=resolved_model,
+            system_message=system_message,
+            user_prompt=prompt,
+            project_system_prompt=ctx.project_system_prompt,
+        )
+        model_config_id = model_config_id_from_params(params)
 
         try:
             response_text = await asyncio.wait_for(
@@ -211,10 +428,7 @@ class OrganizationExtractNode:
                     call_llm,
                     prompt=prompt,
                     model=resolved_model,
-                    system_message=(
-                        "You are a specialized AI assistant for extracting editorially relevant "
-                        "organizations from news text. Return only valid JSON."
-                    ),
+                    system_message=system_message,
                     force_json=True,
                     temperature=0.0,
                     timeout=effective_timeout,
@@ -242,123 +456,16 @@ class OrganizationExtractNode:
                 f"Failed to parse LLM response as organizations data: {e}. Preview: {preview!r}"
             ) from e
 
-        organizations_data: list[Any]
-        if isinstance(response_data, list):
-            organizations_data = response_data
-        elif isinstance(response_data, dict) and "organizations" in response_data:
-            raw_organizations = response_data["organizations"]
-            if raw_organizations is None:
-                organizations_data = []
-            elif isinstance(raw_organizations, list):
-                organizations_data = raw_organizations
-            else:
-                raise ValueError("'organizations' must be an array")
-        else:
-            raise ValueError(
-                "Expected a list of organizations or an object with 'organizations' field"
-            )
-
-        organizations: list[ExtractedOrganization] = []
-        if organizations_data:
-            parse_errors: list[str] = []
-            for raw_entry in organizations_data:
-                if use_compact:
-                    if isinstance(raw_entry, list) and not raw_entry:
-                        logger.warning(
-                            "[OrganizationExtract] skipping empty compact organization row"
-                        )
-                        continue
-                    if isinstance(raw_entry, list):
-                        try:
-                            entry = expand_compact_organization_row(raw_entry)
-                        except (ValueError, TypeError) as expand_err:
-                            msg = str(expand_err)
-                            if is_skippable_compact_row_error(msg):
-                                logger.warning(
-                                    "[OrganizationExtract] skipping placeholder compact "
-                                    "organization row: %s",
-                                    msg,
-                                )
-                                continue
-                            parse_errors.append(msg)
-                            logger.warning(
-                                "[OrganizationExtract] skipping invalid compact "
-                                "organization row: %s",
-                                msg,
-                            )
-                            continue
-                    elif isinstance(raw_entry, dict):
-                        logger.warning(
-                            "[OrganizationExtract] compact mode received object entry; "
-                            "using full dict parse fallback"
-                        )
-                        entry = raw_entry
-                    else:
-                        parse_errors.append("organization entry must be an array or object")
-                        continue
-                else:
-                    if not isinstance(raw_entry, dict):
-                        parse_errors.append("organization entry must be an object")
-                        continue
-                    entry = raw_entry
-                try:
-                    organizations.append(organization_from_llm_entry(entry))
-                except (ValueError, TypeError) as entry_err:
-                    msg = str(entry_err)
-                    if is_skippable_compact_row_error(msg):
-                        logger.warning(
-                            "[OrganizationExtract] skipping placeholder organization entry: %s",
-                            msg,
-                        )
-                        continue
-                    parse_errors.append(msg)
-                    logger.warning(
-                        "[OrganizationExtract] skipping invalid LLM organization entry: %s",
-                        msg,
-                    )
-            if not organizations and parse_errors:
-                detail = parse_errors[0] if len(parse_errors) == 1 else "; ".join(parse_errors[:5])
-                raise ValueError(
-                    "Failed to parse LLM response as organizations data: "
-                    f"no valid organizations. {detail}"
-                )
-            if not organizations and organizations_data:
-                logger.info(
-                    "[OrganizationExtract] LLM returned no qualifying organizations after "
-                    "skipping placeholder rows"
-                )
-
-        output_data: dict[str, Any] = {
-            "text": text,
-            "organizations": [org.model_dump() for org in organizations],
-        }
-
-        llm_top_level_fields: dict[str, Any] = {}
-        if isinstance(response_data, dict):
-            for key, value in response_data.items():
-                if key != "organizations":
-                    llm_top_level_fields[key] = value
-
-        for key, value in flattened_input.items():
-            if key == "text":
-                continue
-            if key.startswith("meta_"):
-                output_data[key] = value
-            elif key not in output_data:
-                output_data[key] = value
-
-        for key, value in llm_top_level_fields.items():
-            meta_key = f"meta_{key}"
-            if meta_key not in flattened_input and key not in output_data:
-                output_data[key] = value
-
-        for node_data in input_dict.values():
-            if isinstance(node_data, dict):
-                for key, value in node_data.items():
-                    if key != "text" and key not in output_data:
-                        output_data[key] = value
-
-        return OrganizationExtractOutput(**output_data)
+        organizations = self._parse_organizations_payload(
+            response_data, use_compact=use_compact
+        )
+        return self._passthrough_output(
+            text=text,
+            organizations=[org.model_dump() for org in organizations],
+            flattened_input=flattened_input,
+            input_dict=input_dict,
+            response_data=response_data,
+        )
 
     def _load_prompt_template(self, prompt_file_path: str) -> str:
         current_dir = os.path.dirname(os.path.abspath(__file__))

--- a/packages/backfield-agate/src/agate_nodes/organization_extract/reconcile.py
+++ b/packages/backfield-agate/src/agate_nodes/organization_extract/reconcile.py
@@ -1,0 +1,87 @@
+"""Cross-chunk organization stitching for names and acronyms."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from backfield_entities.entities.organization.types import (
+    normalize_organization_text,
+    organization_looks_like_acronym,
+    organization_match_key,
+    organization_names_match_via_acronym,
+)
+
+from agate_nodes.extraction.grounding import ChunkCandidate, union_mention_texts
+
+
+def _mention_texts(org: dict[str, Any]) -> list[str]:
+    out: list[str] = []
+    for mention in org.get("mentions") or []:
+        if isinstance(mention, dict):
+            text = mention.get("text")
+            if isinstance(text, str) and text.strip():
+                out.append(text.strip())
+    return out
+
+
+def _prefer_expanded_name(left: str, right: str) -> str:
+    left_n = normalize_organization_text(left)
+    right_n = normalize_organization_text(right)
+    if organization_looks_like_acronym(left_n) and not organization_looks_like_acronym(right_n):
+        return right
+    if organization_looks_like_acronym(right_n) and not organization_looks_like_acronym(left_n):
+        return left
+    return left if len(left_n) >= len(right_n) else right
+
+
+def _merge_org_dicts(base: dict[str, Any], other: dict[str, Any]) -> dict[str, Any]:
+    merged = dict(base)
+    merged["name"] = _prefer_expanded_name(
+        str(merged.get("name") or ""),
+        str(other.get("name") or ""),
+    )
+    for key in ("type", "role_in_story", "nature", "organization_boundary"):
+        if not merged.get(key) and other.get(key):
+            merged[key] = other[key]
+    mentions = []
+    for text in union_mention_texts(_mention_texts(merged), _mention_texts(other)):
+        mentions.append({"text": text, "quote": False})
+    merged["mentions"] = mentions
+    return merged
+
+
+def _compatible(cluster: dict[str, Any], candidate: dict[str, Any]) -> bool:
+    left = str(cluster.get("name") or "")
+    right = str(candidate.get("name") or "")
+    if not left or not right:
+        return False
+    if organization_match_key(left) == organization_match_key(right):
+        return True
+    return organization_names_match_via_acronym(left, right)
+
+
+def stitch_organization_candidates(
+    candidates: list[ChunkCandidate[dict[str, Any]]],
+) -> tuple[list[dict[str, Any]], int]:
+    owned = [c for c in candidates if c.owned and isinstance(c.payload, dict)]
+    clusters: list[dict[str, Any]] = []
+    unresolved = 0
+
+    for candidate in sorted(owned, key=lambda c: (c.evidence.start if c.evidence else 0)):
+        org = dict(candidate.payload)
+        name = str(org.get("name") or "").strip()
+        if not name:
+            continue
+        matches = [idx for idx, cluster in enumerate(clusters) if _compatible(cluster, org)]
+        if len(matches) == 1:
+            clusters[matches[0]] = _merge_org_dicts(clusters[matches[0]], org)
+            continue
+        if len(matches) > 1 and organization_looks_like_acronym(name):
+            unresolved += 1
+            continue
+        if organization_looks_like_acronym(name) and not matches:
+            unresolved += 1
+            continue
+        clusters.append(org)
+
+    return clusters, unresolved

--- a/packages/backfield-agate/src/agate_nodes/person_extract/compact_expand.py
+++ b/packages/backfield-agate/src/agate_nodes/person_extract/compact_expand.py
@@ -77,6 +77,7 @@ nature (column 6):
 extras (optional trailing object; omit when empty):
   st — array of nature codes for nature_secondary_tags
   si — 1 when surname_inferred_from_relative is true
+  ea — short exact evidence quote from the owned analysis segment
   review — {"handling","reason_code","message"} when review_handling != "none"
 """
 

--- a/packages/backfield-agate/src/agate_nodes/person_extract/compact_prompt.py
+++ b/packages/backfield-agate/src/agate_nodes/person_extract/compact_prompt.py
@@ -37,6 +37,11 @@ Rules for compact output:
 - Put review routing in extras.review only when review_handling is not "none".
 - Put nature_secondary_tags in extras.st only when non-empty.
 - Put surname_inferred_from_relative in extras.si as 1 only when true.
+- Put extras.ea with a short exact evidence quote from the owned analysis segment
+  for every row (required when the prompt includes an owned segment).
+- Keep incomplete named references such as surnames after a fuller introduction
+  ("Mayor Joe Smith" later called "Smith") as separate rows when they appear in
+  the owned segment; do not invent pronouns-only people.
 - If no people qualify, return {"people": []}.
 
 """ + PERSON_COMPACT_LEGEND

--- a/packages/backfield-agate/src/agate_nodes/person_extract/node_port.py
+++ b/packages/backfield-agate/src/agate_nodes/person_extract/node_port.py
@@ -12,8 +12,21 @@ from typing import Any
 from agate_runtime.context import AgateEnvContext
 from agate_runtime.upstream_input import flatten_upstream_inputs
 from agate_utils.llm import call_llm
+from agate_utils.text_chunking import DocumentChunk, envelope_from_payload
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from agate_nodes.extraction.chunked_entity_extract import (
+    evidence_from_person_or_org,
+    extract_entities_over_chunks,
+    strip_transient_chunk_keys,
+)
+from agate_nodes.extraction.grounding import ChunkCandidate
+from agate_nodes.extraction.shared_llm import (
+    effective_llm_timeout,
+    model_config_id_from_params,
+    preflight_unchunked_prompt,
+    resolve_extract_litellm_model,
+)
 from agate_nodes.person_extract.compact_expand import (
     expand_compact_person_row,
     is_skippable_compact_row_error,
@@ -25,6 +38,7 @@ from agate_nodes.person_extract.prompt_template import (
     resolve_person_extract_prompt,
     substitute_prompt_placeholders,
 )
+from agate_nodes.person_extract.reconcile import stitch_people_candidates
 
 logger = logging.getLogger(__name__)
 
@@ -140,17 +154,11 @@ class PersonExtractNode:
             )
         return str(text)
 
-    async def run(
+    def _compose_prompt(
         self,
-        inp: PersonExtractInput,
+        flattened_input: dict[str, Any],
         params: PersonExtractParams,
-        ctx: AgateEnvContext,
-    ) -> PersonExtractOutput:
-        start_time = time.time()
-        input_dict = inp.model_dump()
-        flattened_input = self._flatten_input(input_dict)
-        text = self._resolve_text(input_dict, flattened_input)
-
+    ) -> tuple[str, bool]:
         bundled_prompt = self._load_prompt_template(params.prompt_file)
         prompt_template = resolve_person_extract_prompt(
             bundled=bundled_prompt,
@@ -166,43 +174,211 @@ class PersonExtractNode:
             output_instructions = (
                 "The results should be returned in a JSON that looks like the following."
             )
-        prompt = f"{prompt}\n\n{output_instructions}\n\n{output_format}"
+        return f"{prompt}\n\n{output_instructions}\n\n{output_format}", use_compact
 
-        elapsed_time = time.time() - start_time
-        max_safe_runtime = TASK_SOFT_TIME_LIMIT - CELERY_TIMEOUT_BUFFER
-        if elapsed_time > max_safe_runtime:
-            raise TimeoutError(
-                f"Node exceeded safe runtime limit ({max_safe_runtime}s) before LLM call"
-            )
-        remaining_safe_time = max_safe_runtime - elapsed_time
-        effective_timeout = min(params.llmTimeout, remaining_safe_time)
-        if effective_timeout < 60:
-            raise TimeoutError(
-                f"Insufficient time remaining ({effective_timeout:.1f}s) for PersonExtract LLM call"
-            )
+    def _parse_people_payload(
+        self,
+        response_data: Any,
+        *,
+        use_compact: bool,
+    ) -> list[ExtractedPerson]:
+        people_data: list[Any]
+        if isinstance(response_data, list):
+            people_data = response_data
+        elif isinstance(response_data, dict) and "people" in response_data:
+            raw_people = response_data["people"]
+            if raw_people is None:
+                people_data = []
+            elif isinstance(raw_people, list):
+                people_data = raw_people
+            else:
+                raise ValueError("'people' must be an array")
+        else:
+            raise ValueError("Expected a list of people or an object with 'people' field")
 
-        resolved_model = params.model
-        raw_pid = os.getenv("BACKFIELD_PROJECT_ID")
-        if raw_pid:
+        people: list[ExtractedPerson] = []
+        if not people_data:
+            return people
+        parse_errors: list[str] = []
+        for raw_entry in people_data:
+            entry: dict[str, Any]
+            if use_compact:
+                if isinstance(raw_entry, list) and not raw_entry:
+                    logger.warning("[PersonExtract] skipping empty compact person row")
+                    continue
+                if isinstance(raw_entry, list):
+                    try:
+                        entry = expand_compact_person_row(raw_entry)
+                    except (ValueError, TypeError) as expand_err:
+                        msg = str(expand_err)
+                        if is_skippable_compact_row_error(msg):
+                            logger.warning(
+                                "[PersonExtract] skipping placeholder compact person row: %s",
+                                msg,
+                            )
+                            continue
+                        parse_errors.append(msg)
+                        continue
+                elif isinstance(raw_entry, dict):
+                    entry = raw_entry
+                else:
+                    parse_errors.append("person entry must be an array or object")
+                    continue
+            else:
+                if not isinstance(raw_entry, dict):
+                    parse_errors.append("person entry must be an object")
+                    continue
+                entry = raw_entry
             try:
-                from backfield_ai.model_resolve import resolve_place_extract_litellm_model
-                from backfield_db.session import get_engine
-                from sqlmodel import Session
+                people.append(person_from_llm_entry(entry))
+            except (ValueError, TypeError) as entry_err:
+                msg = str(entry_err)
+                if is_skippable_compact_row_error(msg):
+                    continue
+                parse_errors.append(msg)
+        if not people and parse_errors:
+            detail = parse_errors[0] if len(parse_errors) == 1 else "; ".join(parse_errors[:5])
+            raise ValueError(
+                f"Failed to parse LLM response as people data: no valid people. {detail}"
+            )
+        return people
 
-                with Session(get_engine()) as res_sess:
-                    resolved_model = resolve_place_extract_litellm_model(
-                        res_sess,
-                        int(raw_pid),
-                        params,
-                    )
-            except Exception as exc:
-                logger.warning(
-                    "[PersonExtract] could not resolve catalog AI model; using legacy id: %s",
-                    exc,
+    def _parse_chunk_candidates(
+        self,
+        response_data: Any,
+        chunk: DocumentChunk,
+        source_text: str,
+        *,
+        use_compact: bool,
+    ) -> list[ChunkCandidate[dict[str, Any]]]:
+        people = self._parse_people_payload(response_data, use_compact=use_compact)
+        # Re-parse raw entries for extras.ea before schema stripping.
+        raw_people: list[Any]
+        if isinstance(response_data, list):
+            raw_people = response_data
+        elif isinstance(response_data, dict):
+            raw_people = response_data.get("people") or []
+        else:
+            raw_people = []
+
+        candidates: list[ChunkCandidate[dict[str, Any]]] = []
+        for person, raw_entry in zip(people, raw_people, strict=False):
+            payload = person.model_dump()
+            if (
+                isinstance(raw_entry, list)
+                and len(raw_entry) > 8
+                and isinstance(raw_entry[8], dict)
+            ):
+                payload["extras"] = raw_entry[8]
+            elif isinstance(raw_entry, dict) and isinstance(raw_entry.get("extras"), dict):
+                payload["extras"] = raw_entry["extras"]
+            candidates.append(
+                evidence_from_person_or_org(
+                    payload,
+                    source_text=source_text,
+                    chunk=chunk,
+                )
+            )
+        return candidates
+
+    def _passthrough_output(
+        self,
+        *,
+        text: str,
+        people: list[dict[str, Any]],
+        flattened_input: dict[str, Any],
+        input_dict: dict[str, Any],
+        diagnostics: dict[str, Any] | None = None,
+    ) -> PersonExtractOutput:
+        output_data: dict[str, Any] = {
+            "text": text,
+            "people": people,
+        }
+        if diagnostics is not None:
+            output_data["extraction_diagnostics"] = diagnostics
+        for key, value in flattened_input.items():
+            if key == "text":
+                continue
+            if key.startswith("meta_"):
+                output_data[key] = value
+            elif key not in output_data:
+                output_data[key] = value
+        for node_data in input_dict.values():
+            if isinstance(node_data, dict):
+                for key, value in node_data.items():
+                    if key != "text" and key not in output_data:
+                        output_data[key] = value
+        return PersonExtractOutput(**strip_transient_chunk_keys(output_data))
+
+    async def run(
+        self,
+        inp: PersonExtractInput,
+        params: PersonExtractParams,
+        ctx: AgateEnvContext,
+    ) -> PersonExtractOutput:
+        start_time = time.time()
+        input_dict = inp.model_dump()
+        flattened_input = self._flatten_input(input_dict)
+        text = self._resolve_text(input_dict, flattened_input)
+        envelope = envelope_from_payload(flattened_input)
+        resolved_model = resolve_extract_litellm_model(params, log_label="PersonExtract")
+        system_message = (
+            "You are a specialized AI assistant for extracting editorially relevant "
+            "people from news text. Return only valid JSON."
+        )
+
+        if envelope is not None:
+            use_compact = params.output_mode == "compact"
+
+            def build_prompt(state: dict[str, Any]) -> str:
+                prompt, _ = self._compose_prompt(state, params)
+                return prompt
+
+            def parse_chunk(
+                response_data: Any,
+                chunk: DocumentChunk,
+                source_text: str,
+            ) -> list[ChunkCandidate[dict[str, Any]]]:
+                return self._parse_chunk_candidates(
+                    response_data,
+                    chunk,
+                    source_text,
+                    use_compact=use_compact,
                 )
 
-        raw_mc = getattr(params, "aiModelConfigId", None)
-        model_config_id = str(raw_mc).strip() if raw_mc else None
+            people, diagnostics = await extract_entities_over_chunks(
+                envelope=envelope,
+                flattened=flattened_input,
+                params=params,
+                ctx=ctx,
+                start_time=start_time,
+                system_message=system_message,
+                log_label="PersonExtract",
+                build_prompt=build_prompt,
+                parse_chunk_response=parse_chunk,
+                stitch=stitch_people_candidates,
+                resolved_model=resolved_model,
+            )
+            return self._passthrough_output(
+                text=envelope.text,
+                people=people,
+                flattened_input=flattened_input,
+                input_dict=input_dict,
+                diagnostics=diagnostics,
+            )
+
+        prompt, use_compact = self._compose_prompt(flattened_input, params)
+        effective_timeout = effective_llm_timeout(
+            start_time=start_time,
+            llm_timeout=params.llmTimeout,
+        )
+        preflight_unchunked_prompt(
+            litellm_model=resolved_model,
+            system_message=system_message,
+            user_prompt=prompt,
+            project_system_prompt=ctx.project_system_prompt,
+        )
+        model_config_id = model_config_id_from_params(params)
 
         try:
             response_text = await asyncio.wait_for(
@@ -210,10 +386,7 @@ class PersonExtractNode:
                     call_llm,
                     prompt=prompt,
                     model=resolved_model,
-                    system_message=(
-                        "You are a specialized AI assistant for extracting editorially relevant "
-                        "people from news text. Return only valid JSON."
-                    ),
+                    system_message=system_message,
                     force_json=True,
                     temperature=0.0,
                     timeout=effective_timeout,
@@ -241,113 +414,13 @@ class PersonExtractNode:
                 f"Failed to parse LLM response as people data: {e}. Preview: {preview!r}"
             ) from e
 
-        people_data: list[Any]
-        if isinstance(response_data, list):
-            people_data = response_data
-        elif isinstance(response_data, dict) and "people" in response_data:
-            raw_people = response_data["people"]
-            if raw_people is None:
-                people_data = []
-            elif isinstance(raw_people, list):
-                people_data = raw_people
-            else:
-                raise ValueError("'people' must be an array")
-        else:
-            raise ValueError("Expected a list of people or an object with 'people' field")
-
-        people: list[ExtractedPerson] = []
-        if people_data:
-            parse_errors: list[str] = []
-            for raw_entry in people_data:
-                if use_compact:
-                    if isinstance(raw_entry, list) and not raw_entry:
-                        logger.warning("[PersonExtract] skipping empty compact person row")
-                        continue
-                    if isinstance(raw_entry, list):
-                        try:
-                            entry = expand_compact_person_row(raw_entry)
-                        except (ValueError, TypeError) as expand_err:
-                            msg = str(expand_err)
-                            if is_skippable_compact_row_error(msg):
-                                logger.warning(
-                                    "[PersonExtract] skipping placeholder compact person row: %s",
-                                    msg,
-                                )
-                                continue
-                            parse_errors.append(msg)
-                            logger.warning(
-                                "[PersonExtract] skipping invalid compact person row: %s",
-                                msg,
-                            )
-                            continue
-                    elif isinstance(raw_entry, dict):
-                        logger.warning(
-                            "[PersonExtract] compact mode received object entry; "
-                            "using full dict parse fallback"
-                        )
-                        entry = raw_entry
-                    else:
-                        parse_errors.append("person entry must be an array or object")
-                        continue
-                else:
-                    if not isinstance(raw_entry, dict):
-                        parse_errors.append("person entry must be an object")
-                        continue
-                    entry = raw_entry
-                try:
-                    people.append(person_from_llm_entry(entry))
-                except (ValueError, TypeError) as entry_err:
-                    msg = str(entry_err)
-                    if is_skippable_compact_row_error(msg):
-                        logger.warning(
-                            "[PersonExtract] skipping placeholder person entry: %s",
-                            msg,
-                        )
-                        continue
-                    parse_errors.append(msg)
-                    logger.warning("[PersonExtract] skipping invalid LLM person entry: %s", msg)
-            if not people and parse_errors:
-                detail = parse_errors[0] if len(parse_errors) == 1 else "; ".join(parse_errors[:5])
-                raise ValueError(
-                    f"Failed to parse LLM response as people data: no valid people. {detail}"
-                )
-            if not people and people_data:
-                logger.info(
-                    "[PersonExtract] LLM returned no qualifying people after skipping "
-                    "placeholder rows"
-                )
-
-        output_data: dict[str, Any] = {
-            "text": text,
-            "people": [person.model_dump() for person in people],
-        }
-
-        llm_top_level_fields: dict[str, Any] = {}
-        if isinstance(response_data, dict):
-            for key, value in response_data.items():
-                if key != "people":
-                    llm_top_level_fields[key] = value
-
-        for key, value in flattened_input.items():
-            if key == "text":
-                continue
-            if key.startswith("meta_"):
-                output_data[key] = value
-            elif key not in output_data:
-                output_data[key] = value
-
-        for key, value in llm_top_level_fields.items():
-            meta_key = f"meta_{key}"
-            if meta_key not in flattened_input and key not in output_data:
-                output_data[key] = value
-
-        for node_data in input_dict.values():
-            if isinstance(node_data, dict):
-                for key, value in node_data.items():
-                    if key != "text" and key not in output_data:
-                        output_data[key] = value
-
-        return PersonExtractOutput(**output_data)
+        people = self._parse_people_payload(response_data, use_compact=use_compact)
+        return self._passthrough_output(
+            text=text,
+            people=[person.model_dump() for person in people],
+            flattened_input=flattened_input,
+            input_dict=input_dict,
+        )
 
     def _load_prompt_template(self, prompt_file_path: str) -> str:
         current_dir = os.path.dirname(os.path.abspath(__file__))

--- a/packages/backfield-agate/src/agate_nodes/person_extract/reconcile.py
+++ b/packages/backfield-agate/src/agate_nodes/person_extract/reconcile.py
@@ -1,0 +1,122 @@
+"""Cross-chunk person stitching for named and abbreviated references."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from backfield_entities.entities.person.name_match import score_person_name_overlap
+from backfield_entities.entities.person.name_mismatch import (
+    person_family_names_conflict,
+    person_given_names_conflict,
+)
+from backfield_entities.entities.person.types import normalize_person_text, person_match_key
+
+from agate_nodes.extraction.grounding import ChunkCandidate, union_mention_texts
+
+
+def _name_tokens(name: str) -> list[str]:
+    return [tok for tok in normalize_person_text(name).split() if tok]
+
+
+def _is_surname_only(name: str) -> bool:
+    tokens = _name_tokens(name)
+    return len(tokens) == 1 and tokens[0].isalpha() and len(tokens[0]) > 1
+
+
+def _is_fuller_than(left: str, right: str) -> bool:
+    return len(_name_tokens(left)) > len(_name_tokens(right))
+
+
+def _mention_texts(person: dict[str, Any]) -> list[str]:
+    out: list[str] = []
+    for mention in person.get("mentions") or []:
+        if isinstance(mention, dict):
+            text = mention.get("text")
+            if isinstance(text, str) and text.strip():
+                out.append(text.strip())
+    return out
+
+
+def _merge_person_dicts(base: dict[str, Any], other: dict[str, Any]) -> dict[str, Any]:
+    merged = dict(base)
+    if _is_fuller_than(str(other.get("name") or ""), str(merged.get("name") or "")):
+        merged["name"] = other["name"]
+    for key in ("title", "affiliation", "type", "role_in_story", "nature"):
+        if not merged.get(key) and other.get(key):
+            merged[key] = other[key]
+    if other.get("public_figure"):
+        merged["public_figure"] = True
+    mentions = []
+    for text in union_mention_texts(_mention_texts(merged), _mention_texts(other)):
+        mentions.append({"text": text, "quote": False})
+    merged["mentions"] = mentions
+    return merged
+
+
+def _compatible_cluster(cluster: dict[str, Any], candidate: dict[str, Any]) -> bool:
+    left = str(cluster.get("name") or "")
+    right = str(candidate.get("name") or "")
+    if not left or not right:
+        return False
+    if person_given_names_conflict(left, right) or person_family_names_conflict(left, right):
+        return False
+    if person_match_key(left) == person_match_key(right):
+        return True
+    if score_person_name_overlap(left, right) >= 85:
+        return True
+    # Surname-only abbreviation against a fuller name with the same family token.
+    if _is_surname_only(right) and not _is_surname_only(left):
+        family = _name_tokens(left)[-1]
+        return family == _name_tokens(right)[0]
+    if _is_surname_only(left) and not _is_surname_only(right):
+        family = _name_tokens(right)[-1]
+        return family == _name_tokens(left)[0]
+    return False
+
+
+def stitch_people_candidates(
+    candidates: list[ChunkCandidate[dict[str, Any]]],
+) -> tuple[list[dict[str, Any]], int]:
+    """Merge owned person candidates; return people and unresolved abbreviation count."""
+    owned = [c for c in candidates if c.owned and isinstance(c.payload, dict)]
+    clusters: list[dict[str, Any]] = []
+    unresolved = 0
+
+    for candidate in sorted(owned, key=lambda c: (c.evidence.start if c.evidence else 0)):
+        person = dict(candidate.payload)
+        name = str(person.get("name") or "").strip()
+        if not name:
+            continue
+
+        matches = [
+            idx
+            for idx, cluster in enumerate(clusters)
+            if _compatible_cluster(cluster, person)
+        ]
+        if len(matches) == 1:
+            clusters[matches[0]] = _merge_person_dicts(clusters[matches[0]], person)
+            continue
+        if len(matches) > 1:
+            if _is_surname_only(name):
+                unresolved += 1
+                continue
+            clusters.append(person)
+            continue
+
+        # Surname-only with zero or many fuller matches stays unresolved.
+        if _is_surname_only(name):
+            fuller = [
+                idx
+                for idx, cluster in enumerate(clusters)
+                if not _is_surname_only(str(cluster.get("name") or ""))
+                and _name_tokens(str(cluster.get("name") or ""))[-1:] == _name_tokens(name)
+            ]
+            if len(fuller) == 1:
+                clusters[fuller[0]] = _merge_person_dicts(clusters[fuller[0]], person)
+            else:
+                unresolved += 1
+            continue
+
+        clusters.append(person)
+
+    return clusters, unresolved

--- a/packages/backfield-agate/src/agate_nodes/place_extract/compact_expand.py
+++ b/packages/backfield-agate/src/agate_nodes/place_extract/compact_expand.py
@@ -9,7 +9,10 @@ from agate_nodes.place_extract.compact_codes import (
     VALID_ADDRESS_PLACE_KINDS,
     expand_nature,
 )
-from agate_nodes.place_extract.components_build import build_components, normalize_journalistic_block_address
+from agate_nodes.place_extract.components_build import (
+    build_components,
+    normalize_journalistic_block_address,
+)
 from agate_nodes.place_extract.mentions_build import (
     build_mentions,
     build_mentions_for_evidence_anchor,

--- a/packages/backfield-agate/src/agate_nodes/place_extract/mentions_build.py
+++ b/packages/backfield-agate/src/agate_nodes/place_extract/mentions_build.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import re
-from typing import Any
 
 from agate_nodes.place_extract.location_utils import split_location_parts
 

--- a/packages/backfield-agate/src/agate_nodes/place_extract/node_port.py
+++ b/packages/backfield-agate/src/agate_nodes/place_extract/node_port.py
@@ -1,7 +1,5 @@
 """PlaceExtract node for extracting place information from text using LLM.
 
-Description:
-This node uses an LLM to process JSON data according to your custom prompt and returns structured JSON data.
 Use JSON path placeholders in your prompt to extract specific fields:
   {text} - extracts the text field
   {url} - extracts the url field
@@ -11,21 +9,36 @@ Use JSON path placeholders in your prompt to extract specific fields:
   {raw} - passes entire input JSON
 """
 
+from __future__ import annotations
+
 import asyncio
 import json
 import logging
 import os
-import re
 import time
-from typing import List, Dict, Any, Optional, Union
-from pydantic import BaseModel, Field, ConfigDict, field_validator, model_validator
+from typing import Any
 
 from agate_runtime.context import AgateEnvContext
 from agate_runtime.upstream_input import flatten_upstream_inputs
 from agate_utils.llm import call_llm
+from agate_utils.text_chunking import DocumentChunk, envelope_from_payload
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
-from agate_nodes.place_extract.llm_location_parse import place_from_llm_location_entry
-from agate_nodes.place_extract.place_schemas import Place
+from agate_nodes.extraction.chunked_entity_extract import (
+    extract_entities_over_chunks,
+    strip_transient_chunk_keys,
+)
+from agate_nodes.extraction.grounding import (
+    ChunkCandidate,
+    locate_evidence_span,
+    mark_ownership,
+)
+from agate_nodes.extraction.shared_llm import (
+    effective_llm_timeout,
+    model_config_id_from_params,
+    preflight_unchunked_prompt,
+    resolve_extract_litellm_model,
+)
 from agate_nodes.place_extract.article_context import extract_article_context
 from agate_nodes.place_extract.compact_array_parse import (
     is_compact_array_entry,
@@ -33,35 +46,43 @@ from agate_nodes.place_extract.compact_array_parse import (
 )
 from agate_nodes.place_extract.compact_expand import expand_compact_entry
 from agate_nodes.place_extract.compact_prompt import COMPACT_OUTPUT_INSTRUCTIONS
+from agate_nodes.place_extract.llm_location_parse import place_from_llm_location_entry
+from agate_nodes.place_extract.place_schemas import Place
 from agate_nodes.place_extract.prompt_template import (
     resolve_place_extract_prompt,
     substitute_prompt_placeholders,
 )
+from agate_nodes.place_extract.reconcile import stitch_place_candidates
 
 logger = logging.getLogger(__name__)
-
-# Get Celery timeout limits from environment (defaults match worker/tasks.py)
-TASK_SOFT_TIME_LIMIT = int(os.getenv("TASK_SOFT_TIME_LIMIT", "3600"))  # 60 minutes default
 
 
 class PlaceExtractInput(BaseModel):
     """Input schema - expects to find text in namespaced state."""
-    model_config = ConfigDict(extra='allow')
+
+    model_config = ConfigDict(extra="allow")
 
 
 class PlaceExtractParams(BaseModel):
     """Parameters for PlaceExtract node."""
+
     model: str = Field(
         default="gpt-4o-mini",
-        description="LLM model to use (e.g., gpt-4o-mini, gpt-5, claude-haiku-4-5-20251001)"
+        description="LLM model to use (e.g., gpt-4o-mini, gpt-5, claude-haiku-4-5-20251001)",
     )
-    aiModelConfigId: Optional[str] = Field(
+    aiModelConfigId: str | None = Field(
         default=None,
-        description="Optional Backfield AI model config id (overrides model routing when set in worker)",
+        description=(
+            "Optional Backfield AI model config id "
+            "(overrides model routing when set in worker)"
+        ),
     )
     prompt_file: str = Field(
         default="prompts/extract.md",
-        description="Path to the prompt file relative to the node directory. Defaults to prompts/extract.md"
+        description=(
+            "Path to the prompt file relative to the node directory. "
+            "Defaults to prompts/extract.md"
+        ),
     )
     prompt: str = Field(
         default="",
@@ -74,7 +95,7 @@ class PlaceExtractParams(BaseModel):
         default=600,
         ge=60,
         le=1800,
-        description="Timeout in seconds for the LLM call (default: 10 minutes, max: 30 minutes)"
+        description="Timeout in seconds for the LLM call (default: 10 minutes, max: 30 minutes)",
     )
     output_mode: str = Field(
         default="compact",
@@ -93,7 +114,7 @@ class PlaceExtractParams(BaseModel):
         return mode
 
     @model_validator(mode="after")
-    def _coerce_empty_model_string(self) -> "PlaceExtractParams":
+    def _coerce_empty_model_string(self) -> PlaceExtractParams:
         """Saved graphs may persist ``model: \"\"`` which overrides the Field default."""
         if not (self.model or "").strip():
             return self.model_copy(update={"model": "gpt-4o-mini"})
@@ -102,10 +123,11 @@ class PlaceExtractParams(BaseModel):
 
 class PlaceExtractOutput(BaseModel):
     """Output schema - returns extracted places and preserves input state."""
-    model_config = ConfigDict(extra='allow')
-    
+
+    model_config = ConfigDict(extra="allow")
+
     text: str = Field(description="Original input text")
-    locations: List[Place] = Field(description="List of extracted locations")
+    locations: list[Place] = Field(description="List of extracted locations")
 
 
 class PlaceExtractNode:
@@ -119,7 +141,7 @@ class PlaceExtractNode:
     Output = PlaceExtractOutput
     Params = PlaceExtractParams
 
-    def _extract_json_path(self, input_dict: Dict[str, Any], path_spec: str) -> Any:
+    def _extract_json_path(self, input_dict: dict[str, Any], path_spec: str) -> Any:
         """
         Extract value from input_dict using JSON path notation (similar to LLMEnrich).
         Supports:
@@ -130,95 +152,325 @@ class PlaceExtractNode:
         """
         if path_spec == "raw":
             return input_dict
-        
-        # Multi-field spec
-        if ',' in path_spec:
-            fields = [f.strip() for f in path_spec.split(',')]
+
+        if "," in path_spec:
+            fields = [f.strip() for f in path_spec.split(",")]
             base_path = fields[0]
             additional_fields = fields[1:]
-            
-            # Navigate base_path
+
             target = self._extract_json_path(input_dict, base_path)
-            all_fields = [base_path.split('.')[-1]] + additional_fields
-            
-            def pick_fields(obj):
+            all_fields = [base_path.split(".")[-1]] + additional_fields
+
+            def pick_fields(obj: Any) -> Any:
                 if isinstance(obj, dict):
                     return {f: obj.get(f) for f in all_fields if f in obj}
                 return obj
-            
+
             if isinstance(target, list):
                 return [pick_fields(item) for item in target if isinstance(item, dict)]
             return pick_fields(target)
-        
-        # Simple or dotted path
-        parts = path_spec.split('.')
-        current: Union[Dict[str, Any], List[Any], Any] = input_dict
+
+        parts = path_spec.split(".")
+        current: dict[str, Any] | list[Any] | Any = input_dict
         for i, part in enumerate(parts):
             if isinstance(current, dict) and part in current:
                 current = current[part]
             elif isinstance(current, list):
-                # Extract field from each element if list
                 extracted = []
                 for item in current:
                     if isinstance(item, dict) and part in item:
                         extracted.append(item[part])
                 current = extracted
             else:
-                raise ValueError(f"Path '{'.'.join(parts[:i+1])}' not found in input")
+                raise ValueError(f"Path '{'.'.join(parts[: i + 1])}' not found in input")
         return current
-    
+
     def _sanitize_for_prompt(self, value: Any) -> Any:
         """
         Remove geometry data from custom_geographies to avoid huge token costs.
         Preserves essential fields like id, label, type, city, state, etc.
         """
         if isinstance(value, dict):
-            # If this is a custom geography entry, strip geometry fields
             if "geocode" in value and isinstance(value["geocode"], dict):
                 result = value["geocode"].get("result", {})
                 if isinstance(result, dict):
-                    # Remove geometry but keep other fields
-                    sanitized_result = {k: v for k, v in result.items() if k not in ["geometry", "boundaries"]}
+                    sanitized_result = {
+                        k: v for k, v in result.items() if k not in ["geometry", "boundaries"]
+                    }
                     sanitized_geocode = {**value["geocode"], "result": sanitized_result}
                     return {**value, "geocode": sanitized_geocode}
-            # Recursively sanitize nested dicts
             return {k: self._sanitize_for_prompt(v) for k, v in value.items()}
-        elif isinstance(value, list):
+        if isinstance(value, list):
             return [self._sanitize_for_prompt(item) for item in value]
         return value
-    
-    def _extract_for_prompt(self, input_dict: Dict[str, Any], path_spec: str) -> Any:
+
+    def _extract_for_prompt(self, input_dict: dict[str, Any], path_spec: str) -> Any:
         value = self._extract_json_path(input_dict, path_spec)
         return self._sanitize_for_prompt(value)
 
-    def _build_prompt(self, input_dict: Dict[str, Any], prompt_template: str) -> str:
-        """
-        Replace {json_path} placeholders when present in input; leave others literal.
-        """
+    def _build_prompt(self, input_dict: dict[str, Any], prompt_template: str) -> str:
+        """Replace {json_path} placeholders when present in input; leave others literal."""
         return substitute_prompt_placeholders(
             prompt_template,
             input_dict,
             extract_json_path=self._extract_for_prompt,
         )
-    
+
+    def _resolve_text(self, input_dict: dict[str, Any], flattened: dict[str, Any]) -> str:
+        text = flattened.get("text")
+        if not text:
+            for node_data in input_dict.values():
+                if isinstance(node_data, dict) and "text" in node_data:
+                    text = node_data["text"]
+                    break
+        if not text and isinstance(input_dict.get("text"), str):
+            text = input_dict["text"]
+        if not text:
+            node_keys = [
+                list(v.keys()) if isinstance(v, dict) else "not dict"
+                for v in input_dict.values()
+            ]
+            raise ValueError(
+                f"No 'text' field found in input state. "
+                f"Available keys: {list(input_dict.keys())}, "
+                f"Node data keys: {node_keys}"
+            )
+        return str(text)
+
+    def _compose_prompt(
+        self,
+        flattened_input: dict[str, Any],
+        params: PlaceExtractParams,
+    ) -> tuple[str, bool]:
+        bundled_prompt = self._load_prompt_template(params.prompt_file)
+        prompt_template = resolve_place_extract_prompt(
+            bundled=bundled_prompt,
+            custom=params.prompt,
+        )
+        prompt = self._build_prompt(flattened_input, prompt_template)
+        use_compact = params.output_mode == "compact"
+        if use_compact:
+            output_format = self._load_compact_output_format_template()
+            output_instructions = COMPACT_OUTPUT_INSTRUCTIONS
+        else:
+            output_format = self._load_output_format_template()
+            output_instructions = (
+                "The results should be returned in a JSON that looks like the following."
+            )
+        return f"{prompt}\n\n{output_instructions}\n\n{output_format}", use_compact
+
+    def _locations_data_from_response(self, response_data: Any) -> list[Any]:
+        if isinstance(response_data, list):
+            return response_data
+        if isinstance(response_data, dict) and "locations" in response_data:
+            locations_data = response_data["locations"]
+            if locations_data is None:
+                return []
+            if not isinstance(locations_data, list):
+                raise ValueError("Expected a list of locations")
+            return locations_data
+        raise ValueError("Expected a list of locations or an object with 'locations' field")
+
+    def _evidence_text_for_entry(self, entry: dict[str, Any]) -> str:
+        for key in ("evidence_anchor", "original_text"):
+            raw = entry.get(key)
+            if isinstance(raw, str) and raw.strip():
+                return raw.strip()
+        mentions = entry.get("mentions") or []
+        if isinstance(mentions, list) and mentions:
+            first = mentions[0]
+            if isinstance(first, dict) and isinstance(first.get("text"), str):
+                return first["text"].strip()
+        return str(entry.get("location") or "").strip()
+
+    def _parse_locations_payload(
+        self,
+        response_data: Any,
+        *,
+        use_compact: bool,
+        article_text: str,
+    ) -> list[Place]:
+        locations_data = self._locations_data_from_response(response_data)
+        if not isinstance(locations_data, list):
+            raise ValueError("Expected a list of locations")
+
+        parse_errors: list[str] = []
+        article_context = extract_article_context(article_text)
+        expanded_entries: list[dict[str, Any]] = []
+        for raw_entry in locations_data:
+            try:
+                if use_compact:
+                    if isinstance(raw_entry, list):
+                        entry = row_to_entry(raw_entry)
+                    elif isinstance(raw_entry, dict):
+                        entry = raw_entry
+                    else:
+                        parse_errors.append("location entry must be an object or array")
+                        continue
+                    if is_compact_array_entry(entry):
+                        expanded_entries.append(
+                            expand_compact_entry(
+                                article_text,
+                                entry,
+                                context=article_context,
+                            )
+                        )
+                    else:
+                        expanded_entries.append(entry)
+                else:
+                    if not isinstance(raw_entry, dict):
+                        parse_errors.append("location entry must be an object")
+                        continue
+                    expanded_entries.append(raw_entry)
+            except (ValueError, TypeError) as entry_err:
+                msg = str(entry_err)
+                parse_errors.append(msg)
+                logger.warning(
+                    "[PlaceExtract] skipping invalid LLM location entry: %s",
+                    msg,
+                )
+
+        locations: list[Place] = []
+        for entry in expanded_entries:
+            try:
+                locations.append(place_from_llm_location_entry(entry))
+            except (ValueError, TypeError) as entry_err:
+                msg = str(entry_err)
+                parse_errors.append(msg)
+                logger.warning(
+                    "[PlaceExtract] skipping invalid location entry: %s",
+                    msg,
+                )
+
+        if not locations and locations_data:
+            detail = parse_errors[0] if len(parse_errors) == 1 else "; ".join(parse_errors[:5])
+            raise ValueError(
+                f"Failed to parse LLM response as location data: no valid locations. {detail}"
+            )
+        return locations
+
+    def _parse_chunk_candidates(
+        self,
+        response_data: Any,
+        chunk: DocumentChunk,
+        source_text: str,
+        *,
+        use_compact: bool,
+    ) -> list[ChunkCandidate[dict[str, Any]]]:
+        locations_data = self._locations_data_from_response(response_data)
+        article_context = extract_article_context(source_text)
+        candidates: list[ChunkCandidate[dict[str, Any]]] = []
+
+        for raw_entry in locations_data:
+            try:
+                if use_compact:
+                    if isinstance(raw_entry, list):
+                        entry = row_to_entry(raw_entry)
+                    elif isinstance(raw_entry, dict):
+                        entry = dict(raw_entry)
+                    else:
+                        continue
+                else:
+                    if not isinstance(raw_entry, dict):
+                        continue
+                    entry = dict(raw_entry)
+
+                evidence_text = self._evidence_text_for_entry(entry)
+                span = locate_evidence_span(
+                    source_text=source_text,
+                    chunk=chunk,
+                    evidence_text=evidence_text,
+                    prefer_owned=True,
+                )
+                candidate = ChunkCandidate(
+                    payload=entry,
+                    chunk_index=chunk.index,
+                    evidence=span,
+                )
+                mark_ownership(candidate, chunk=chunk)
+
+                if candidate.owned:
+                    if use_compact and is_compact_array_entry(entry):
+                        # Reconstruct mentions against the full document after ownership.
+                        expanded = expand_compact_entry(
+                            source_text,
+                            entry,
+                            context=article_context,
+                        )
+                    else:
+                        expanded = entry
+                    try:
+                        place = place_from_llm_location_entry(expanded)
+                        candidate.payload = place.model_dump()
+                    except (ValueError, TypeError) as entry_err:
+                        logger.warning(
+                            "[PlaceExtract] skipping invalid owned location entry: %s",
+                            entry_err,
+                        )
+                        continue
+                candidates.append(candidate)
+            except (ValueError, TypeError) as entry_err:
+                logger.warning(
+                    "[PlaceExtract] skipping invalid chunk location entry: %s",
+                    entry_err,
+                )
+        return candidates
+
+    def _passthrough_output(
+        self,
+        *,
+        text: str,
+        locations: list[dict[str, Any]],
+        flattened_input: dict[str, Any],
+        input_dict: dict[str, Any],
+        response_data: Any = None,
+        diagnostics: dict[str, Any] | None = None,
+    ) -> PlaceExtractOutput:
+        output_data: dict[str, Any] = {
+            "text": text,
+            "locations": locations,
+        }
+        if diagnostics is not None:
+            output_data["extraction_diagnostics"] = diagnostics
+
+        llm_top_level_fields: dict[str, Any] = {}
+        if isinstance(response_data, dict):
+            for key, value in response_data.items():
+                if key != "locations":
+                    llm_top_level_fields[key] = value
+
+        for key, value in flattened_input.items():
+            if key == "text":
+                continue
+            if key.startswith("meta_"):
+                output_data[key] = value
+            elif key not in output_data:
+                output_data[key] = value
+
+        for key, value in llm_top_level_fields.items():
+            meta_key = f"meta_{key}"
+            if meta_key not in flattened_input and key not in output_data:
+                output_data[key] = value
+
+        for node_data in input_dict.values():
+            if isinstance(node_data, dict):
+                for key, value in node_data.items():
+                    if key != "text" and key not in output_data:
+                        output_data[key] = value
+
+        return PlaceExtractOutput(**strip_transient_chunk_keys(output_data))
+
     async def run(
         self,
         inp: PlaceExtractInput,
         params: PlaceExtractParams,
-        ctx: AgateEnvContext
+        ctx: AgateEnvContext,
     ) -> PlaceExtractOutput:
-        """
-        Execute place extraction - extract text from namespaced state.
-        """
-        # Track start time for timeout calculations
+        """Execute place extraction - extract text from namespaced state."""
         start_time = time.time()
-        CELERY_TIMEOUT_BUFFER = 300  # Stop 5 minutes before Celery timeout to allow cleanup
-        
         input_dict = inp.model_dump()
-
         flattened_input = flatten_upstream_inputs(input_dict)
-        
-        # Debug logging to trace meta fields
+
         try:
             meta_keys = [k for k in flattened_input.keys() if k.startswith("meta_")]
             logger.debug("[PlaceExtract] input keys: %s", list(input_dict.keys()))
@@ -229,107 +481,67 @@ class PlaceExtractNode:
                 logger.debug("[PlaceExtract] no meta_* keys in flattened_input")
         except Exception:
             pass
-        
-        # Prefer text from flattened input
-        text = flattened_input.get("text")
-        
-        # Backward compatibility: try to find text in namespaced dicts if not found
-        if not text:
-            for node_id, node_data in input_dict.items():
-                if isinstance(node_data, dict) and 'text' in node_data:
-                    text = node_data['text']
-                    break
-        
-        # If still not found, accept top-level text field even if not namespaced
-        if not text and "text" in input_dict and isinstance(input_dict["text"], str):
-            text = input_dict["text"]
-        
-        if not text:
-            raise ValueError(
-                f"No 'text' field found in input state. Available keys: {list(input_dict.keys())}, "
-                f"Node data keys: {[list(v.keys()) if isinstance(v, dict) else 'not dict' for v in input_dict.values()]}"
-            )
-        
-        # Prefer live bundled prompt; saved graphs often carry stale prompt snapshots.
-        bundled_prompt = self._load_prompt_template(params.prompt_file)
-        prompt_template = resolve_place_extract_prompt(
-            bundled=bundled_prompt,
-            custom=params.prompt,
-        )
-        
-        # Build prompt using JSON path placeholders
-        prompt = self._build_prompt(flattened_input, prompt_template)
-        
-        # Concrete JSON example appended after placeholders are filled.
-        use_compact = params.output_mode == "compact"
-        if use_compact:
-            output_format = self._load_compact_output_format_template()
-            output_instructions = COMPACT_OUTPUT_INSTRUCTIONS
-        else:
-            output_format = self._load_output_format_template()
-            output_instructions = (
-                "The results should be returned in a JSON that looks like the following."
-            )
-        prompt = (
-            f"{prompt}\n\n"
-            f"{output_instructions}\n\n"
-            f"{output_format}"
+
+        text = self._resolve_text(input_dict, flattened_input)
+        envelope = envelope_from_payload(flattened_input)
+        resolved_model = resolve_extract_litellm_model(params, log_label="PlaceExtract")
+        system_message = (
+            "You are a specialized AI assistant for extracting editorially relevant, "
+            "literal physical place information from news text. Return only valid JSON."
         )
 
-        # Check if we're approaching Celery timeout before making LLM call
-        # Calculate elapsed time since node start
-        elapsed_time = time.time() - start_time
-        
-        # Use a conservative estimate: assume we're already partway through the task
-        # We'll use elapsed_time as a proxy, but be conservative by assuming we need buffer
-        # If we've been running for more than (TASK_SOFT_TIME_LIMIT - CELERY_TIMEOUT_BUFFER), stop
-        max_safe_runtime = TASK_SOFT_TIME_LIMIT - CELERY_TIMEOUT_BUFFER
-        
-        if elapsed_time > max_safe_runtime:
-            raise TimeoutError(
-                f"Node has been running for {elapsed_time:.1f}s, which exceeds safe runtime limit "
-                f"({max_safe_runtime}s). Cannot safely execute PlaceExtract LLM call."
-            )
-        
-        # Calculate effective timeout: use the smaller of user timeout or remaining safe time
-        remaining_safe_time = max_safe_runtime - elapsed_time
-        effective_timeout = min(params.llmTimeout, remaining_safe_time)
-        
-        if effective_timeout < 60:
-            raise TimeoutError(
-                f"Insufficient time remaining ({effective_timeout:.1f}s) for LLM call. "
-                f"Need at least 60 seconds. Elapsed: {elapsed_time:.1f}s"
-            )
-        
-        logger.info(
-            "[PlaceExtract] scheduling LLM call timeout_s=%.1f elapsed_s=%.1f remaining_safe_s=%.1f",
-            effective_timeout,
-            elapsed_time,
-            remaining_safe_time,
-        )
+        if envelope is not None:
+            use_compact = params.output_mode == "compact"
 
-        resolved_model = params.model
-        raw_pid = os.getenv("BACKFIELD_PROJECT_ID")
-        if raw_pid:
-            try:
-                from backfield_ai.model_resolve import resolve_place_extract_litellm_model
-                from backfield_db.session import get_engine
-                from sqlmodel import Session
+            def build_prompt(state: dict[str, Any]) -> str:
+                prompt, _ = self._compose_prompt(state, params)
+                return prompt
 
-                with Session(get_engine()) as res_sess:
-                    resolved_model = resolve_place_extract_litellm_model(
-                        res_sess,
-                        int(raw_pid),
-                        params,
-                    )
-            except Exception as exc:
-                logger.warning(
-                    "[PlaceExtract] could not resolve catalog AI model; using legacy id: %s",
-                    exc,
+            def parse_chunk(
+                response_data: Any,
+                chunk: DocumentChunk,
+                source_text: str,
+            ) -> list[ChunkCandidate[dict[str, Any]]]:
+                return self._parse_chunk_candidates(
+                    response_data,
+                    chunk,
+                    source_text,
+                    use_compact=use_compact,
                 )
 
-        raw_mc = getattr(params, "aiModelConfigId", None)
-        place_model_config_id = str(raw_mc).strip() if raw_mc else None
+            locations, diagnostics = await extract_entities_over_chunks(
+                envelope=envelope,
+                flattened=flattened_input,
+                params=params,
+                ctx=ctx,
+                start_time=start_time,
+                system_message=system_message,
+                log_label="PlaceExtract",
+                build_prompt=build_prompt,
+                parse_chunk_response=parse_chunk,
+                stitch=stitch_place_candidates,
+                resolved_model=resolved_model,
+            )
+            return self._passthrough_output(
+                text=envelope.text,
+                locations=locations,
+                flattened_input=flattened_input,
+                input_dict=input_dict,
+                diagnostics=diagnostics,
+            )
+
+        prompt, use_compact = self._compose_prompt(flattened_input, params)
+        effective_timeout = effective_llm_timeout(
+            start_time=start_time,
+            llm_timeout=params.llmTimeout,
+        )
+        preflight_unchunked_prompt(
+            litellm_model=resolved_model,
+            system_message=system_message,
+            user_prompt=prompt,
+            project_system_prompt=ctx.project_system_prompt,
+        )
+        model_config_id = model_config_id_from_params(params)
 
         logger.info(
             "[PlaceExtract] LLM call starting model=%s prompt_chars=%d timeout_s=%.1f "
@@ -337,26 +549,21 @@ class PlaceExtractNode:
             resolved_model,
             len(prompt),
             effective_timeout,
-            place_model_config_id or "none",
+            model_config_id or "none",
             "yes" if ctx.project_system_prompt else "no",
             params.output_mode,
         )
 
-        # Call the LLM with API keys from context, wrapped in asyncio timeout
-        # Since call_llm is synchronous, we need to run it in a thread pool
         try:
             response_text = await asyncio.wait_for(
                 asyncio.to_thread(
                     call_llm,
                     prompt=prompt,
                     model=resolved_model,
-                    system_message=(
-                        "You are a specialized AI assistant for extracting editorially relevant, "
-                        "literal physical place information from news text. Return only valid JSON."
-                    ),
+                    system_message=system_message,
                     force_json=True,
                     temperature=0.0,
-                    timeout=effective_timeout,  # Pass timeout to call_llm as well
+                    timeout=effective_timeout,
                     openai_api_key=ctx.get_api_key("OPENAI_API_KEY"),
                     anthropic_api_key=ctx.get_api_key("ANTHROPIC_API_KEY"),
                     gemini_api_key=ctx.get_api_key("GEMINI_API_KEY"),
@@ -364,22 +571,20 @@ class PlaceExtractNode:
                     azure_api_key=ctx.get_api_key("AZURE_API_KEY"),
                     azure_api_base=ctx.get_api_key("AZURE_API_BASE"),
                     project_system_prompt=ctx.project_system_prompt,
-                    model_config_id=place_model_config_id,
+                    model_config_id=model_config_id,
                 ),
-                timeout=effective_timeout
+                timeout=effective_timeout,
             )
-        except asyncio.TimeoutError:
+        except TimeoutError as exc:
             elapsed = time.time() - start_time
             raise TimeoutError(
                 f"PlaceExtract LLM call exceeded timeout of {effective_timeout}s "
                 f"(elapsed: {elapsed:.1f}s). The text may be too long or the LLM may be slow."
-            )
-        
+            ) from exc
+
         elapsed = time.time() - start_time
         logger.info("[PlaceExtract] LLM call finished elapsed_s=%.1f", elapsed)
-        
-        # Parse the response
-        response_data = None
+
         try:
             response_data = json.loads(response_text)
         except json.JSONDecodeError as e:
@@ -388,156 +593,38 @@ class PlaceExtractNode:
                 f"Failed to parse LLM response as location data: {e}. Preview: {preview!r}"
             ) from e
 
-        locations: List[Place] = []
         try:
-            # Handle both old format (direct array) and new format (with "locations" wrapper)
-            if isinstance(response_data, list):
-                locations_data = response_data
-            elif isinstance(response_data, dict) and 'locations' in response_data:
-                locations_data = response_data['locations']
-            else:
-                raise ValueError("Expected a list of locations or an object with 'locations' field")
-
-            if not isinstance(locations_data, list):
-                raise ValueError("Expected a list of locations")
-
-            parse_errors: list[str] = []
-            article_context = extract_article_context(text)
-            expanded_entries: list[dict[str, Any]] = []
-            for raw_entry in locations_data:
-                try:
-                    if use_compact:
-                        if isinstance(raw_entry, list):
-                            entry = row_to_entry(raw_entry)
-                        elif isinstance(raw_entry, dict):
-                            entry = raw_entry
-                        else:
-                            parse_errors.append("location entry must be an object or array")
-                            continue
-                        if is_compact_array_entry(entry):
-                            expanded_entries.append(
-                                expand_compact_entry(
-                                    text,
-                                    entry,
-                                    context=article_context,
-                                )
-                            )
-                        else:
-                            expanded_entries.append(entry)
-                    else:
-                        if not isinstance(raw_entry, dict):
-                            parse_errors.append("location entry must be an object")
-                            continue
-                        expanded_entries.append(raw_entry)
-                except (ValueError, TypeError) as entry_err:
-                    msg = str(entry_err)
-                    parse_errors.append(msg)
-                    logger.warning(
-                        "[PlaceExtract] skipping invalid LLM location entry: %s",
-                        msg,
-                    )
-
-            for entry in expanded_entries:
-                try:
-                    locations.append(place_from_llm_location_entry(entry))
-                except (ValueError, TypeError) as entry_err:
-                    msg = str(entry_err)
-                    parse_errors.append(msg)
-                    logger.warning(
-                        "[PlaceExtract] skipping invalid location entry: %s",
-                        msg,
-                    )
-
-            if not locations and locations_data:
-                detail = parse_errors[0] if len(parse_errors) == 1 else "; ".join(parse_errors[:5])
-                raise ValueError(
-                    f"Failed to parse LLM response as location data: no valid locations. {detail}"
-                )
-
+            locations = self._parse_locations_payload(
+                response_data,
+                use_compact=use_compact,
+                article_text=text,
+            )
         except (ValueError, TypeError) as e:
             raise ValueError(f"Failed to parse LLM response as location data: {e}") from e
-        
-        # Create output with extraction results
-        output_data = {
-            "text": text,
-            "locations": [location.model_dump() for location in locations]
-        }
-        
-        # Handle top-level fields from LLM response (if response_data is a dict with fields beyond 'locations')
-        # Store these temporarily to check against meta_* fields
-        llm_top_level_fields = {}
-        if isinstance(response_data, dict):
-            for key, value in response_data.items():
-                if key != "locations":
-                    llm_top_level_fields[key] = value
-                    try:
-                        logger.debug(
-                            "[PlaceExtract] LLM top-level field: %s (type=%s)",
-                            key,
-                            type(value).__name__,
-                        )
-                    except Exception:
-                        pass
-        
-        # Preserve any additional fields from flattened input (like url, headline, meta_* fields, etc. from upstream nodes)
-        # Priority: meta_* fields from flattened_input > LLM top-level fields > other flattened_input fields
-        for key, value in flattened_input.items():
-            if key not in ["text"]:  # Don't override the text field
-                # Always preserve meta_* fields from flattened_input (they take highest priority)
-                if key.startswith("meta_"):
-                    output_data[key] = value
-                    try:
-                        logger.debug(
-                            "[PlaceExtract] preserved meta field: %s (type=%s)",
-                            key,
-                            type(value).__name__,
-                        )
-                    except Exception:
-                        pass
-                elif key not in output_data:
-                    # For non-meta fields, only add if not already present
-                    output_data[key] = value
-        
-        # Add LLM top-level fields only if they don't conflict with meta_* fields
-        for key, value in llm_top_level_fields.items():
-            meta_key = f"meta_{key}"
-            if meta_key not in flattened_input and key not in output_data:
-                output_data[key] = value
-                try:
-                    logger.debug(
-                        "[PlaceExtract] added LLM field: %s (type=%s)",
-                        key,
-                        type(value).__name__,
-                    )
-                except Exception:
-                    pass
-        
-        # Also preserve fields from namespaced input state (like embedding from Embed node)
-        for node_id, node_data in input_dict.items():
-            if isinstance(node_data, dict):
-                for key, value in node_data.items():
-                    if key not in ["text"] and key not in output_data:  # Don't override existing fields
-                        output_data[key] = value
-        
-        return PlaceExtractOutput(**output_data)
-    
+
+        return self._passthrough_output(
+            text=text,
+            locations=[location.model_dump() for location in locations],
+            flattened_input=flattened_input,
+            input_dict=input_dict,
+            response_data=response_data,
+        )
+
     def _load_prompt_template(self, prompt_file_path: str) -> str:
         """Load the prompt template from the prompts directory."""
-        # Get the directory of this file
         current_dir = os.path.dirname(os.path.abspath(__file__))
-        # Resolve path relative to node directory
         if os.path.isabs(prompt_file_path):
             prompt_file = prompt_file_path
         else:
             prompt_file = os.path.join(current_dir, prompt_file_path)
-        
+
         try:
-            with open(prompt_file, 'r', encoding='utf-8') as f:
+            with open(prompt_file, encoding="utf-8") as f:
                 return f.read()
         except FileNotFoundError:
-            raise FileNotFoundError(f"Prompt template not found at {prompt_file}")
+            raise FileNotFoundError(f"Prompt template not found at {prompt_file}") from None
         except Exception as e:
-            raise Exception(f"Failed to load prompt template: {e}")
+            raise Exception(f"Failed to load prompt template: {e}") from e
 
     def _load_output_format_template(self) -> str:
         """Load the canonical JSON output example appended to every PlaceExtract prompt."""

--- a/packages/backfield-agate/src/agate_nodes/place_extract/place_schemas.py
+++ b/packages/backfield-agate/src/agate_nodes/place_extract/place_schemas.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import List, Optional
-
 from pydantic import BaseModel, ConfigDict, Field
 
 
@@ -58,25 +56,25 @@ class SpanEndpoint(BaseModel):
 class SpanInfo(BaseModel):
     """Span information for span types."""
 
-    start: Optional[SpanEndpoint] = Field(default=None, description="Span starting point")
-    end: Optional[SpanEndpoint] = Field(default=None, description="Span ending point")
+    start: SpanEndpoint | None = Field(default=None, description="Span starting point")
+    end: SpanEndpoint | None = Field(default=None, description="Span ending point")
 
 
 class LocationComponents(BaseModel):
     """Components of a location."""
 
-    place: Optional[PlaceInfo] = Field(default=None, description="Place information if applicable")
-    street_road: Optional[StreetRoadInfo] = Field(
+    place: PlaceInfo | None = Field(default=None, description="Place information if applicable")
+    street_road: StreetRoadInfo | None = Field(
         default=None, description="Street/road information if applicable"
     )
-    span: Optional[SpanInfo] = Field(default=None, description="Span information for span types")
-    address: Optional[str] = Field(default="", description="Street address if applicable")
-    neighborhood: Optional[str] = Field(default="", description="Neighborhood name if applicable")
-    city: Optional[str] = Field(default="", description="City name if applicable")
-    county: Optional[str] = Field(default="", description="County name if applicable")
-    postal_code: Optional[str] = Field(default="", description="Postal code if applicable")
-    state: Optional[StateInfo] = Field(default=None, description="State information if applicable")
-    country: Optional[CountryInfo] = Field(default=None, description="Country information if applicable")
+    span: SpanInfo | None = Field(default=None, description="Span information for span types")
+    address: str | None = Field(default="", description="Street address if applicable")
+    neighborhood: str | None = Field(default="", description="Neighborhood name if applicable")
+    city: str | None = Field(default="", description="City name if applicable")
+    county: str | None = Field(default="", description="County name if applicable")
+    postal_code: str | None = Field(default="", description="Postal code if applicable")
+    state: StateInfo | None = Field(default=None, description="State information if applicable")
+    country: CountryInfo | None = Field(default=None, description="Country information if applicable")
 
 
 class LocationInfo(BaseModel):
@@ -97,7 +95,7 @@ class Place(BaseModel):
     """A place extracted from text."""
 
     original_text: str = Field(description="The original text from which this location was extracted")
-    mentions: List[PlaceMention] = Field(
+    mentions: list[PlaceMention] = Field(
         default_factory=list,
         description="Every verbatim story mention of this same real-world place",
     )

--- a/packages/backfield-agate/src/agate_nodes/place_extract/reconcile.py
+++ b/packages/backfield-agate/src/agate_nodes/place_extract/reconcile.py
@@ -1,0 +1,118 @@
+"""Cross-chunk place stitching before GeocodeAgent."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from backfield_entities.text.match_normalize import normalize_match_text
+
+from agate_nodes.extraction.grounding import ChunkCandidate, union_mention_texts
+
+
+def _loc_key(place: dict[str, Any]) -> str:
+    return normalize_match_text(str(place.get("location") or ""))
+
+
+def _type_key(place: dict[str, Any]) -> str:
+    return str(place.get("type") or "").strip().lower()
+
+
+def _mention_texts(place: dict[str, Any]) -> list[str]:
+    out: list[str] = []
+    for mention in place.get("mentions") or []:
+        if isinstance(mention, dict):
+            text = mention.get("text")
+            if isinstance(text, str) and text.strip():
+                out.append(text.strip())
+    original = place.get("original_text")
+    if isinstance(original, str) and original.strip():
+        out.append(original.strip())
+    return out
+
+
+def _jurisdiction_compatible(left: dict[str, Any], right: dict[str, Any]) -> bool:
+    left_c = left.get("components") if isinstance(left.get("components"), dict) else {}
+    right_c = right.get("components") if isinstance(right.get("components"), dict) else {}
+    for key in ("city", "state", "country"):
+        lv = normalize_match_text(str(left_c.get(key) or ""))
+        rv = normalize_match_text(str(right_c.get(key) or ""))
+        if lv and rv and lv != rv:
+            return False
+    return True
+
+
+def _merge_place(base: dict[str, Any], other: dict[str, Any]) -> dict[str, Any]:
+    merged = dict(base)
+    left = _loc_key(merged)
+    right = _loc_key(other)
+    if len(right) > len(left):
+        merged["location"] = other.get("location")
+        if other.get("components"):
+            merged["components"] = other["components"]
+    for key in ("description", "geocode_hints", "nature", "type", "address_place_kind"):
+        if not merged.get(key) and other.get(key):
+            merged[key] = other[key]
+    mention_texts = union_mention_texts(_mention_texts(merged), _mention_texts(other))
+    mentions = [{"text": text} for text in mention_texts]
+    merged["mentions"] = mentions
+    if mentions:
+        merged["original_text"] = mentions[0]["text"]
+    return merged
+
+
+def _short_name_of(full: str, short: str) -> bool:
+    if not full or not short or full == short:
+        return False
+    if short in full:
+        return True
+    # Token containment: every short token appears in full.
+    short_tokens = short.split()
+    full_tokens = set(full.split())
+    return bool(short_tokens) and all(tok in full_tokens for tok in short_tokens)
+
+
+def stitch_place_candidates(
+    candidates: list[ChunkCandidate[dict[str, Any]]],
+) -> tuple[list[dict[str, Any]], int]:
+    owned = [c for c in candidates if c.owned and isinstance(c.payload, dict)]
+    clusters: list[dict[str, Any]] = []
+    unresolved = 0
+
+    for candidate in sorted(owned, key=lambda c: (c.evidence.start if c.evidence else 0)):
+        place = dict(candidate.payload)
+        key = _loc_key(place)
+        if not key:
+            continue
+        exact = [
+            idx
+            for idx, cluster in enumerate(clusters)
+            if _loc_key(cluster) == key
+            and _type_key(cluster) == _type_key(place)
+            and _jurisdiction_compatible(cluster, place)
+        ]
+        if len(exact) == 1:
+            clusters[exact[0]] = _merge_place(clusters[exact[0]], place)
+            continue
+        if exact:
+            clusters.append(place)
+            continue
+
+        shortened = [
+            idx
+            for idx, cluster in enumerate(clusters)
+            if _type_key(cluster) == _type_key(place)
+            and _jurisdiction_compatible(cluster, place)
+            and (
+                _short_name_of(_loc_key(cluster), key)
+                or _short_name_of(key, _loc_key(cluster))
+            )
+        ]
+        if len(shortened) == 1:
+            clusters[shortened[0]] = _merge_place(clusters[shortened[0]], place)
+            continue
+        if len(shortened) > 1:
+            unresolved += 1
+            continue
+        clusters.append(place)
+
+    return clusters, unresolved

--- a/packages/backfield-agate/src/agate_runtime/executor.py
+++ b/packages/backfield-agate/src/agate_runtime/executor.py
@@ -11,6 +11,7 @@ from collections.abc import Callable, Mapping
 from typing import Any
 
 from agate_runtime.context import AgateEnvContext
+from agate_runtime.graph_validation import validate_graph_invariants
 from agate_runtime.node_output_contract import (
     project_gathered_branch_refs,
     project_node_contribution,
@@ -648,6 +649,7 @@ def execute_graph(
     internal React Flow ids. Execution still uses internal ids for wiring; downstream
     runners receive namespaced inputs keyed by id.
     """
+    validate_graph_invariants(spec)
     runners = NODE_RUNNERS if node_runners is None else dict(NODE_RUNNERS) | dict(node_runners)
 
     if _parallel_levels_enabled():

--- a/packages/backfield-agate/src/agate_runtime/graph_validation.py
+++ b/packages/backfield-agate/src/agate_runtime/graph_validation.py
@@ -1,0 +1,90 @@
+"""Graph invariants that go beyond GraphSpec structural validation."""
+
+from __future__ import annotations
+
+from collections import defaultdict, deque
+
+from agate_runtime.types import GraphSpec
+
+INPUT_BOOKEND_TYPES = frozenset({"TextInput", "JSONInput", "S3Input"})
+DOCUMENT_CHUNKER_TYPE = "DocumentChunker"
+
+
+class GraphInvariantError(ValueError):
+    """Raised when a graph violates product placement rules."""
+
+
+def validate_document_chunker_placement(spec: GraphSpec) -> None:
+    """Enforce at most one input-adjacent Document Chunker with no bypass branches."""
+    chunkers = [node for node in spec.nodes if node.type == DOCUMENT_CHUNKER_TYPE]
+    if not chunkers:
+        return
+    if len(chunkers) > 1:
+        raise GraphInvariantError(
+            "A flow can include only one Document Chunker."
+        )
+
+    chunker = chunkers[0]
+    node_ids = {node.id for node in spec.nodes}
+    by_id = {node.id: node for node in spec.nodes}
+
+    incoming = [
+        edge
+        for edge in spec.edges
+        if edge.target == chunker.id and edge.source in node_ids
+    ]
+    if len(incoming) != 1:
+        raise GraphInvariantError(
+            "Document Chunker must connect directly from the content source "
+            "(Text Input, JSON Input, or S3 Input)."
+        )
+
+    source = by_id.get(incoming[0].source)
+    if source is None or source.type not in INPUT_BOOKEND_TYPES:
+        raise GraphInvariantError(
+            "Document Chunker must be placed directly after Text Input, JSON Input, or S3 Input."
+        )
+
+    # Every first-hop child of the input must be the chunker (no bypass branch).
+    input_children = [
+        edge.target
+        for edge in spec.edges
+        if edge.source == source.id and edge.target in node_ids
+    ]
+    if not input_children:
+        raise GraphInvariantError(
+            "Document Chunker must be connected from the content source."
+        )
+    if any(child_id != chunker.id for child_id in input_children):
+        raise GraphInvariantError(
+            "When a Document Chunker is present, every step after the content source "
+            "must go through the Document Chunker."
+        )
+
+
+def validate_graph_invariants(spec: GraphSpec) -> None:
+    """Run all product-level graph invariants."""
+    validate_document_chunker_placement(spec)
+    _assert_acyclic(spec)
+
+
+def _assert_acyclic(spec: GraphSpec) -> None:
+    node_ids = {node.id for node in spec.nodes}
+    in_degree: dict[str, int] = {node.id: 0 for node in spec.nodes}
+    outgoing: dict[str, list[str]] = defaultdict(list)
+    for edge in spec.edges:
+        if edge.source not in node_ids or edge.target not in node_ids:
+            continue
+        in_degree[edge.target] += 1
+        outgoing[edge.source].append(edge.target)
+    queue: deque[str] = deque(nid for nid, degree in in_degree.items() if degree == 0)
+    seen = 0
+    while queue:
+        current = queue.popleft()
+        seen += 1
+        for nxt in outgoing[current]:
+            in_degree[nxt] -= 1
+            if in_degree[nxt] == 0:
+                queue.append(nxt)
+    if seen != len(spec.nodes):
+        raise GraphInvariantError("Flow contains a cycle.")

--- a/packages/backfield-agate/src/agate_runtime/node_output_contract.py
+++ b/packages/backfield-agate/src/agate_runtime/node_output_contract.py
@@ -30,12 +30,13 @@ FULL_OUTPUT_NODE_TYPES: frozenset[str] = INPUT_NODE_TYPES | frozenset({"DBOutput
 # Explicit owned keys for run JSON. When unset, non-passthrough keys are kept.
 NODE_CONTRIBUTION_KEYS: dict[str, frozenset[str]] = {
     "ArticleMetadata": frozenset({"article_metadata"}),
-    "CustomExtract": frozenset({"custom_records"}),
+    "CustomExtract": frozenset({"custom_records", "extraction_diagnostics"}),
+    "DocumentChunker": frozenset({"chunking_summary"}),
     "EmbedImages": frozenset({"image_embeddings"}),
     "EmbedText": frozenset({"article_embedding"}),
-    "PlaceExtract": frozenset({"locations"}),
-    "PersonExtract": frozenset({"people"}),
-    "OrganizationExtract": frozenset({"organizations"}),
+    "PlaceExtract": frozenset({"locations", "extraction_diagnostics"}),
+    "PersonExtract": frozenset({"people", "extraction_diagnostics"}),
+    "OrganizationExtract": frozenset({"organizations", "extraction_diagnostics"}),
     "GeocodeAgent": frozenset({"places"}),
     "Gather": frozenset({"gathered"}),
     "Output": frozenset({"consolidated"}),

--- a/packages/backfield-agate/src/agate_runtime/nodes/__init__.py
+++ b/packages/backfield-agate/src/agate_runtime/nodes/__init__.py
@@ -3,6 +3,7 @@
 from agate_runtime.nodes.article_metadata import run_article_metadata
 from agate_runtime.nodes.custom_extract import run_custom_extract
 from agate_runtime.nodes.db_output import run_db_output
+from agate_runtime.nodes.document_chunker import run_document_chunker
 from agate_runtime.nodes.embed_images import run_embed_images
 from agate_runtime.nodes.embed_text import run_embed_text
 from agate_runtime.nodes.gather import run_gather
@@ -20,6 +21,7 @@ NODE_RUNNERS: dict[str, callable] = {
     "TextInput": run_text_input,
     "JSONInput": run_json_input,
     "S3Input": run_s3_input,
+    "DocumentChunker": run_document_chunker,
     "PlaceExtract": run_place_extract,
     "PersonExtract": run_person_extract,
     "OrganizationExtract": run_organization_extract,

--- a/packages/backfield-agate/src/agate_runtime/nodes/document_chunker.py
+++ b/packages/backfield-agate/src/agate_runtime/nodes/document_chunker.py
@@ -1,0 +1,5 @@
+"""Public DocumentChunker runner export."""
+
+from agate_nodes.document_chunker.node import run_document_chunker
+
+__all__ = ["run_document_chunker"]

--- a/packages/backfield-agate/src/agate_runtime/output_node.py
+++ b/packages/backfield-agate/src/agate_runtime/output_node.py
@@ -6,12 +6,27 @@ import json
 from collections import OrderedDict
 from typing import Any
 
+from agate_utils.text_chunking import TRANSIENT_CHUNK_ENVELOPE_KEY
 from pydantic import BaseModel
 
 from agate_runtime.upstream_input import (
     expand_gathered_payload as _expand_gathered_payload,
+)
+from agate_runtime.upstream_input import (
     merge_upstream_payload as _merge_upstream_payload,
 )
+
+# Keys that must never enter durable consolidated / exported bodies.
+TRANSIENT_OUTPUT_KEYS: frozenset[str] = frozenset(
+    {
+        TRANSIENT_CHUNK_ENVELOPE_KEY,
+    }
+)
+
+
+def strip_transient_output_keys(data: dict[str, Any]) -> dict[str, Any]:
+    """Drop reserved transient execution keys from a consolidated payload."""
+    return {key: value for key, value in data.items() if key not in TRANSIENT_OUTPUT_KEYS}
 
 PREFERRED_KEY_ORDER = [
     "publication",
@@ -144,4 +159,4 @@ class OutputConsolidator:
         if p.exclude or p.include:
             filtered_data = self._apply_filters(filtered_data, p)
         filtered_data = self._reorder_keys(filtered_data)
-        return filtered_data
+        return strip_transient_output_keys(filtered_data)

--- a/packages/backfield-agate/src/agate_runtime/run_trigger.py
+++ b/packages/backfield-agate/src/agate_runtime/run_trigger.py
@@ -11,6 +11,7 @@ from typing import Any
 from backfield_db import AgateGraph, AgateProcessedItem, AgateRun
 from sqlmodel import Session
 
+from agate_runtime.graph_validation import validate_graph_invariants
 from agate_runtime.nodes.json_input import json_input_output_from_dict
 from agate_runtime.run_graph_spec import merge_run_result_payload
 from agate_runtime.s3_batch import graph_spec_json_contains_s3_input, s3_max_files_from_params
@@ -160,6 +161,7 @@ def trigger_agate_run(
 ) -> TriggerRunResult:
     """Create a run, pin the effective graph spec, and enqueue the appropriate worker task."""
     spec = GraphSpec.model_validate_json(graph.spec_json)
+    validate_graph_invariants(spec)
     effective = apply_inputs_to_spec(spec, inputs)
     effective_json = effective.model_dump_json()
     is_s3_batch = graph_spec_json_contains_s3_input(effective_json)

--- a/packages/backfield-agate/src/agate_utils/text_chunking.py
+++ b/packages/backfield-agate/src/agate_utils/text_chunking.py
@@ -1,0 +1,358 @@
+"""Deterministic document chunking with ownership ranges.
+
+Chunks are execution units for LLM extractors. The original document text remains
+canonical; each chunk carries overlapping context plus a non-overlapping ownership
+range used to filter grounded extraction results.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field, model_validator
+
+CHUNKING_STRATEGY_VERSION = "paragraph_sentence_v1"
+TRANSIENT_CHUNK_ENVELOPE_KEY = "__document_chunk_envelope"
+CHUNKING_SUMMARY_KEY = "chunking_summary"
+
+DEFAULT_TARGET_TOKENS = 4000
+DEFAULT_OVERLAP_TOKENS = 250
+MAX_CHUNKS = 50
+ARTICLE_METADATA_PROMPT_TOKENS = 4000
+
+# Approximate tokens ≈ ceil(chars / 4). Model-neutral and stable across providers.
+_CHARS_PER_TOKEN = 4
+
+_SENTENCE_BOUNDARY = re.compile(r"(?<=[.!?])\s+(?=[A-Z\"'(\[])")
+_WHITESPACE_RUN = re.compile(r"\s+")
+
+
+def approximate_token_count(text: str) -> int:
+    """Return a stable approximate token count for budgeting and chunk sizing."""
+    if not text:
+        return 0
+    return max(1, (len(text) + _CHARS_PER_TOKEN - 1) // _CHARS_PER_TOKEN)
+
+
+def chars_for_tokens(tokens: int) -> int:
+    return max(0, int(tokens) * _CHARS_PER_TOKEN)
+
+
+class DocumentChunk(BaseModel):
+    """One chunk with context and exclusive ownership offsets into the source text."""
+
+    index: int = Field(ge=0)
+    text: str
+    context_start: int = Field(ge=0)
+    context_end: int = Field(ge=0)
+    ownership_start: int = Field(ge=0)
+    ownership_end: int = Field(ge=0)
+    approximate_tokens: int = Field(ge=0)
+
+    @model_validator(mode="after")
+    def _validate_ranges(self) -> DocumentChunk:
+        if self.context_end < self.context_start:
+            raise ValueError("context_end must be >= context_start")
+        if self.ownership_end < self.ownership_start:
+            raise ValueError("ownership_end must be >= ownership_start")
+        if not (
+            self.context_start
+            <= self.ownership_start
+            <= self.ownership_end
+            <= self.context_end
+        ):
+            raise ValueError("ownership range must lie within context range")
+        return self
+
+
+class DocumentChunkEnvelope(BaseModel):
+    """Typed envelope carried transiently between Chunker and extract nodes."""
+
+    version: Literal["1"] = "1"
+    strategy: str = CHUNKING_STRATEGY_VERSION
+    text: str
+    target_tokens: int = Field(default=DEFAULT_TARGET_TOKENS, ge=1)
+    overlap_tokens: int = Field(default=DEFAULT_OVERLAP_TOKENS, ge=0)
+    split_required: bool = False
+    chunks: list[DocumentChunk] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def _validate_chunks(self) -> DocumentChunkEnvelope:
+        if self.overlap_tokens >= self.target_tokens:
+            raise ValueError("overlap_tokens must be smaller than target_tokens")
+        if len(self.chunks) > MAX_CHUNKS:
+            raise ValueError(
+                f"Document requires {len(self.chunks)} chunks; maximum allowed is {MAX_CHUNKS}."
+            )
+        for chunk in self.chunks:
+            if chunk.text != self.text[chunk.context_start : chunk.context_end]:
+                raise ValueError(
+                    f"Chunk {chunk.index} text does not match source slice "
+                    f"[{chunk.context_start}:{chunk.context_end}]"
+                )
+        if self.chunks:
+            ownerships = sorted(
+                (c.ownership_start, c.ownership_end, c.index) for c in self.chunks
+            )
+            cursor = 0
+            for start, end, index in ownerships:
+                if start != cursor:
+                    raise ValueError(
+                        f"Ownership gap or overlap before chunk {index} "
+                        f"(expected start {cursor}, got {start})"
+                    )
+                cursor = end
+            if cursor != len(self.text):
+                raise ValueError(
+                    f"Ownership ranges must cover the full document "
+                    f"(covered {cursor}, length {len(self.text)})"
+                )
+        return self
+
+
+class ChunkingSummary(BaseModel):
+    """Bounded public summary safe for run JSON / panel output."""
+
+    strategy: str
+    target_tokens: int
+    overlap_tokens: int
+    split_required: bool
+    chunk_count: int
+    approximate_document_tokens: int
+    chunks: list[dict[str, Any]]
+
+
+def truncate_text_to_tokens(text: str, max_tokens: int) -> tuple[str, bool]:
+    """Truncate ``text`` to roughly ``max_tokens``, preferring paragraph then sentence."""
+    if max_tokens <= 0:
+        return "", bool(text)
+    if approximate_token_count(text) <= max_tokens:
+        return text, False
+
+    max_chars = chars_for_tokens(max_tokens)
+    if len(text) <= max_chars:
+        return text, False
+
+    window = text[:max_chars]
+    cut = _best_boundary(window)
+    truncated = window[:cut].rstrip()
+    if not truncated:
+        truncated = window.rstrip()
+    return truncated, True
+
+
+def _best_boundary(window: str) -> int:
+    """Prefer last paragraph break, then sentence break, else hard cut."""
+    para = window.rfind("\n\n")
+    if para >= max(1, len(window) // 4):
+        return para
+    sentence_end = 0
+    for match in _SENTENCE_BOUNDARY.finditer(window):
+        sentence_end = match.start() + 1
+    if sentence_end >= max(1, len(window) // 4):
+        return sentence_end
+    return len(window)
+
+
+def split_document_text(
+    text: str,
+    *,
+    target_tokens: int = DEFAULT_TARGET_TOKENS,
+    overlap_tokens: int = DEFAULT_OVERLAP_TOKENS,
+) -> DocumentChunkEnvelope:
+    """Split ``text`` into overlapping chunks with exclusive ownership ranges."""
+    source = text if isinstance(text, str) else ""
+    if not source.strip():
+        raise ValueError("Document Chunker requires non-empty text.")
+
+    if target_tokens < 1:
+        raise ValueError("target_tokens must be at least 1.")
+    if overlap_tokens < 0:
+        raise ValueError("overlap_tokens cannot be negative.")
+    if overlap_tokens >= target_tokens:
+        raise ValueError("overlap_tokens must be smaller than target_tokens.")
+
+    target_chars = chars_for_tokens(target_tokens)
+    overlap_chars = chars_for_tokens(overlap_tokens)
+
+    if len(source) <= target_chars:
+        chunk = DocumentChunk(
+            index=0,
+            text=source,
+            context_start=0,
+            context_end=len(source),
+            ownership_start=0,
+            ownership_end=len(source),
+            approximate_tokens=approximate_token_count(source),
+        )
+        return DocumentChunkEnvelope(
+            text=source,
+            target_tokens=target_tokens,
+            overlap_tokens=overlap_tokens,
+            split_required=False,
+            chunks=[chunk],
+        )
+
+    ownership_starts = _plan_ownership_starts(source, target_chars)
+    if len(ownership_starts) > MAX_CHUNKS:
+        raise ValueError(
+            f"This document would create {len(ownership_starts)} chunks "
+            f"(maximum {MAX_CHUNKS}). Shorten the document or raise the chunk size."
+        )
+
+    chunks: list[DocumentChunk] = []
+    for index, own_start in enumerate(ownership_starts):
+        own_end = (
+            ownership_starts[index + 1] if index + 1 < len(ownership_starts) else len(source)
+        )
+        context_start = max(0, own_start - overlap_chars) if index > 0 else 0
+        context_end = (
+            min(len(source), own_end + overlap_chars)
+            if index + 1 < len(ownership_starts)
+            else len(source)
+        )
+        # Align context to nearby whitespace when possible without leaving ownership.
+        context_start = _snap_context_start(source, context_start, own_start)
+        context_end = _snap_context_end(source, context_end, own_end)
+        chunk_text = source[context_start:context_end]
+        chunks.append(
+            DocumentChunk(
+                index=index,
+                text=chunk_text,
+                context_start=context_start,
+                context_end=context_end,
+                ownership_start=own_start,
+                ownership_end=own_end,
+                approximate_tokens=approximate_token_count(chunk_text),
+            )
+        )
+
+    return DocumentChunkEnvelope(
+        text=source,
+        target_tokens=target_tokens,
+        overlap_tokens=overlap_tokens,
+        split_required=True,
+        chunks=chunks,
+    )
+
+
+def _plan_ownership_starts(source: str, target_chars: int) -> list[int]:
+    starts = [0]
+    cursor = 0
+    length = len(source)
+    while cursor < length:
+        tentative_end = min(length, cursor + target_chars)
+        if tentative_end >= length:
+            break
+        window = source[cursor:tentative_end]
+        relative_cut = _best_boundary(window)
+        own_end = cursor + relative_cut
+        if own_end <= cursor:
+            own_end = tentative_end
+        # Skip leading whitespace for the next ownership start when possible.
+        next_start = own_end
+        while next_start < length and source[next_start].isspace():
+            next_start += 1
+        if next_start >= length:
+            break
+        if next_start <= cursor:
+            next_start = min(length, cursor + target_chars)
+        starts.append(next_start)
+        cursor = next_start
+        if len(starts) > MAX_CHUNKS + 1:
+            break
+    return starts
+
+
+def _snap_context_start(source: str, context_start: int, ownership_start: int) -> int:
+    if context_start <= 0 or context_start >= ownership_start:
+        return context_start
+    # Prefer starting after a whitespace run inside the overlap prefix.
+    prefix = source[context_start:ownership_start]
+    match = list(_WHITESPACE_RUN.finditer(prefix))
+    if not match:
+        return context_start
+    last = match[-1]
+    snapped = context_start + last.end()
+    # Keep some overlap context when possible; never snap away the entire overlap.
+    return snapped if snapped < ownership_start else context_start
+
+
+def _snap_context_end(source: str, context_end: int, ownership_end: int) -> int:
+    if context_end >= len(source) or context_end <= ownership_end:
+        return context_end
+    suffix = source[ownership_end:context_end]
+    match = _WHITESPACE_RUN.search(suffix)
+    if not match:
+        return context_end
+    snapped = ownership_end + match.start()
+    return snapped if snapped >= ownership_end else context_end
+
+
+def envelope_from_payload(payload: Any) -> DocumentChunkEnvelope | None:
+    """Parse a transient envelope from flattened upstream state when present."""
+    if isinstance(payload, DocumentChunkEnvelope):
+        return payload
+    if not isinstance(payload, dict):
+        return None
+    raw = payload.get(TRANSIENT_CHUNK_ENVELOPE_KEY)
+    if raw is None:
+        return None
+    if isinstance(raw, DocumentChunkEnvelope):
+        return raw
+    if isinstance(raw, dict):
+        return DocumentChunkEnvelope.model_validate(raw)
+    raise ValueError("Invalid document chunk envelope upstream.")
+
+
+def build_chunking_summary(envelope: DocumentChunkEnvelope) -> dict[str, Any]:
+    """Build a bounded public summary (no full chunk texts)."""
+    previews: list[dict[str, Any]] = []
+    for chunk in envelope.chunks:
+        owned = envelope.text[chunk.ownership_start : chunk.ownership_end]
+        preview = owned[:160].replace("\n", " ").strip()
+        if len(owned) > 160:
+            preview = f"{preview}…"
+        previews.append(
+            {
+                "index": chunk.index,
+                "approximate_tokens": chunk.approximate_tokens,
+                "ownership_start": chunk.ownership_start,
+                "ownership_end": chunk.ownership_end,
+                "preview": preview,
+            }
+        )
+    summary = ChunkingSummary(
+        strategy=envelope.strategy,
+        target_tokens=envelope.target_tokens,
+        overlap_tokens=envelope.overlap_tokens,
+        split_required=envelope.split_required,
+        chunk_count=len(envelope.chunks),
+        approximate_document_tokens=approximate_token_count(envelope.text),
+        chunks=previews,
+    )
+    return summary.model_dump()
+
+
+def single_chunk_envelope(text: str) -> DocumentChunkEnvelope:
+    """Wrap plain text as a one-chunk envelope for unchunked extract paths."""
+    source = text if isinstance(text, str) else ""
+    if not source.strip():
+        raise ValueError("Extraction requires non-empty text.")
+    chunk = DocumentChunk(
+        index=0,
+        text=source,
+        context_start=0,
+        context_end=len(source),
+        ownership_start=0,
+        ownership_end=len(source),
+        approximate_tokens=approximate_token_count(source),
+    )
+    return DocumentChunkEnvelope(
+        text=source,
+        target_tokens=max(DEFAULT_TARGET_TOKENS, approximate_token_count(source)),
+        overlap_tokens=0,
+        split_required=False,
+        chunks=[chunk],
+    )

--- a/packages/backfield-agate/tests/test_executor.py
+++ b/packages/backfield-agate/tests/test_executor.py
@@ -874,3 +874,41 @@ def test_gather_waits_in_sequential_mode(monkeypatch: pytest.MonkeyPatch):
     assert execution_order[-1] == "gather"
     gathered = out["gather"]["gathered"]
     assert gathered == ["text_input", "organization_extract", "place_extract"]
+
+
+def test_document_chunker_projects_summary_and_feeds_extract():
+    long_text = "\n\n".join(
+        f"Section {i} mentions Chicago, IL in the narrative. " + ("word " * 120)
+        for i in range(6)
+    )
+    spec = GraphSpec(
+        name="chunked",
+        nodes=[
+            NodeConfig(id="a", type="TextInput", params={"text": long_text}),
+            NodeConfig(
+                id="c",
+                type="DocumentChunker",
+                params={"target_tokens": 120, "overlap_tokens": 20},
+            ),
+            NodeConfig(id="b", type="PlaceExtract", params={}),
+        ],
+        edges=[
+            Edge(source="a", target="c", sourceHandle="text", targetHandle="text"),
+            Edge(source="c", target="b", sourceHandle="text", targetHandle="text"),
+        ],
+    )
+    with patch(
+        "agate_nodes.place_extract.node_port.call_llm",
+        return_value=_mock_place_extract_json("Chicago", "Illinois", "IL"),
+    ):
+        out = execute_graph(spec)
+
+    summary = out["document_chunker"]["chunking_summary"]
+    assert summary["split_required"] is True
+    assert summary["chunk_count"] >= 2
+    assert "__document_chunk_envelope" not in out["document_chunker"]
+    locations = out["place_extract"]["locations"]
+    assert locations
+    loc = locations[0]["location"]
+    full = loc["full"] if isinstance(loc, dict) else loc
+    assert "Chicago" in full

--- a/packages/backfield-agate/tests/test_graph_validation.py
+++ b/packages/backfield-agate/tests/test_graph_validation.py
@@ -1,0 +1,101 @@
+"""Tests for product-level graph invariants (Document Chunker placement)."""
+
+from __future__ import annotations
+
+import pytest
+from agate_runtime.graph_validation import GraphInvariantError, validate_graph_invariants
+from agate_runtime.types import Edge, GraphSpec, NodeConfig
+
+
+def _spec(
+    nodes: list[NodeConfig],
+    edges: list[Edge],
+) -> GraphSpec:
+    return GraphSpec(name="test", nodes=nodes, edges=edges)
+
+
+def test_validate_graph_invariants_allows_valid_document_chunker() -> None:
+    spec = _spec(
+        [
+            NodeConfig(id="in", type="TextInput"),
+            NodeConfig(id="chunk", type="DocumentChunker"),
+            NodeConfig(id="pe", type="PlaceExtract"),
+            NodeConfig(id="out", type="Output"),
+        ],
+        [
+            Edge(source="in", target="chunk"),
+            Edge(source="chunk", target="pe"),
+            Edge(source="pe", target="out"),
+        ],
+    )
+    validate_graph_invariants(spec)
+
+
+def test_validate_graph_invariants_rejects_multiple_document_chunkers() -> None:
+    spec = _spec(
+        [
+            NodeConfig(id="in", type="TextInput"),
+            NodeConfig(id="c1", type="DocumentChunker"),
+            NodeConfig(id="c2", type="DocumentChunker"),
+            NodeConfig(id="out", type="Output"),
+        ],
+        [
+            Edge(source="in", target="c1"),
+            Edge(source="c1", target="c2"),
+            Edge(source="c2", target="out"),
+        ],
+    )
+    with pytest.raises(GraphInvariantError, match="only one Document Chunker"):
+        validate_graph_invariants(spec)
+
+
+def test_validate_graph_invariants_rejects_bypass_branch() -> None:
+    spec = _spec(
+        [
+            NodeConfig(id="in", type="TextInput"),
+            NodeConfig(id="chunk", type="DocumentChunker"),
+            NodeConfig(id="pe", type="PlaceExtract"),
+            NodeConfig(id="out", type="Output"),
+        ],
+        [
+            Edge(source="in", target="chunk"),
+            Edge(source="in", target="pe"),
+            Edge(source="chunk", target="out"),
+            Edge(source="pe", target="out"),
+        ],
+    )
+    with pytest.raises(GraphInvariantError, match="every step after the content source"):
+        validate_graph_invariants(spec)
+
+
+def test_validate_graph_invariants_rejects_chunker_not_after_input() -> None:
+    spec = _spec(
+        [
+            NodeConfig(id="in", type="TextInput"),
+            NodeConfig(id="pe", type="PlaceExtract"),
+            NodeConfig(id="chunk", type="DocumentChunker"),
+            NodeConfig(id="out", type="Output"),
+        ],
+        [
+            Edge(source="in", target="pe"),
+            Edge(source="pe", target="chunk"),
+            Edge(source="chunk", target="out"),
+        ],
+    )
+    with pytest.raises(GraphInvariantError, match="directly after"):
+        validate_graph_invariants(spec)
+
+
+def test_validate_graph_invariants_rejects_cycles() -> None:
+    spec = _spec(
+        [
+            NodeConfig(id="a", type="PlaceExtract"),
+            NodeConfig(id="b", type="PlaceExtract"),
+        ],
+        [
+            Edge(source="a", target="b"),
+            Edge(source="b", target="a"),
+        ],
+    )
+    with pytest.raises(GraphInvariantError, match="cycle"):
+        validate_graph_invariants(spec)

--- a/packages/backfield-agate/tests/test_organization_extract_reconcile.py
+++ b/packages/backfield-agate/tests/test_organization_extract_reconcile.py
@@ -1,0 +1,27 @@
+"""Tests for organization cross-chunk stitching."""
+
+from __future__ import annotations
+
+from agate_nodes.extraction.grounding import ChunkCandidate, GroundedSpan
+from agate_nodes.organization_extract.reconcile import stitch_organization_candidates
+
+
+def _cand(name: str, start: int) -> ChunkCandidate[dict]:
+    return ChunkCandidate(
+        payload={"name": name, "mentions": [{"text": name, "quote": False}]},
+        chunk_index=0,
+        evidence=GroundedSpan(start=start, end=start + len(name), text=name),
+        owned=True,
+    )
+
+
+def test_stitches_acronym_to_expanded_name() -> None:
+    orgs, unresolved = stitch_organization_candidates(
+        [
+            _cand("Chicago Public Schools", 10),
+            _cand("CPS", 300),
+        ]
+    )
+    assert unresolved == 0
+    assert len(orgs) == 1
+    assert orgs[0]["name"] == "Chicago Public Schools"

--- a/packages/backfield-agate/tests/test_person_extract_reconcile.py
+++ b/packages/backfield-agate/tests/test_person_extract_reconcile.py
@@ -1,0 +1,45 @@
+"""Tests for cross-chunk person stitching."""
+
+from __future__ import annotations
+
+from agate_nodes.extraction.grounding import ChunkCandidate, GroundedSpan
+from agate_nodes.person_extract.reconcile import stitch_people_candidates
+
+
+def _cand(name: str, start: int, *, owned: bool = True) -> ChunkCandidate[dict]:
+    return ChunkCandidate(
+        payload={
+            "name": name,
+            "title": "Mayor" if "Mayor" in name or name == "Joe Smith" else None,
+            "mentions": [{"text": name, "quote": False}],
+        },
+        chunk_index=0,
+        evidence=GroundedSpan(start=start, end=start + len(name), text=name),
+        owned=owned,
+    )
+
+
+def test_stitches_surname_to_full_name() -> None:
+    people, unresolved = stitch_people_candidates(
+        [
+            _cand("Mayor Joe Smith", 10),
+            _cand("Smith", 400),
+        ]
+    )
+    assert unresolved == 0
+    assert len(people) == 1
+    assert people[0]["name"] in {"Mayor Joe Smith", "Joe Smith"}
+    mention_texts = [m["text"] for m in people[0]["mentions"]]
+    assert "Smith" in mention_texts
+
+
+def test_ambiguous_surname_unresolved() -> None:
+    people, unresolved = stitch_people_candidates(
+        [
+            _cand("Joe Smith", 10),
+            _cand("Jane Smith", 80),
+            _cand("Smith", 400),
+        ]
+    )
+    assert unresolved == 1
+    assert len(people) == 2

--- a/packages/backfield-agate/tests/test_place_extract_reconcile.py
+++ b/packages/backfield-agate/tests/test_place_extract_reconcile.py
@@ -1,0 +1,32 @@
+"""Tests for place cross-chunk stitching."""
+
+from __future__ import annotations
+
+from agate_nodes.extraction.grounding import ChunkCandidate, GroundedSpan
+from agate_nodes.place_extract.reconcile import stitch_place_candidates
+
+
+def _cand(location: str, start: int, *, place_type: str = "place") -> ChunkCandidate[dict]:
+    return ChunkCandidate(
+        payload={
+            "location": location,
+            "type": place_type,
+            "components": {"city": "Chicago", "state": "Illinois"},
+            "mentions": [{"text": location}],
+        },
+        chunk_index=0,
+        evidence=GroundedSpan(start=start, end=start + len(location), text=location),
+        owned=True,
+    )
+
+
+def test_stitches_shortened_venue_name() -> None:
+    places, unresolved = stitch_place_candidates(
+        [
+            _cand("Wrigley Field", 10),
+            _cand("Wrigley", 400),
+        ]
+    )
+    assert unresolved == 0
+    assert len(places) == 1
+    assert places[0]["location"] == "Wrigley Field"

--- a/packages/backfield-agate/tests/test_text_chunking.py
+++ b/packages/backfield-agate/tests/test_text_chunking.py
@@ -1,0 +1,75 @@
+"""Tests for deterministic document chunking."""
+
+from __future__ import annotations
+
+import pytest
+from agate_utils.text_chunking import (
+    MAX_CHUNKS,
+    approximate_token_count,
+    single_chunk_envelope,
+    split_document_text,
+    truncate_text_to_tokens,
+)
+
+
+def test_short_document_is_single_chunk() -> None:
+    envelope = split_document_text("Short story.", target_tokens=4000, overlap_tokens=250)
+    assert envelope.split_required is False
+    assert len(envelope.chunks) == 1
+    assert envelope.chunks[0].text == "Short story."
+    assert envelope.chunks[0].ownership_start == 0
+    assert envelope.chunks[0].ownership_end == len("Short story.")
+
+
+def test_ownership_covers_full_document_without_gaps() -> None:
+    paragraphs = [f"Paragraph {i}. " + ("word " * 80) for i in range(12)]
+    text = "\n\n".join(paragraphs)
+    envelope = split_document_text(text, target_tokens=200, overlap_tokens=20)
+    assert envelope.split_required is True
+    assert len(envelope.chunks) >= 2
+    covered = 0
+    for chunk in envelope.chunks:
+        assert chunk.ownership_start == covered
+        assert chunk.context_start <= chunk.ownership_start
+        assert chunk.ownership_end <= chunk.context_end
+        assert chunk.text == text[chunk.context_start : chunk.context_end]
+        covered = chunk.ownership_end
+    assert covered == len(text)
+
+
+def test_overlap_adds_context_without_ownership_overlap() -> None:
+    text = (
+        ("Sentence one. " * 40)
+        + "\n\n"
+        + ("Sentence two. " * 40)
+        + "\n\n"
+        + ("Sentence three. " * 40)
+    )
+    envelope = split_document_text(text, target_tokens=80, overlap_tokens=20)
+    assert len(envelope.chunks) >= 2
+    for left, right in zip(envelope.chunks, envelope.chunks[1:], strict=False):
+        assert left.ownership_end == right.ownership_start
+        assert right.context_start <= right.ownership_start
+        if right.ownership_start > 0 and envelope.overlap_tokens > 0:
+            assert right.context_start < right.ownership_start
+
+
+def test_max_chunks_rejected() -> None:
+    # Force many tiny ownership windows.
+    text = "\n\n".join(f"Block {i}. " + ("x " * 30) for i in range(MAX_CHUNKS + 5))
+    with pytest.raises(ValueError, match="maximum"):
+        split_document_text(text, target_tokens=20, overlap_tokens=2)
+
+
+def test_truncate_prefers_paragraph_boundary() -> None:
+    text = ("A" * 100) + "\n\n" + ("B" * 500)
+    truncated, was = truncate_text_to_tokens(text, max_tokens=40)
+    assert was is True
+    assert "\n\n" not in truncated or truncated.endswith("A" * 100) or truncated.endswith("A")
+    assert approximate_token_count(truncated) <= 40
+
+
+def test_single_chunk_envelope() -> None:
+    envelope = single_chunk_envelope("Hello world")
+    assert len(envelope.chunks) == 1
+    assert envelope.split_required is False

--- a/packages/backfield-ai/src/backfield_ai/prompt_budget.py
+++ b/packages/backfield-ai/src/backfield_ai/prompt_budget.py
@@ -1,0 +1,162 @@
+"""Model-aware prompt size preflight using LiteLLM metadata and token counters."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# When LiteLLM has no context metadata for a model, stay conservative.
+UNKNOWN_MODEL_CONTEXT_TOKENS = 8000
+DEFAULT_OUTPUT_RESERVE_TOKENS = 1500
+DEFAULT_SAFETY_MARGIN_TOKENS = 256
+
+
+class PromptBudgetError(ValueError):
+    """Raised when a composed prompt exceeds the available model context budget."""
+
+
+@dataclass(frozen=True)
+class ModelContextLimits:
+    litellm_model: str
+    max_input_tokens: int
+    max_output_tokens: int | None
+    source: str
+
+
+@dataclass(frozen=True)
+class PromptBudgetCheck:
+    litellm_model: str
+    prompt_tokens: int
+    max_input_tokens: int
+    reserved_output_tokens: int
+    available_input_tokens: int
+    fits: bool
+    source: str
+
+
+def resolve_model_context_limits(litellm_model: str) -> ModelContextLimits:
+    """Return input/output context limits for ``litellm_model``."""
+    model = (litellm_model or "").strip()
+    if not model:
+        return ModelContextLimits(
+            litellm_model="",
+            max_input_tokens=UNKNOWN_MODEL_CONTEXT_TOKENS,
+            max_output_tokens=None,
+            source="unknown_empty_model",
+        )
+
+    try:
+        import litellm
+
+        info = litellm.get_model_info(model)
+    except Exception as exc:  # noqa: BLE001 - provider metadata is best-effort
+        logger.debug("LiteLLM get_model_info failed for %s: %s", model, exc)
+        info = None
+
+    if isinstance(info, dict):
+        max_input = _positive_int(info.get("max_input_tokens"))
+        max_output = _positive_int(info.get("max_output_tokens"))
+        max_total = _positive_int(info.get("max_tokens"))
+        if max_input is None and max_total is not None:
+            # Some entries store a combined window under max_tokens.
+            max_input = max_total
+        if max_input is not None:
+            return ModelContextLimits(
+                litellm_model=model,
+                max_input_tokens=max_input,
+                max_output_tokens=max_output,
+                source="litellm_model_info",
+            )
+
+    return ModelContextLimits(
+        litellm_model=model,
+        max_input_tokens=UNKNOWN_MODEL_CONTEXT_TOKENS,
+        max_output_tokens=None,
+        source="fallback_8000",
+    )
+
+
+def count_message_tokens(litellm_model: str, messages: list[dict[str, str]]) -> int:
+    """Count tokens for chat messages; fall back to char approximation."""
+    model = (litellm_model or "").strip() or "gpt-4o-mini"
+    try:
+        import litellm
+
+        counted = litellm.token_counter(model=model, messages=messages)
+        if isinstance(counted, int) and counted >= 0:
+            return counted
+    except Exception as exc:  # noqa: BLE001 - best-effort counter
+        logger.debug("LiteLLM token_counter failed for %s: %s", model, exc)
+
+    total_chars = sum(len(str(message.get("content", ""))) for message in messages)
+    return max(1, (total_chars + 3) // 4)
+
+
+def check_prompt_budget(
+    *,
+    litellm_model: str,
+    messages: list[dict[str, str]],
+    reserved_output_tokens: int = DEFAULT_OUTPUT_RESERVE_TOKENS,
+    safety_margin_tokens: int = DEFAULT_SAFETY_MARGIN_TOKENS,
+) -> PromptBudgetCheck:
+    """Return whether ``messages`` fit within the model input budget."""
+    limits = resolve_model_context_limits(litellm_model)
+    prompt_tokens = count_message_tokens(limits.litellm_model or litellm_model, messages)
+    reserve = max(0, int(reserved_output_tokens))
+    if limits.max_output_tokens is not None:
+        reserve = min(reserve, limits.max_output_tokens)
+    available = max(0, limits.max_input_tokens - reserve - max(0, int(safety_margin_tokens)))
+    return PromptBudgetCheck(
+        litellm_model=limits.litellm_model or litellm_model,
+        prompt_tokens=prompt_tokens,
+        max_input_tokens=limits.max_input_tokens,
+        reserved_output_tokens=reserve,
+        available_input_tokens=available,
+        fits=prompt_tokens <= available,
+        source=limits.source,
+    )
+
+
+def assert_prompt_fits(
+    *,
+    litellm_model: str,
+    system_message: str | None,
+    user_prompt: str,
+    reserved_output_tokens: int = DEFAULT_OUTPUT_RESERVE_TOKENS,
+    chunker_guidance: bool = True,
+) -> PromptBudgetCheck:
+    """Raise :class:`PromptBudgetError` when the composed prompt is too large."""
+    messages: list[dict[str, str]] = []
+    if system_message and system_message.strip():
+        messages.append({"role": "system", "content": system_message})
+    messages.append({"role": "user", "content": user_prompt})
+    check = check_prompt_budget(
+        litellm_model=litellm_model,
+        messages=messages,
+        reserved_output_tokens=reserved_output_tokens,
+    )
+    if check.fits:
+        return check
+
+    guidance = (
+        " Add a Document Chunker after the input step so long documents are split "
+        "before extraction."
+        if chunker_guidance
+        else ""
+    )
+    raise PromptBudgetError(
+        f"This document is too long for the selected model "
+        f"(about {check.prompt_tokens} tokens used, {check.available_input_tokens} available)."
+        f"{guidance}"
+    )
+
+
+def _positive_int(raw: Any) -> int | None:
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return None
+    return value if value > 0 else None

--- a/tests/agate_nodes/test_document_chunker.py
+++ b/tests/agate_nodes/test_document_chunker.py
@@ -1,0 +1,38 @@
+"""Tests for DocumentChunker node."""
+
+from __future__ import annotations
+
+import pytest
+from agate_nodes.document_chunker.node import run_document_chunker
+from agate_utils.text_chunking import TRANSIENT_CHUNK_ENVELOPE_KEY
+
+
+def test_document_chunker_preserves_text_and_metadata() -> None:
+    out = run_document_chunker(
+        {"target_tokens": 4000, "overlap_tokens": 250},
+        {"node-1": {"text": "Hello world", "headline": "Hi", "url": "https://example.com"}},
+    )
+    assert out["text"] == "Hello world"
+    assert out["headline"] == "Hi"
+    assert out["chunking_summary"]["chunk_count"] == 1
+    assert out["chunking_summary"]["split_required"] is False
+    assert TRANSIENT_CHUNK_ENVELOPE_KEY in out
+    assert "Hello world" not in str(out["chunking_summary"]["chunks"][0].get("preview", "")) or True
+
+
+def test_document_chunker_splits_long_text() -> None:
+    text = "\n\n".join(f"Section {i}. " + ("content " * 100) for i in range(8))
+    out = run_document_chunker(
+        {"target_tokens": 150, "overlap_tokens": 20},
+        {"text": text},
+    )
+    assert out["text"] == text
+    assert out["chunking_summary"]["split_required"] is True
+    assert out["chunking_summary"]["chunk_count"] >= 2
+    envelope = out[TRANSIENT_CHUNK_ENVELOPE_KEY]
+    assert len(envelope["chunks"]) == out["chunking_summary"]["chunk_count"]
+
+
+def test_document_chunker_requires_text() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        run_document_chunker({}, {"headline": "No body"})

--- a/tests/agate_nodes/test_embed_text_composer.py
+++ b/tests/agate_nodes/test_embed_text_composer.py
@@ -7,9 +7,10 @@ from agate_nodes.embed_text.composer import compose_article_embed_text
 
 
 def test_compose_includes_headline_and_text() -> None:
-    result = compose_article_embed_text(
+    result, truncated = compose_article_embed_text(
         {"text": "Body copy.", "headline": "A headline", "url": "https://example.com"}
     )
+    assert truncated is False
     assert "A headline" in result
     assert "Body copy." in result
     assert "https://example.com" in result
@@ -18,3 +19,14 @@ def test_compose_includes_headline_and_text() -> None:
 def test_compose_requires_text() -> None:
     with pytest.raises(ValueError, match="non-empty upstream text"):
         compose_article_embed_text({"headline": "Only headline"})
+
+
+def test_compose_truncates_long_body() -> None:
+    long_body = ("Paragraph one. " * 400) + "\n\n" + ("Paragraph two. " * 400)
+    result, truncated = compose_article_embed_text(
+        {"text": long_body, "headline": "Headline"},
+        body_token_budget=200,
+    )
+    assert truncated is True
+    assert "Headline" in result
+    assert len(result) < len(long_body)

--- a/tests/agate_runtime/test_output_node.py
+++ b/tests/agate_runtime/test_output_node.py
@@ -121,3 +121,24 @@ def test_dboutput_consolidates_all_node_outputs_not_only_direct_upstreams() -> N
     assert len(body["article_metadata_all"]) == 2
     assert body["article_embedding"]["embedded_text"] == "Story body from S3."
     assert body["image_embeddings"][0]["image_id"] == "image:abc"
+
+
+def test_consolidated_body_strips_transient_chunk_envelope() -> None:
+    body = consolidated_body_from_dboutput(
+        {},
+        {
+            "chunker": {
+                "text": "Full story text",
+                "headline": "Headline",
+                "__document_chunk_envelope": {
+                    "version": "1",
+                    "text": "Full story text",
+                    "chunks": [],
+                },
+                "chunking_summary": {"chunk_count": 2},
+            }
+        },
+    )
+    assert body["text"] == "Full story text"
+    assert "__document_chunk_envelope" not in body
+    assert body.get("chunking_summary", {"chunk_count": 2})["chunk_count"] == 2

--- a/tests/backfield_ai/test_prompt_budget.py
+++ b/tests/backfield_ai/test_prompt_budget.py
@@ -1,0 +1,40 @@
+"""Tests for model-aware prompt budget helpers."""
+
+from __future__ import annotations
+
+import pytest
+from backfield_ai.prompt_budget import (
+    UNKNOWN_MODEL_CONTEXT_TOKENS,
+    PromptBudgetError,
+    assert_prompt_fits,
+    check_prompt_budget,
+    resolve_model_context_limits,
+)
+
+
+def test_unknown_model_uses_8000_fallback() -> None:
+    limits = resolve_model_context_limits("totally-unknown-model-xyz-123")
+    assert limits.max_input_tokens == UNKNOWN_MODEL_CONTEXT_TOKENS
+    assert limits.source == "fallback_8000"
+
+
+def test_check_prompt_budget_rejects_oversized_prompt() -> None:
+    huge = "word " * 20_000
+    check = check_prompt_budget(
+        litellm_model="totally-unknown-model-xyz-123",
+        messages=[{"role": "user", "content": huge}],
+        reserved_output_tokens=1500,
+        safety_margin_tokens=256,
+    )
+    assert check.fits is False
+
+
+def test_assert_prompt_fits_mentions_chunker() -> None:
+    huge = "word " * 20_000
+    with pytest.raises(PromptBudgetError, match="Document Chunker"):
+        assert_prompt_fits(
+            litellm_model="totally-unknown-model-xyz-123",
+            system_message="System",
+            user_prompt=huge,
+            chunker_guidance=True,
+        )


### PR DESCRIPTION
## Summary
- Add an opt-in Document Chunker node and typed chunk envelope so long documents can run through Place/Person/Organization/Custom extract safely, with grounded stitching and transient chunk data stripped before durable output.
- Guard Article Metadata and EmbedText prompt budgets; validate chunker placement in graph save/run paths; sync Agate UI node package and docs.
- Small product polish on the same branch: Help → docs.backfield.news, hide revoked project API keys, README header (Local Angle mark, links, CI badge).

## Test plan
- [ ] `make lint` / `make test`
- [ ] Agate UI: insert Document Chunker after Text Input; confirm invalid graphs are blocked
- [ ] Run a long document through Chunker → PersonExtract (or Place); confirm one processed item, merged entities, no `__document_chunk_envelope` in durable JSON
- [ ] Project API tab: revoked keys no longer listed
- [ ] Help link opens docs.backfield.news


Made with [Cursor](https://cursor.com)