### PR TITLE
Fix release workflow tag validation fetch clobber

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -47,7 +47,12 @@ jobs:
         run: |
           set -euo pipefail
           TAG="${{ steps.tag.outputs.name }}"
-          git fetch origin main --tags
+          # Fetch main only. ``--tags`` fails under set -e when the checked-out
+          # release tag already exists locally ("would clobber existing tag").
+          git fetch origin main
+          if ! git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            git fetch origin "refs/tags/${TAG}:refs/tags/${TAG}"
+          fi
           TAG_SHA="$(git rev-list -n 1 "$TAG")"
           git merge-base --is-ancestor "$TAG_SHA" origin/main \
             || { echo "::error::Release commit is not on main"; exit 1; }
@@ -117,7 +122,12 @@ jobs:
         run: |
           set -euo pipefail
           TAG="${{ steps.tag.outputs.name }}"
-          git fetch origin main --tags
+          # Fetch main only. ``--tags`` fails under set -e when the checked-out
+          # release tag already exists locally ("would clobber existing tag").
+          git fetch origin main
+          if ! git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            git fetch origin "refs/tags/${TAG}:refs/tags/${TAG}"
+          fi
           TAG_SHA="$(git rev-list -n 1 "$TAG")"
           git merge-base --is-ancestor "$TAG_SHA" origin/main \
             || { echo "::error::Release commit is not on main"; exit 1; }


### PR DESCRIPTION
## Summary
- Stop fetching `--tags` during SemVer release validation; `git fetch origin main --tags` fails under `set -e` when the checked-out release tag already exists (`would clobber existing tag`).
- Matches the working `alias` job pattern and still fetches the tag only when missing (workflow_dispatch).

## Why
Cutting `v0.8.1` showed `github-release` and `docs-sync` failing validation while `alias` succeeded. Artifact aliasing for `v0.8.1` already completed; GitHub Release was created manually as a follow-up. After this merges, re-run **Release** via workflow_dispatch with tag `v0.8.1` to finish docs-sync.

## Test plan
- [x] Inspect failed run logs for v0.8.1
- [ ] Merge, then `gh workflow run release-artifacts.yml -f tag=v0.8.1` and confirm github-release (idempotent) + docs-sync


Made with [Cursor](https://cursor.com)