### PR TITLE
Fix chunked PlaceExtract unit test mock

### DIFF
--- a/docs/development/nodes.md
+++ b/docs/development/nodes.md
@@ -289,7 +289,6 @@ Tab IDs and labels are centralized in `src/lib/nodePanelTabs.ts`. Current routin
 | Embed Text, Embed Images | Settings, Info |
 | Gather | Settings, Info; Output when run output exists |
 | Document Chunker | Settings, Info; Output when run output exists |
-| Document Chunker | Settings, Info; Output when run output exists |
 | JSON Output | Output only when run output exists |
 | Backfield Output | Settings, Stylebook |
 | S3 Output | Settings; Output when run output exists |

--- a/packages/backfield-agate/tests/test_executor.py
+++ b/packages/backfield-agate/tests/test_executor.py
@@ -898,7 +898,7 @@ def test_document_chunker_projects_summary_and_feeds_extract():
         ],
     )
     with patch(
-        "agate_nodes.place_extract.node_port.call_llm",
+        "agate_nodes.extraction.chunked_entity_extract.call_llm",
         return_value=_mock_place_extract_json("Chicago", "Illinois", "IL"),
     ):
         out = execute_graph(spec)


### PR DESCRIPTION
## Summary
- Patch `call_llm` where chunked extraction actually imports it so CI no longer hits a real OPENAI_API_KEY path.
- Remove a duplicate Document Chunker row in the nodes panel-tabs table.

## Test plan
- [x] `uv run pytest packages/backfield-agate/tests/test_executor.py::test_document_chunker_projects_summary_and_feeds_extract -q`
- [ ] CI `test` job green


Made with [Cursor](https://cursor.com)