### PR TITLE
Add tag-triggered GitHub Releases for SemVer cuts

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -1,4 +1,4 @@
-name: Release Artifact Alias
+name: Release
 
 on:
   push:
@@ -7,9 +7,63 @@ on:
 
 permissions:
   id-token: write
-  contents: read
+  contents: write
 
 jobs:
+  github-release:
+    if: github.repository == 'localangle/backfield'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    concurrency:
+      group: github-release-${{ github.ref_name }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate release tag is on main
+        run: |
+          set -euo pipefail
+          [[ "$GITHUB_REF_NAME" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] \
+            || { echo "::error::Tag must be SemVer vX.Y.Z"; exit 1; }
+          git fetch origin main
+          git merge-base --is-ancestor "$GITHUB_SHA" origin/main \
+            || { echo "::error::Release commit is not on main"; exit 1; }
+
+      - name: Check whether GitHub Release already exists
+        id: existing
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create GitHub Release
+        if: steps.existing.outputs.exists != 'true'
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          generate_release_notes: true
+          body: |
+            ## Deploy
+
+            This SemVer tag aliases immutable CI artifacts for commit `${{ github.sha }}`.
+            Images and UIs are **not** rebuilt at tag time.
+
+            Promote the complete manifest alias `${{ github.ref_name }}` with the deployment
+            system. See [docs/operations/deployment.md](https://github.com/localangle/backfield/blob/main/docs/operations/deployment.md).
+
+      - name: Summarize existing release
+        if: steps.existing.outputs.exists == 'true'
+        run: |
+          echo "GitHub Release ${GITHUB_REF_NAME} already exists; skipping create." >> "$GITHUB_STEP_SUMMARY"
+
   alias:
     if: >
       github.repository == 'localangle/backfield' &&

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@
   <a href="https://github.com/localangle/backfield/actions/workflows/ci.yml">
     <img src="https://github.com/localangle/backfield/actions/workflows/ci.yml/badge.svg" alt="CI" />
   </a>
+  <a href="https://github.com/localangle/backfield/releases">
+    <img src="https://img.shields.io/github/v/release/localangle/backfield" alt="Release" />
+  </a>
 </p>
 
 Backfield turns unstructured news stories into structured data at scale. Among other things, it extracts and geocodes the locations of news events; organizes people and their quotes; and connect people, places and organizations into a knowledge graph based on your coverage.

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -117,15 +117,19 @@ every required artifact is available and verified. Fork workflows do not publish
 Product releases use SemVer tags (`vX.Y.Z`). The workspace `pyproject.toml` version is an internal
 monorepo stub and is **not** the product version.
 
+The first public baseline is **`v0.8.0`**. Earlier tags such as `v0.0.1` are pre-history artifact
+aliases only and are not advertised as product releases. Stay on `0.Y.Z` until you are ready to treat
+the public API and upgrade path as a `1.0.0` stability contract.
+
 ### Cut a release
 
 1. Choose a commit already on `main` whose CI `publish-artifacts` job has produced a complete SHA
    manifest (`main-<first-12-sha>-amd64`).
-2. Pick the SemVer bump:
-   - **patch** — fixes and small non-breaking changes
-   - **minor** — backward-compatible features
-   - **major** — breaking or ops-notable changes (for example migrations that need a coordinated
-     upgrade)
+2. Pick the SemVer bump (from the current public baseline, starting at `v0.8.0`):
+   - **patch** — fixes and small non-breaking changes (`0.8.0` → `0.8.1`)
+   - **minor** — backward-compatible features (`0.8.0` → `0.9.0`)
+   - **major** — breaking or ops-notable changes, or the jump to `1.0.0` when you are ready for a
+     stability contract (for example migrations that need a coordinated upgrade)
 3. Create and push an annotated tag:
 
 ```bash

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -114,9 +114,33 @@ every required artifact is available and verified. Fork workflows do not publish
 
 ## Release aliases
 
-Pushing a tag matching `vX.Y.Z` runs the release-alias workflow. The tag must point to a commit on
-`main`. The workflow does not rebuild images or UIs; it aliases the existing immutable manifest after
-validating the source commit and artifact set.
+Product releases use SemVer tags (`vX.Y.Z`). The workspace `pyproject.toml` version is an internal
+monorepo stub and is **not** the product version.
+
+### Cut a release
+
+1. Choose a commit already on `main` whose CI `publish-artifacts` job has produced a complete SHA
+   manifest (`main-<first-12-sha>-amd64`).
+2. Pick the SemVer bump:
+   - **patch** — fixes and small non-breaking changes
+   - **minor** — backward-compatible features
+   - **major** — breaking or ops-notable changes (for example migrations that need a coordinated
+     upgrade)
+3. Create and push an annotated tag:
+
+```bash
+git checkout main
+git pull
+git tag -a vX.Y.Z -m "Backfield vX.Y.Z"
+git push origin vX.Y.Z
+```
+
+Pushing the tag runs the `Release` workflow, which:
+
+1. Creates a GitHub Release (auto-generated notes plus a short deploy preamble). Re-running is
+   idempotent if the release already exists.
+2. Aliases the existing immutable artifact manifest to `vX.Y.Z` (when artifact publisher credentials
+   are configured). Images and UIs are not rebuilt at tag time.
 
 Do not deploy an arbitrary mutable image tag or a partial artifact set. Use an immutable main version
 or validated SemVer alias backed by a complete manifest.


### PR DESCRIPTION
## Summary
- On `vX.Y.Z` tag push, create a GitHub Release (auto notes + deploy preamble) independently of AWS artifact aliasing.
- Document the operator cut process and SemVer bump guidance in deployment docs.
- Establish **`v0.8.0`** as the first public baseline (treat `v0.0.1` as pre-history).
- Add a Release badge next to CI on the README.

## Test plan
- [ ] Workflow YAML review: `github-release` skips when release exists; `alias` job unchanged aside from shared `contents: write`
- [ ] Docs: cut steps match existing SemVer alias rules (tag on `main`, no rebuild); baseline is `v0.8.0`
- [ ] After merge: tag `v0.8.0` on `main` (once SHA artifacts exist) so the Release badge resolves