### PR TITLE
Fix Select and DropdownMenu stacking above Dialog overlays

### DIFF
--- a/apps/agate-ui/src/components/ui/dialog.tsx
+++ b/apps/agate-ui/src/components/ui/dialog.tsx
@@ -20,6 +20,7 @@ const DialogOverlay = React.forwardRef<
     ref={ref}
     className={cn(
       // Above Leaflet map panes/controls (often 400–1000) so dialogs are not trapped under maps.
+      // Portaled Select/DropdownMenu content must stay above this (see z-[2100] there).
       "fixed inset-0 z-[2000] bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}

--- a/apps/agate-ui/src/components/ui/dropdown-menu.tsx
+++ b/apps/agate-ui/src/components/ui/dropdown-menu.tsx
@@ -47,7 +47,8 @@ const DropdownMenuSubContent = React.forwardRef<
   <DropdownMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      // Above Dialog (z-[2000]); menus portal to body and must clear the overlay.
+      "z-[2100] min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
       className
     )}
     {...props}
@@ -65,7 +66,8 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        // Above Dialog (z-[2000]); menus portal to body and must clear the overlay.
+        "z-[2100] min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className
       )}
       {...props}

--- a/apps/agate-ui/src/components/ui/select.tsx
+++ b/apps/agate-ui/src/components/ui/select.tsx
@@ -75,7 +75,8 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        // Above Dialog (z-[2000]); Select portals to body and must clear the overlay.
+        "relative z-[2100] max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         position === "popper" &&
           "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
         className


### PR DESCRIPTION
## Summary
- Raise Select and DropdownMenu portal z-index above Dialog (`z-[2000]` → menus at `z-[2100]`) so dropdowns inside dialogs are visible and clickable again.
- Fixes Settings → AI models Add/Edit model dialogs, where model type and credential selects appeared broken after #136 raised Dialog above Leaflet maps.

## Test plan
- [ ] Open Settings → AI models → Add model
- [ ] Confirm Model type, Preset, and API credential selects open above the dialog and accept a selection
- [ ] Confirm Edit model credential/status selects still work
- [ ] Spot-check a map dialog that motivated Dialog `z-[2000]` still appears above the map


Made with [Cursor](https://cursor.com)