### PR TITLE
Launch Cursor docs sync on SemVer releases

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: SemVer tag to process (e.g. v0.8.0). Required for manual docs-sync / release jobs.
+        required: true
+        type: string
 
 permissions:
   id-token: write
@@ -11,24 +17,39 @@ permissions:
 
 jobs:
   github-release:
-    if: github.repository == 'localangle/backfield'
+    if: >
+      github.repository == 'localangle/backfield' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     concurrency:
-      group: github-release-${{ github.ref_name }}
+      group: github-release-${{ github.event.inputs.tag || github.ref_name }}
       cancel-in-progress: false
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
+      - name: Resolve release tag
+        id: tag
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ github.event.inputs.tag }}"
+          else
+            TAG="${{ github.ref_name }}"
+          fi
+          [[ "$TAG" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] \
+            || { echo "::error::Tag must be SemVer vX.Y.Z"; exit 1; }
+          echo "name=$TAG" >> "$GITHUB_OUTPUT"
+
       - name: Validate release tag is on main
         run: |
           set -euo pipefail
-          [[ "$GITHUB_REF_NAME" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] \
-            || { echo "::error::Tag must be SemVer vX.Y.Z"; exit 1; }
-          git fetch origin main
-          git merge-base --is-ancestor "$GITHUB_SHA" origin/main \
+          TAG="${{ steps.tag.outputs.name }}"
+          git fetch origin main --tags
+          TAG_SHA="$(git rev-list -n 1 "$TAG")"
+          git merge-base --is-ancestor "$TAG_SHA" origin/main \
             || { echo "::error::Release commit is not on main"; exit 1; }
 
       - name: Check whether GitHub Release already exists
@@ -37,7 +58,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+          TAG="${{ steps.tag.outputs.name }}"
+          if gh release view "$TAG" >/dev/null 2>&1; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
@@ -47,26 +69,131 @@ jobs:
         if: steps.existing.outputs.exists != 'true'
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
-          tag_name: ${{ github.ref_name }}
-          name: ${{ github.ref_name }}
+          tag_name: ${{ steps.tag.outputs.name }}
+          name: ${{ steps.tag.outputs.name }}
           generate_release_notes: true
           body: |
             ## Deploy
 
-            This SemVer tag aliases immutable CI artifacts for commit `${{ github.sha }}`.
+            This SemVer tag aliases immutable CI artifacts for commit associated with `${{ steps.tag.outputs.name }}`.
             Images and UIs are **not** rebuilt at tag time.
 
-            Promote the complete manifest alias `${{ github.ref_name }}` with the deployment
+            Promote the complete manifest alias `${{ steps.tag.outputs.name }}` with the deployment
             system. See [docs/operations/deployment.md](https://github.com/localangle/backfield/blob/main/docs/operations/deployment.md).
 
       - name: Summarize existing release
         if: steps.existing.outputs.exists == 'true'
         run: |
-          echo "GitHub Release ${GITHUB_REF_NAME} already exists; skipping create." >> "$GITHUB_STEP_SUMMARY"
+          echo "GitHub Release ${{ steps.tag.outputs.name }} already exists; skipping create." >> "$GITHUB_STEP_SUMMARY"
+
+  docs-sync:
+    if: >
+      github.repository == 'localangle/backfield' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    concurrency:
+      group: docs-sync-${{ github.event.inputs.tag || github.ref_name }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve release tag
+        id: tag
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ github.event.inputs.tag }}"
+          else
+            TAG="${{ github.ref_name }}"
+          fi
+          [[ "$TAG" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] \
+            || { echo "::error::Tag must be SemVer vX.Y.Z"; exit 1; }
+          echo "name=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Validate release tag is on main
+        run: |
+          set -euo pipefail
+          TAG="${{ steps.tag.outputs.name }}"
+          git fetch origin main --tags
+          TAG_SHA="$(git rev-list -n 1 "$TAG")"
+          git merge-base --is-ancestor "$TAG_SHA" origin/main \
+            || { echo "::error::Release commit is not on main"; exit 1; }
+
+      - name: Build release context for docs agent
+        id: context
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          TAG="${{ steps.tag.outputs.name }}"
+          PREV="$(git tag -l 'v*.*.*' --sort=-v:refname | awk -v t="$TAG" '$0 != t { print; exit }')"
+          if [ -n "${PREV:-}" ]; then
+            SUMMARY="$(git log --pretty=format:'%h %s' "${PREV}..${TAG}")"
+          else
+            SUMMARY="$(git log --pretty=format:'%h %s' -n 80 "${TAG}")"
+          fi
+          NOTES=""
+          if gh release view "$TAG" --json body --jq .body >/tmp/release-notes.md 2>/dev/null; then
+            NOTES="$(cat /tmp/release-notes.md)"
+          fi
+          {
+            echo "previous_tag=${PREV:-}"
+            echo "release_url=https://github.com/localangle/backfield/releases/tag/${TAG}"
+          } >> "$GITHUB_OUTPUT"
+          {
+            echo "commit_summary<<EOF"
+            echo "$SUMMARY"
+            echo "EOF"
+            echo "release_notes<<EOF"
+            echo "$NOTES"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: scripts/release_docs_agent/package-lock.json
+
+      - name: Install docs agent dependencies
+        working-directory: scripts/release_docs_agent
+        run: npm ci
+
+      - name: Launch Cursor docs sync agent
+        working-directory: scripts/release_docs_agent
+        env:
+          CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
+          RELEASE_TAG: ${{ steps.tag.outputs.name }}
+          PREVIOUS_TAG: ${{ steps.context.outputs.previous_tag }}
+          COMMIT_SUMMARY: ${{ steps.context.outputs.commit_summary }}
+          RELEASE_NOTES: ${{ steps.context.outputs.release_notes }}
+          RELEASE_URL: ${{ steps.context.outputs.release_url }}
+        run: |
+          set -euo pipefail
+          if [ -z "${CURSOR_API_KEY:-}" ]; then
+            echo "::error::CURSOR_API_KEY secret is required for docs-sync. Add a Cursor service-account key with GitHub access to localangle/backfield-docs."
+            exit 1
+          fi
+          node launch.mjs | tee /tmp/docs-sync.log
+          {
+            echo "## Docs sync"
+            echo
+            echo "Launched Cursor cloud agent for \`${{ steps.tag.outputs.name }}\` against \`localangle/backfield-docs\`."
+            echo
+            echo "Contract: https://github.com/localangle/backfield-docs/blob/main/docs/meta/release-update-contract.md"
+            echo
+            echo '```text'
+            tail -n 40 /tmp/docs-sync.log
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
 
   alias:
     if: >
       github.repository == 'localangle/backfield' &&
+      github.event_name == 'push' &&
       vars.AWS_ARTIFACT_PUBLISHER_ROLE_ARN != '' &&
       vars.BACKFIELD_ARTIFACT_BUCKET != ''
     runs-on: ubuntu-latest

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -145,6 +145,13 @@ Pushing the tag runs the `Release` workflow, which:
    idempotent if the release already exists.
 2. Aliases the existing immutable artifact manifest to `vX.Y.Z` (when artifact publisher credentials
    are configured). Images and UIs are not rebuilt at tag time.
+3. Launches a Cursor cloud agent against [`backfield-docs`](https://github.com/localangle/backfield-docs)
+   to open a human-reviewed product-docs PR (changelog + targeted pages). Requires repository secret
+   `CURSOR_API_KEY`. The agent must follow
+   [release-update-contract.md](https://github.com/localangle/backfield-docs/blob/main/docs/meta/release-update-contract.md).
+   Docs deploy only after that PR is merged. You can re-run docs sync alone via **workflow_dispatch**
+   on the `Release` workflow with a tag input. See
+   [`scripts/release_docs_agent/README.md`](../../scripts/release_docs_agent/README.md).
 
 Do not deploy an arbitrary mutable image tag or a partial artifact set. Use an immutable main version
 or validated SemVer alias backed by a complete manifest.

--- a/scripts/release_docs_agent/README.md
+++ b/scripts/release_docs_agent/README.md
@@ -1,0 +1,25 @@
+# Release docs agent launcher
+
+Launches a Cursor cloud agent against [`localangle/backfield-docs`](https://github.com/localangle/backfield-docs)
+when Backfield cuts a SemVer release. The agent must follow
+`docs/meta/release-update-contract.md` in that repository and open a human-reviewed PR.
+
+## Operator setup
+
+1. Create a Cursor **service-account** API key (or user key) with GitHub connected to
+   `localangle/backfield-docs`.
+2. Add repository secret `CURSOR_API_KEY` on `localangle/backfield`.
+3. SemVer tag pushes run the `docs-sync` job in `.github/workflows/release-artifacts.yml`.
+   You can also run that workflow with **workflow_dispatch** and a tag input.
+
+## Local dry run
+
+```bash
+cd scripts/release_docs_agent
+npm install
+export CURSOR_API_KEY=cursor_...
+export RELEASE_TAG=v0.8.0
+export PREVIOUS_TAG=v0.0.1
+export COMMIT_SUMMARY="$(git -C ../.. log --oneline v0.0.1..v0.8.0)"
+node launch.mjs
+```

--- a/scripts/release_docs_agent/launch.mjs
+++ b/scripts/release_docs_agent/launch.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+/**
+ * Launch a Cursor cloud agent against localangle/backfield-docs for a SemVer release.
+ *
+ * Required env:
+ *   CURSOR_API_KEY
+ *   RELEASE_TAG          e.g. v0.8.0
+ *
+ * Optional env:
+ *   PREVIOUS_TAG         prior SemVer tag (empty = first public baseline)
+ *   COMMIT_SUMMARY       git log / subject list between tags
+ *   RELEASE_NOTES        GitHub-generated release notes body
+ *   RELEASE_URL          https://github.com/localangle/backfield/releases/tag/...
+ *   DOCS_REPO_URL        default https://github.com/localangle/backfield-docs
+ *   DOCS_STARTING_REF    default main
+ *   CURSOR_MODEL         default composer-2.5
+ */
+
+import { Agent, CursorAgentError } from "@cursor/sdk"
+
+function requiredEnv(name) {
+  const value = process.env[name]
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error(`Missing required env ${name}`)
+  }
+  return value.trim()
+}
+
+function optionalEnv(name, fallback = "") {
+  const value = process.env[name]
+  if (typeof value !== "string") return fallback
+  return value.trim()
+}
+
+function buildPrompt({
+  releaseTag,
+  previousTag,
+  commitSummary,
+  releaseNotes,
+  releaseUrl,
+}) {
+  const previousLabel = previousTag || "(none — first public baseline or unknown prior tag)"
+  return `You are updating Backfield product documentation after a SemVer release.
+
+## Contract (must follow)
+Read and obey \`docs/meta/release-update-contract.md\` in this repository before editing anything.
+
+## Release context
+- RELEASE_TAG: ${releaseTag}
+- PREVIOUS_TAG: ${previousLabel}
+- Backfield release URL: ${releaseUrl || "(not provided)"}
+
+### Commit summary
+\`\`\`
+${commitSummary || "(not provided)"}
+\`\`\`
+
+### GitHub release notes
+\`\`\`
+${releaseNotes || "(not provided)"}
+\`\`\`
+
+## Your job
+1. Follow the contract hard rules and path allowlist.
+2. Prepend a product-facing changelog row for ${releaseTag} in \`docs/changelog.md\`.
+3. Update only the existing platform/tutorial/api/support pages that must stay accurate for user-visible changes described above. Prefer omit over inventing API or UI details.
+4. Open or update a pull request titled \`docs: Backfield ${releaseTag} release notes\`.
+5. In the PR body include the tag, Backfield release URL, files touched, and whether this was changelog-only.
+6. Do not merge the PR. Do not deploy. Do not edit files outside the allowlist.
+
+If an open PR already exists for this tag, update that branch instead of opening a duplicate.
+`
+}
+
+async function main() {
+  const apiKey = requiredEnv("CURSOR_API_KEY")
+  const releaseTag = requiredEnv("RELEASE_TAG")
+  const previousTag = optionalEnv("PREVIOUS_TAG")
+  const commitSummary = optionalEnv("COMMIT_SUMMARY")
+  const releaseNotes = optionalEnv("RELEASE_NOTES")
+  const releaseUrl = optionalEnv(
+    "RELEASE_URL",
+    `https://github.com/localangle/backfield/releases/tag/${releaseTag}`,
+  )
+  const docsRepoUrl = optionalEnv(
+    "DOCS_REPO_URL",
+    "https://github.com/localangle/backfield-docs",
+  )
+  const startingRef = optionalEnv("DOCS_STARTING_REF", "main")
+  const modelId = optionalEnv("CURSOR_MODEL", "composer-2.5")
+
+  const prompt = buildPrompt({
+    releaseTag,
+    previousTag,
+    commitSummary,
+    releaseNotes,
+    releaseUrl,
+  })
+
+  console.log(`Launching docs sync cloud agent for ${releaseTag}`)
+  console.log(`docs repo=${docsRepoUrl} startingRef=${startingRef} model=${modelId}`)
+
+  let result
+  try {
+    result = await Agent.prompt(prompt, {
+      apiKey,
+      model: { id: modelId },
+      cloud: {
+        repos: [{ url: docsRepoUrl, startingRef }],
+        autoCreatePR: true,
+        skipReviewerRequest: true,
+      },
+    })
+  } catch (err) {
+    if (err instanceof CursorAgentError) {
+      console.error(`Cursor agent failed to start: ${err.message}`)
+      if (err.isRetryable) {
+        console.error("Failure is marked retryable.")
+      }
+      process.exit(1)
+    }
+    throw err
+  }
+
+  console.log(`agent status=${result.status}`)
+  if (result.result) {
+    console.log(String(result.result).slice(0, 4000))
+  }
+
+  if (result.status === "error") {
+    console.error("Cloud agent run finished with status=error")
+    process.exit(2)
+  }
+
+  if (result.status !== "finished") {
+    console.error(`Unexpected agent status: ${result.status}`)
+    process.exit(2)
+  }
+
+  console.log("Docs sync agent finished successfully.")
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/scripts/release_docs_agent/package-lock.json
+++ b/scripts/release_docs_agent/package-lock.json
@@ -1,0 +1,206 @@
+{
+  "name": "backfield-release-docs-agent",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "backfield-release-docs-agent",
+      "dependencies": {
+        "@cursor/sdk": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.0.tgz",
+      "integrity": "sha512-QDdVFLoN93Zjg36NoQPZfsVH9tZew7wKDKyV5qRdj8ntT4wQCOradQjRaTdwMhWUYsgKsvCINKKm87FdEk96Ag==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
+    "node_modules/@connectrpc/connect": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-1.7.0.tgz",
+      "integrity": "sha512-iNKdJRi69YP3mq6AePRT8F/HrxWCewrhxnLMNm0vpqXAR8biwzRtO6Hjx80C6UvtKJ5sFmffQT7I4Baecz389w==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.10.0"
+      }
+    },
+    "node_modules/@connectrpc/connect-node": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect-node/-/connect-node-1.7.0.tgz",
+      "integrity": "sha512-6vaPIkG/NyhxlYgytLoR9KYbPhczEboFB2OYWkA9qvUz1K7efXfeGrlRxoLtpa+r8VxyIOw73w5ktNe743nD+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "undici": "^5.28.4"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.10.0",
+        "@connectrpc/connect": "1.7.0"
+      }
+    },
+    "node_modules/@connectrpc/connect-web": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect-web/-/connect-web-1.7.0.tgz",
+      "integrity": "sha512-qyP0YOnUPRWwCc/VfsoydMJvkb7EyUPr2q9sHgBuJzbADjiqck1gKH5V5ZPzPhTLBvmz5UvG+wiZ5sMRQHU1MQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.10.0",
+        "@connectrpc/connect": "1.7.0"
+      }
+    },
+    "node_modules/@cursor/sdk": {
+      "version": "1.0.27",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk/-/sdk-1.0.27.tgz",
+      "integrity": "sha512-QR2RYZagCUlil/A4JcRU8rI4JmYICuMdWkuIsiz/yHvd/N3bisjw9o2uXhkKitDKHgIyeGDHwrQfH/MYttM37g==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@bufbuild/protobuf": "1.10.0",
+        "@connectrpc/connect": "^1.6.1",
+        "@connectrpc/connect-node": "^1.6.1",
+        "@connectrpc/connect-web": "^1.6.1",
+        "@statsig/js-client": "3.31.0",
+        "zod": "^3.25.0"
+      },
+      "engines": {
+        "node": ">=22.13"
+      },
+      "optionalDependencies": {
+        "@cursor/sdk-darwin-arm64": "1.0.27",
+        "@cursor/sdk-darwin-x64": "1.0.27",
+        "@cursor/sdk-linux-arm64": "1.0.27",
+        "@cursor/sdk-linux-x64": "1.0.27",
+        "@cursor/sdk-win32-x64": "1.0.27"
+      }
+    },
+    "node_modules/@cursor/sdk-darwin-arm64": {
+      "version": "1.0.27",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-darwin-arm64/-/sdk-darwin-arm64-1.0.27.tgz",
+      "integrity": "sha512-lO9chGVwb9lISwYtfolgF9IvTLR0Z0M8vd6AqwUfl607G/hesh+LICMD/tal2JWP0rm/hds66tIRo//M4RVupA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "rg": "bin/rg"
+      }
+    },
+    "node_modules/@cursor/sdk-darwin-x64": {
+      "version": "1.0.27",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-darwin-x64/-/sdk-darwin-x64-1.0.27.tgz",
+      "integrity": "sha512-moYR40uq0Mu2Runm7XWa60+8n9Epyah++fkaW/avAYMAel/qOeHTH/uiNKTjwuCledQmczCYWDTVlZQOGEhrxg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "rg": "bin/rg"
+      }
+    },
+    "node_modules/@cursor/sdk-linux-arm64": {
+      "version": "1.0.27",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-linux-arm64/-/sdk-linux-arm64-1.0.27.tgz",
+      "integrity": "sha512-caDqO0RPYmaCbQYpJwTMT5YeVqP6WkZq1y7n5v1N3rlkjdaM2mWbkdSFEUL4GOTdkm8oIEx2diRNQ1hrJbVPYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "rg": "bin/rg"
+      }
+    },
+    "node_modules/@cursor/sdk-linux-x64": {
+      "version": "1.0.27",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-linux-x64/-/sdk-linux-x64-1.0.27.tgz",
+      "integrity": "sha512-z3aVQaXk4T9QjB11u77JihHrSN0XeFYCrnuqvd9PMZQSqiXfUheqX/lQTRxFjfccoU4tK1p/nJ91IWKAUVQU4g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "rg": "bin/rg"
+      }
+    },
+    "node_modules/@cursor/sdk-win32-x64": {
+      "version": "1.0.27",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-win32-x64/-/sdk-win32-x64-1.0.27.tgz",
+      "integrity": "sha512-LbkimreWuz+FsyUcRKlvgwnWbXwzzcFexCUGkHCWNuO0JSspjhqUGfDtFFxhHU5ohMMy2FpzU7qs5wKzAc8NgA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "rg": "bin/rg.exe"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@statsig/client-core": {
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@statsig/client-core/-/client-core-3.31.0.tgz",
+      "integrity": "sha512-SuxQD6TmVszPG7FoMKwTk/uyBuVFk7XnxI3T/E0uyb7PL7GNjONtfsoh+NqBBVUJVse0CUeSFfgJPoZy1ZOslQ==",
+      "license": "ISC"
+    },
+    "node_modules/@statsig/js-client": {
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@statsig/js-client/-/js-client-3.31.0.tgz",
+      "integrity": "sha512-LFa5E0LjT6sTfZv3sNGoyRLSZ1078+agdgOA+Vm1ecjG+KbSOfBLTW7hMwimrJ29slRwbYDzbtKaPJo/R37N2g==",
+      "license": "ISC",
+      "dependencies": {
+        "@statsig/client-core": "3.31.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/scripts/release_docs_agent/package.json
+++ b/scripts/release_docs_agent/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "backfield-release-docs-agent",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
+  "dependencies": {
+    "@cursor/sdk": "1.0.27"
+  }
+}


### PR DESCRIPTION
## Summary
- Add a Node launcher that starts a Cursor cloud agent against `backfield-docs` with `autoCreatePR`.
- Extend the `Release` workflow with an independent `docs-sync` job (tag push or workflow_dispatch).
- Document `CURSOR_API_KEY` setup and link the product-docs contract.

Companion PR in backfield-docs lands the canonical contract file.

## Test plan
- [ ] Add `CURSOR_API_KEY` secret on `localangle/backfield` (service account with GitHub access to `backfield-docs`)
- [ ] Merge companion contract PR in `backfield-docs` first
- [ ] After merge: `workflow_dispatch` Release with tag `v0.8.0` and confirm a docs PR opens
- [ ] Confirm `alias` / `github-release` still succeed independently if docs-sync fails


Made with [Cursor](https://cursor.com)