### PR TITLE
Fix Stylebook prune UX, GPT-5.6 extract truncation, and org user edit

### DIFF
--- a/apps/agate-ui/src/lib/core-api.ts
+++ b/apps/agate-ui/src/lib/core-api.ts
@@ -592,7 +592,11 @@ export async function createOrgUser(
 export async function patchOrgUser(
   orgId: number,
   userId: number,
-  body: { display_name?: string | null; role?: string | null },
+  body: {
+    display_name?: string | null
+    role?: string | null
+    disabled?: boolean
+  },
 ): Promise<OrgUserRow> {
   return jsonFetch(`/v1/organizations/${orgId}/users/${userId}`, {
     method: "PATCH",
@@ -607,6 +611,13 @@ export async function disableOrgUser(
   await jsonFetch(`/v1/organizations/${orgId}/users/${userId}`, {
     method: "DELETE",
   })
+}
+
+export async function enableOrgUser(
+  orgId: number,
+  userId: number,
+): Promise<OrgUserRow> {
+  return patchOrgUser(orgId, userId, { disabled: false })
 }
 
 /** @deprecated Prefer workspace-based access via replaceWorkspaceMemberships. */

--- a/apps/agate-ui/src/pages/ManageUsers.tsx
+++ b/apps/agate-ui/src/pages/ManageUsers.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react"
-import { BookOpen, Building2, UserX } from "lucide-react"
+import { BookOpen, Building2, Pencil, UserCheck, UserX } from "lucide-react"
 import { useAppMessage } from "@/components/AppMessageProvider"
 import { Button } from "@/components/ui/button"
 import {
@@ -31,6 +31,7 @@ import { useAuth } from "@/lib/auth"
 import {
   createOrgUser,
   disableOrgUser,
+  enableOrgUser,
   listOrgUsers,
   listOrgWorkspaces,
   patchOrgUser,
@@ -59,6 +60,10 @@ export default function ManageUsersPage() {
   const [createPassword, setCreatePassword] = useState("")
   const [createDisplay, setCreateDisplay] = useState("")
   const [createRole, setCreateRole] = useState("member")
+  const [editUser, setEditUser] = useState<OrgUserRow | null>(null)
+  const [editDisplay, setEditDisplay] = useState("")
+  const [editRole, setEditRole] = useState("member")
+  const [editSaving, setEditSaving] = useState(false)
   const [accessUser, setAccessUser] = useState<OrgUserRow | null>(null)
   const [selectedWorkspaceIds, setSelectedWorkspaceIds] = useState<Set<number>>(
     new Set(),
@@ -115,6 +120,32 @@ export default function ManageUsersPage() {
       cancelled = true
     }
   }, [organizationId, reload])
+
+  const openEditUser = (u: OrgUserRow) => {
+    setEditUser(u)
+    setEditDisplay(u.display_name ?? "")
+    setEditRole(u.role)
+  }
+
+  const saveEditUser = async () => {
+    if (!editUser || !organizationId) {
+      return
+    }
+    setEditSaving(true)
+    setError("")
+    try {
+      await patchOrgUser(organizationId, editUser.id, {
+        display_name: editDisplay.trim() || null,
+        role: editRole,
+      })
+      setEditUser(null)
+      await reload()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not update user")
+    } finally {
+      setEditSaving(false)
+    }
+  }
 
   const openWorkspaceAccess = (u: OrgUserRow) => {
     setAccessUser(u)
@@ -285,11 +316,7 @@ export default function ManageUsersPage() {
                 <TableCell className="font-medium">{u.email}</TableCell>
                 <TableCell>{u.display_name ?? "—"}</TableCell>
                 <TableCell>
-                  <OrgRoleSelect
-                    orgId={orgId}
-                    user={u}
-                    onUpdated={reload}
-                  />
+                  {u.role === "org_admin" ? "Organization admin" : "Member"}
                 </TableCell>
                 <TableCell>
                   {u.disabled_at ? (
@@ -300,6 +327,18 @@ export default function ManageUsersPage() {
                 </TableCell>
                 <TableCell className="text-right align-middle">
                   <div className="flex flex-nowrap items-center justify-end gap-2">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="shrink-0 gap-1.5 max-lg:px-2.5"
+                      onClick={() => openEditUser(u)}
+                      title="Edit display name and role"
+                      aria-label={`Edit ${u.email}`}
+                    >
+                      <Pencil className="h-4 w-4 shrink-0" aria-hidden />
+                      <span className="hidden lg:inline">Edit</span>
+                    </Button>
                     <Button
                       type="button"
                       variant="outline"
@@ -338,30 +377,70 @@ export default function ManageUsersPage() {
                       <BookOpen className="h-4 w-4 shrink-0" aria-hidden />
                       <span className="hidden lg:inline">Stylebooks</span>
                     </Button>
-                    <Button
-                      type="button"
-                      variant="destructive"
-                      size="sm"
-                      className="shrink-0 gap-1.5 max-lg:px-2.5"
-                      disabled={!!u.disabled_at}
-                      aria-label={`Disable ${u.email}`}
-                      onClick={async () => {
-                        const ok = await showConfirm(
-                          `Disable ${u.email}? They will not be able to sign in.`,
-                          {
-                            title: "Disable user",
-                            confirmLabel: "Disable",
-                            destructive: true,
-                          },
-                        )
-                        if (!ok) return
-                        await disableOrgUser(orgId, u.id)
-                        await reload()
-                      }}
-                    >
-                      <UserX className="h-4 w-4 shrink-0" aria-hidden />
-                      <span className="hidden lg:inline">Disable</span>
-                    </Button>
+                    {u.disabled_at ? (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        className="shrink-0 gap-1.5 max-lg:px-2.5"
+                        aria-label={`Re-enable ${u.email}`}
+                        onClick={async () => {
+                          const ok = await showConfirm(
+                            `Re-enable ${u.email}? They will be able to sign in again.`,
+                            {
+                              title: "Re-enable user",
+                              confirmLabel: "Re-enable",
+                            },
+                          )
+                          if (!ok) return
+                          try {
+                            await enableOrgUser(orgId, u.id)
+                            await reload()
+                          } catch (e) {
+                            setError(
+                              e instanceof Error
+                                ? e.message
+                                : "Could not re-enable user",
+                            )
+                          }
+                        }}
+                      >
+                        <UserCheck className="h-4 w-4 shrink-0" aria-hidden />
+                        <span className="hidden lg:inline">Re-enable</span>
+                      </Button>
+                    ) : (
+                      <Button
+                        type="button"
+                        variant="destructive"
+                        size="sm"
+                        className="shrink-0 gap-1.5 max-lg:px-2.5"
+                        aria-label={`Disable ${u.email}`}
+                        onClick={async () => {
+                          const ok = await showConfirm(
+                            `Disable ${u.email}? They will not be able to sign in.`,
+                            {
+                              title: "Disable user",
+                              confirmLabel: "Disable",
+                              destructive: true,
+                            },
+                          )
+                          if (!ok) return
+                          try {
+                            await disableOrgUser(orgId, u.id)
+                            await reload()
+                          } catch (e) {
+                            setError(
+                              e instanceof Error
+                                ? e.message
+                                : "Could not disable user",
+                            )
+                          }
+                        }}
+                      >
+                        <UserX className="h-4 w-4 shrink-0" aria-hidden />
+                        <span className="hidden lg:inline">Disable</span>
+                      </Button>
+                    )}
                   </div>
                 </TableCell>
               </TableRow>
@@ -424,6 +503,73 @@ export default function ManageUsersPage() {
               onClick={() => void handleCreate().catch((e) => setError(String(e)))}
             >
               Create
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={!!editUser}
+        onOpenChange={(o) => {
+          if (!o) {
+            setEditUser(null)
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Edit user</DialogTitle>
+            <p className="text-sm text-muted-foreground">
+              Update the display name and organization role. Email cannot be
+              changed.
+            </p>
+          </DialogHeader>
+          <div className="space-y-3">
+            <div className="space-y-2">
+              <Label htmlFor="e-email">Email</Label>
+              <Input
+                id="e-email"
+                type="email"
+                value={editUser?.email ?? ""}
+                disabled
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="e-dn">Display name</Label>
+              <Input
+                id="e-dn"
+                value={editDisplay}
+                onChange={(e) => setEditDisplay(e.target.value)}
+                maxLength={200}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>Organization role</Label>
+              <Select value={editRole} onValueChange={setEditRole}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="member">Member</SelectItem>
+                  <SelectItem value="org_admin">Organization admin</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setEditUser(null)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              disabled={editSaving}
+              onClick={() => void saveEditUser()}
+            >
+              {editSaving ? "Saving…" : "Save"}
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -553,49 +699,5 @@ export default function ManageUsersPage() {
         </DialogContent>
       </Dialog>
     </div>
-  )
-}
-
-function OrgRoleSelect({
-  orgId,
-  user,
-  onUpdated,
-}: {
-  orgId: number
-  user: OrgUserRow
-  onUpdated: () => Promise<void>
-}) {
-  const { showError } = useAppMessage()
-  const [value, setValue] = useState(user.role)
-  const [saving, setSaving] = useState(false)
-
-  useEffect(() => {
-    setValue(user.role)
-  }, [user.id, user.role])
-
-  return (
-    <Select
-      value={value}
-      disabled={saving || !!user.disabled_at}
-      onValueChange={(v) => {
-        setValue(v)
-        setSaving(true)
-        void patchOrgUser(orgId, user.id, { role: v })
-          .then(() => onUpdated())
-          .catch((err) => {
-            setValue(user.role)
-            showError(err instanceof Error ? err.message : "Could not update role")
-          })
-          .finally(() => setSaving(false))
-      }}
-    >
-      <SelectTrigger className="w-[180px]">
-        <SelectValue />
-      </SelectTrigger>
-      <SelectContent>
-        <SelectItem value="member">Member</SelectItem>
-        <SelectItem value="org_admin">Organization admin</SelectItem>
-      </SelectContent>
-    </Select>
   )
 }

--- a/apps/core-api/src/core_api/routers/admin_org.py
+++ b/apps/core-api/src/core_api/routers/admin_org.py
@@ -100,6 +100,8 @@ class ProjectSummaryOut(BaseModel):
 class UserPatchBody(BaseModel):
     display_name: str | None = Field(default=None, max_length=200)
     role: OrgRole | None = None
+    # True disables; False re-enables; omit to leave status unchanged.
+    disabled: bool | None = None
 
 
 class MembershipRow(BaseModel):
@@ -716,7 +718,13 @@ def create_user(
     email = body.email
     existing = session.exec(select(BackfieldUser).where(BackfieldUser.email == email)).first()
     if existing:
-        raise HTTPException(status_code=409, detail="Email already registered")
+        detail = (
+            "Email already registered (including disabled accounts). "
+            "Edit or re-enable that user instead of creating a new one."
+            if existing.disabled_at is not None
+            else "Email already registered"
+        )
+        raise HTTPException(status_code=409, detail=detail)
     user = BackfieldUser(
         email=email,
         password_hash=hash_password(body.password),
@@ -751,6 +759,41 @@ def create_user(
     )
 
 
+def _apply_user_disabled_state(
+    *,
+    session: Session,
+    org_id: int,
+    user_id: int,
+    user: BackfieldUser,
+    mem: BackfieldOrganizationMembership,
+    caller_id: int | None,
+    disabled: bool,
+) -> None:
+    """Set or clear ``disabled_at`` with the same guards as soft-delete disable."""
+    if disabled:
+        if caller_id is not None and user_id == caller_id:
+            raise HTTPException(status_code=400, detail="Cannot disable your own account")
+        if str(mem.role) == "org_admin" and _is_only_active_org_admin(session, org_id, user_id):
+            raise HTTPException(
+                status_code=400,
+                detail="Cannot disable the last organization admin",
+            )
+        if user.disabled_at is None:
+            user.disabled_at = datetime.now(UTC)
+            session.add(user)
+        return
+    if user.disabled_at is not None:
+        user.disabled_at = None
+        session.add(user)
+
+
+def _caller_user_id(auth: dict) -> int | None:
+    user = auth.get("user")
+    if user is None:
+        return None
+    return int(user.id)
+
+
 @router.patch("/{org_id}/users/{user_id}", response_model=UserOut)
 def patch_user(
     org_id: int,
@@ -767,7 +810,8 @@ def patch_user(
     if user is None:
         raise HTTPException(status_code=404, detail="User not found")
 
-    if body.role is None and body.display_name is None:
+    fields_set = body.model_fields_set
+    if not fields_set:
         session.refresh(user)
         session.refresh(mem)
         return UserOut(
@@ -780,7 +824,7 @@ def patch_user(
             workspace_memberships=None,
         )
 
-    if body.role is not None:
+    if "role" in fields_set and body.role is not None:
         new_role = body.role
         if str(mem.role) == "org_admin" and new_role == "member":
             if _is_only_active_org_admin(session, org_id, user_id):
@@ -791,9 +835,21 @@ def patch_user(
         mem.role = str(new_role)
         session.add(mem)
 
-    if body.display_name is not None:
-        user.display_name = body.display_name
+    if "display_name" in fields_set:
+        raw = body.display_name
+        user.display_name = (raw.strip() if isinstance(raw, str) else None) or None
         session.add(user)
+
+    if "disabled" in fields_set and body.disabled is not None:
+        _apply_user_disabled_state(
+            session=session,
+            org_id=org_id,
+            user_id=user_id,
+            user=user,
+            mem=mem,
+            caller_id=_caller_user_id(auth),
+            disabled=body.disabled,
+        )
 
     session.commit()
     session.refresh(user)
@@ -817,19 +873,21 @@ def disable_user(
     auth: dict = Depends(get_auth),
 ) -> dict[str, bool]:
     require_org_admin(session, auth, org_id)
-    caller_id = int(auth["user"].id)
-    if user_id == caller_id:
-        raise HTTPException(status_code=400, detail="Cannot disable your own account")
     mem = _membership_for_user_org(session, org_id, user_id)
     if mem is None:
         raise HTTPException(status_code=404, detail="User not in organization")
-    if str(mem.role) == "org_admin" and _is_only_active_org_admin(session, org_id, user_id):
-        raise HTTPException(status_code=400, detail="Cannot disable the last organization admin")
     user = session.get(BackfieldUser, user_id)
     if user is None:
         raise HTTPException(status_code=404, detail="User not found")
-    user.disabled_at = datetime.now(UTC)
-    session.add(user)
+    _apply_user_disabled_state(
+        session=session,
+        org_id=org_id,
+        user_id=user_id,
+        user=user,
+        mem=mem,
+        caller_id=_caller_user_id(auth),
+        disabled=True,
+    )
     session.commit()
     return {"ok": True}
 

--- a/apps/stylebook-api/src/stylebook_api/entities/location/locations.py
+++ b/apps/stylebook-api/src/stylebook_api/entities/location/locations.py
@@ -400,6 +400,11 @@ class LinkCanonicalResponse(BaseModel):
     changed: bool
 
 
+class UnlinkCanonicalResponse(BaseModel):
+    message: str
+    canonical_pruned: bool
+
+
 @router.post("/locations/{location_id}/unlink-canonical")
 def unlink_substrate_from_canonical_route(
     location_id: int,
@@ -407,7 +412,7 @@ def unlink_substrate_from_canonical_route(
     stylebook_slug: StylebookSlugQuery = None,
     session: Session = Depends(get_session),
     auth: dict[str, Any] = Depends(get_auth),
-) -> dict[str, str]:
+) -> UnlinkCanonicalResponse:
     proj = _project_by_slug(session, project_slug)
     require_project_access(session, auth, int(proj.id))
     stylebook_id = _require_stylebook_id(session, proj, stylebook_slug)
@@ -424,7 +429,7 @@ def unlink_substrate_from_canonical_route(
     )
     stylebook_id = int(guarded_stylebook.id)
     try:
-        unlink_substrate_from_canonical(
+        canonical_pruned = unlink_substrate_from_canonical(
             session, stylebook_id=stylebook_id, location=loc, provenance="stylebook_ui_unlink"
         )
     except ValueError as e:
@@ -436,7 +441,7 @@ def unlink_substrate_from_canonical_route(
         entity_type="location",
         entity_id=location_id,
     )
-    return {"message": "unlinked"}
+    return UnlinkCanonicalResponse(message="unlinked", canonical_pruned=canonical_pruned)
 
 
 @router.post("/locations/{location_id}/link-canonical", response_model=LinkCanonicalResponse)

--- a/apps/stylebook-api/src/stylebook_api/entities/organization/organizations.py
+++ b/apps/stylebook-api/src/stylebook_api/entities/organization/organizations.py
@@ -63,6 +63,11 @@ class LinkCanonicalResponse(BaseModel):
     changed: bool
 
 
+class UnlinkCanonicalResponse(BaseModel):
+    message: str
+    canonical_pruned: bool
+
+
 def _manual_organization_type(value: str | None) -> str | None:
     return normalize_organization_type(value)
 
@@ -74,7 +79,7 @@ def unlink_substrate_from_canonical_route(
     stylebook_slug: StylebookSlugQuery = None,
     session: Session = Depends(get_session),
     auth: dict[str, Any] = Depends(get_auth),
-) -> dict[str, str]:
+) -> UnlinkCanonicalResponse:
     proj = _project_by_slug(session, project_slug)
     require_project_access(session, auth, int(proj.id))
     stylebook_id = _require_stylebook_id(session, proj, stylebook_slug)
@@ -91,7 +96,7 @@ def unlink_substrate_from_canonical_route(
     )
     stylebook_id = int(guarded_stylebook.id)
     try:
-        unlink_substrate_from_canonical(
+        canonical_pruned = unlink_substrate_from_canonical(
             session,
             stylebook_id=stylebook_id,
             organization=organization,
@@ -100,7 +105,7 @@ def unlink_substrate_from_canonical_route(
     except ValueError as e:
         raise HTTPException(status_code=409, detail=str(e)) from e
     session.commit()
-    return {"message": "unlinked"}
+    return UnlinkCanonicalResponse(message="unlinked", canonical_pruned=canonical_pruned)
 
 
 @router.post(

--- a/apps/stylebook-api/src/stylebook_api/entities/person/people.py
+++ b/apps/stylebook-api/src/stylebook_api/entities/person/people.py
@@ -70,6 +70,11 @@ class LinkCanonicalResponse(BaseModel):
     changed: bool
 
 
+class UnlinkCanonicalResponse(BaseModel):
+    message: str
+    canonical_pruned: bool
+
+
 def _manual_person_type(value: str | None) -> str | None:
     """Normalize manual UI/API ``person_type`` to the bounded taxonomy."""
     return normalize_person_type(value)
@@ -82,7 +87,7 @@ def unlink_substrate_from_canonical_route(
     stylebook_slug: StylebookSlugQuery = None,
     session: Session = Depends(get_session),
     auth: dict[str, Any] = Depends(get_auth),
-) -> dict[str, str]:
+) -> UnlinkCanonicalResponse:
     proj = _project_by_slug(session, project_slug)
     require_project_access(session, auth, int(proj.id))
     stylebook_id = _require_stylebook_id(session, proj, stylebook_slug)
@@ -99,7 +104,7 @@ def unlink_substrate_from_canonical_route(
     )
     stylebook_id = int(guarded_stylebook.id)
     try:
-        unlink_substrate_from_canonical(
+        canonical_pruned = unlink_substrate_from_canonical(
             session, stylebook_id=stylebook_id, person=person, provenance="stylebook_ui_unlink"
         )
     except ValueError as e:
@@ -111,7 +116,7 @@ def unlink_substrate_from_canonical_route(
         entity_type="person",
         entity_id=person_id,
     )
-    return {"message": "unlinked"}
+    return UnlinkCanonicalResponse(message="unlinked", canonical_pruned=canonical_pruned)
 
 
 @router.post("/people/{person_id}/link-canonical", response_model=LinkCanonicalResponse)

--- a/apps/stylebook-ui/src/lib/stylebook-api/client.ts
+++ b/apps/stylebook-ui/src/lib/stylebook-api/client.ts
@@ -82,6 +82,15 @@ export function isStylebookApiNotFoundError(error: unknown): boolean {
   return error instanceof StylebookApiError && error.status === 404
 }
 
+export type UnlinkCanonicalResult = {
+  message: string
+  canonical_pruned: boolean
+}
+
+function looksLikeHtml(contentType: string, body: string): boolean {
+  return contentType.includes("text/html") || /^\s*</.test(body)
+}
+
 export async function stylebookJsonFetch<T>(path: string, init?: RequestInit): Promise<T> {
   const resolvedPath = augmentStylebookApiPath(path)
   const response = await handleTenantResponse(await fetch(`${stylebookApiBase()}${resolvedPath}`, {
@@ -92,8 +101,9 @@ export async function stylebookJsonFetch<T>(path: string, init?: RequestInit): P
     },
     credentials: "include",
   }))
+  const errorText = await response.text()
+  const contentType = response.headers.get("content-type") ?? ""
   if (!response.ok) {
-    const errorText = await response.text()
     let errorMessage = `API error: ${response.statusText}`
     try {
       const errorJson = JSON.parse(errorText) as { detail?: unknown }
@@ -106,5 +116,13 @@ export async function stylebookJsonFetch<T>(path: string, init?: RequestInit): P
     }
     throw new StylebookApiError(response.status, errorMessage)
   }
-  return response.json() as Promise<T>
+  // CloudFront SPA fallback can rewrite API 404/403 to 200 + index.html.
+  if (looksLikeHtml(contentType, errorText)) {
+    throw new StylebookApiError(404, "This record is no longer available.")
+  }
+  try {
+    return JSON.parse(errorText) as T
+  } catch {
+    throw new StylebookApiError(response.status, "The server returned an unexpected response.")
+  }
 }

--- a/apps/stylebook-ui/src/lib/stylebook-api/locations.ts
+++ b/apps/stylebook-ui/src/lib/stylebook-api/locations.ts
@@ -1,4 +1,4 @@
-import { stylebookJsonFetch } from "@/lib/stylebook-api/client"
+import { stylebookJsonFetch, type UnlinkCanonicalResult } from "@/lib/stylebook-api/client"
 
 export interface Location {
   id: number
@@ -168,8 +168,8 @@ export async function listCanonicalLinkedSubstrates(
 export async function unlinkSubstrateFromCanonical(
   substrateLocationId: number,
   projectSlug: string,
-): Promise<{ message: string }> {
-  return stylebookJsonFetch<{ message: string }>(
+): Promise<UnlinkCanonicalResult> {
+  return stylebookJsonFetch<UnlinkCanonicalResult>(
     `/v1/locations/${substrateLocationId}/unlink-canonical?project_slug=${encodeURIComponent(projectSlug)}`,
     { method: "POST" },
   )

--- a/apps/stylebook-ui/src/lib/stylebook-api/organizations.ts
+++ b/apps/stylebook-ui/src/lib/stylebook-api/organizations.ts
@@ -1,4 +1,4 @@
-import { stylebookJsonFetch } from "@/lib/stylebook-api/client"
+import { stylebookJsonFetch, type UnlinkCanonicalResult } from "@/lib/stylebook-api/client"
 
 /** One ``stylebook_organization_canonical`` row (Stylebook catalog), not a substrate organization. */
 export interface CanonicalOrganization {
@@ -174,8 +174,8 @@ export async function getCanonicalOrganizationMentions(
 export async function unlinkOrganizationSubstrateFromCanonical(
   substrateOrganizationId: number,
   projectSlug: string,
-): Promise<{ message: string }> {
-  return stylebookJsonFetch<{ message: string }>(
+): Promise<UnlinkCanonicalResult> {
+  return stylebookJsonFetch<UnlinkCanonicalResult>(
     `/v1/organizations/${substrateOrganizationId}/unlink-canonical?project_slug=${encodeURIComponent(projectSlug)}`,
     { method: "POST" },
   )

--- a/apps/stylebook-ui/src/lib/stylebook-api/people.ts
+++ b/apps/stylebook-ui/src/lib/stylebook-api/people.ts
@@ -1,4 +1,4 @@
-import { stylebookJsonFetch } from "@/lib/stylebook-api/client"
+import { stylebookJsonFetch, type UnlinkCanonicalResult } from "@/lib/stylebook-api/client"
 
 /** One ``stylebook_person_canonical`` row (Stylebook catalog), not a substrate person. */
 export interface CanonicalPerson {
@@ -196,8 +196,8 @@ export async function getCanonicalPersonMentions(
 export async function unlinkPersonSubstrateFromCanonical(
   substratePersonId: number,
   projectSlug: string,
-): Promise<{ message: string }> {
-  return stylebookJsonFetch<{ message: string }>(
+): Promise<UnlinkCanonicalResult> {
+  return stylebookJsonFetch<UnlinkCanonicalResult>(
     `/v1/people/${substratePersonId}/unlink-canonical?project_slug=${encodeURIComponent(projectSlug)}`,
     { method: "POST" },
   )

--- a/apps/stylebook-ui/src/pages/LocationDetail.tsx
+++ b/apps/stylebook-ui/src/pages/LocationDetail.tsx
@@ -240,7 +240,12 @@ export default function LocationDetail() {
     }
     setUnlinkingId(sub.id)
     try {
-      await unlinkSubstrateFromCanonical(sub.id, sub.project_slug)
+      const result = await unlinkSubstrateFromCanonical(sub.id, sub.project_slug)
+      if (result.canonical_pruned) {
+        setDeleting(true)
+        navigate(canonicalListHref)
+        return
+      }
       setSubstrates((prev) => prev.filter((item) => item.id !== sub.id))
       setCanonical((prev) =>
         prev

--- a/apps/stylebook-ui/src/pages/OrganizationDetail.tsx
+++ b/apps/stylebook-ui/src/pages/OrganizationDetail.tsx
@@ -217,7 +217,12 @@ export default function OrganizationDetail() {
     }
     setUnlinkingId(sub.id)
     try {
-      await unlinkOrganizationSubstrateFromCanonical(sub.id, sub.project_slug)
+      const result = await unlinkOrganizationSubstrateFromCanonical(sub.id, sub.project_slug)
+      if (result.canonical_pruned) {
+        setDeleting(true)
+        navigate(canonicalListHref)
+        return
+      }
       setSubstrates((prev) => prev.filter((item) => item.id !== sub.id))
       setOrganization((prev) =>
         prev

--- a/apps/stylebook-ui/src/pages/PersonDetail.tsx
+++ b/apps/stylebook-ui/src/pages/PersonDetail.tsx
@@ -233,7 +233,12 @@ export default function PersonDetail() {
     }
     setUnlinkingId(sub.id)
     try {
-      await unlinkPersonSubstrateFromCanonical(sub.id, sub.project_slug)
+      const result = await unlinkPersonSubstrateFromCanonical(sub.id, sub.project_slug)
+      if (result.canonical_pruned) {
+        setDeleting(true)
+        navigate(canonicalListHref)
+        return
+      }
       setSubstrates((prev) => prev.filter((item) => item.id !== sub.id))
       setPerson((prev) =>
         prev

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -59,7 +59,7 @@ Routes under `/v1/organizations/{org_id}` manage:
 - workspaces and their assigned Stylebooks;
 - users, roles, and workspace or explicit project memberships.
 
-Workspace membership replacement endpoints treat the submitted collection as the complete desired state. User disable and role changes protect the current user and the last organization administrator.
+Workspace membership replacement endpoints treat the submitted collection as the complete desired state. User disable and role changes protect the current user and the last organization administrator. Soft-disabled accounts keep their email reserved; organization admins can edit display name and role, and re-enable a user with `PATCH /v1/organizations/{org_id}/users/{user_id}` (`disabled: false`) instead of creating a duplicate account.
 
 Workspace deletion is organization-admin only. `GET /v1/organizations/{org_id}/workspaces/{workspace_id}/delete-preview` returns rollup counts plus per-project tallies. `POST /v1/organizations/{org_id}/workspaces/{workspace_id}/delete` requires `{ "confirm_name": "<exact workspace name>" }`, runs the same project teardown for every project in the workspace, then deletes the workspace and its memberships. Shared Stylebook canonicals for the organization are kept.
 

--- a/docs/api/stylebook.md
+++ b/docs/api/stylebook.md
@@ -63,7 +63,7 @@ Project-scoped saved entity routes manage article evidence before or after a can
 - `/v1/people` and `/v1/people/candidates`
 - `/v1/organizations` and `/v1/organizations/candidates`
 
-Saved entities can be inspected, edited, linked or unlinked from a canonical, and removed from an article. Article-evidence create routes for each current domain validate selected quote offsets and create the saved entity, mention, and first occurrence together.
+Saved entities can be inspected, edited, linked or unlinked from a canonical, and removed from an article. Unlink responses include ``canonical_pruned`` when the last linked saved entity caused an ingest-only catalog row to be removed. Article-evidence create routes for each current domain validate selected quote offsets and create the saved entity, mention, and first occurrence together.
 
 Candidate queues support open and deferred review, notes, context, suggested canonicals,
 recommendation clearing, acceptance into a new or existing canonical, and type facets. Existing

--- a/docs/architecture/canonicalization.md
+++ b/docs/architecture/canonicalization.md
@@ -109,7 +109,9 @@ array: omitted machine associations and their system-extraction occurrences are 
 editor-added, editor-modified, and non-extraction associations remain. Shared substrate identities
 remain available to other articles; true orphans are unlinked and removed. When the last linked
 substrate for an ingest-only location, person, or organization canonical is disposed or unlinked,
-that empty catalog shell is pruned (manual, CSV, bundle, and review-queue rows stay). `smart_merge`
+that empty catalog shell is pruned (manual, CSV, bundle, and review-queue rows stay). Stylebook
+unlink responses report that prune as ``canonical_pruned`` so the catalog UI can leave the detail
+page instead of refetching a row that no longer exists. `smart_merge`
 and `add_only` retain their non-authoritative behavior.
 
 Occurrence offsets are optional evidence, not best-effort guesses. Ingest stores `start_char` and

--- a/docs/development/frontend/agate.md
+++ b/docs/development/frontend/agate.md
@@ -138,7 +138,9 @@ can sync reviewed S3 Output content back to its object.
   `workspace_stylebook_*` fields describe the workspace, not the project, and must not be used
   as a catalog target.
 - Organization administrators use the Settings hub for AI models, integrations,
-  users, and Stylebooks.
+  users, and Stylebooks. On Users (`/admin/users`), admins can edit display name
+  and role, soft-disable accounts, and re-enable them (emails stay reserved while
+  disabled, so recreate is not used).
 - Current settings routes are `/settings/models` and `/settings/integrations`.
   Compatibility redirects remain active from `/admin/ai-models` and
   `/admin/integrations`.

--- a/docs/development/nodes.md
+++ b/docs/development/nodes.md
@@ -253,6 +253,12 @@ context window (8,000-token fallback when metadata is unknown) and fail with gui
 to add Document Chunker. Article Metadata and Embed Text keep whole-document outputs
 but truncate prompt/embedding body input safely.
 
+GPT-5.6 extract completions (`gpt-5.6`, Sol, Terra, Luna) always send
+`reasoning_effort=none` and an explicit completion budget (default 8,192 tokens,
+retried once if the JSON is empty or truncated). Do not fall back to `minimal`; 5.6
+does not support it. Other GPT-5 models still pick the lowest LiteLLM-supported
+effort (`none`, then `minimal`).
+
 ## Canvas components
 
 `ui/NodeComponent.tsx` uses React Flow `NodeProps`, normally wrapped in `memo`.

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -78,7 +78,9 @@ Vite loads each app's `.env.production`. The default browser paths are:
 - `/api/stylebook` for Stylebook API
 
 The origin or CDN must route those paths to the matching API and serve `index.html` as the SPA
-fallback. When the API receives a forwarded prefix rather than a stripped path, set
+fallback for document routes only. Do not rewrite API `404`/`403` responses to `index.html`
+(CloudFront custom error responses apply to every origin, including `/api/*` and `/v1/*`).
+When the API receives a forwarded prefix rather than a stripped path, set
 `BACKFIELD_HTTP_PATH_PREFIX` on that API.
 
 Deploy the API Playground at `playground.{organization-slug}.backfield.news`. Configure wildcard

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -84,6 +84,15 @@ BACKFIELD_PARALLEL_GRAPH_LEVELS=0
 
 This serializes nodes within each item; it does not change concurrency across different batch items.
 
+## Extract nodes fail with truncated JSON
+
+Person, Organization, and Place Extract can fail with `Unterminated string` or similar
+JSON parse errors when a GPT-5.6 model (Terra/Luna especially) spends the completion
+budget on hidden reasoning and returns a half-written object. Backfield forces
+`reasoning_effort=none` and an explicit `max_completion_tokens` for `gpt-5.6*` and
+retries once when the JSON is truncated. If failures persist, add Document Chunker or
+switch the extract node to GPT-5.5.
+
 ## Provider or secret errors
 
 - Verify `MASTER_ENCRYPTION_KEY` is the same non-empty value on all APIs and the worker.

--- a/packages/backfield-agate/src/agate_utils/llm.py
+++ b/packages/backfield-agate/src/agate_utils/llm.py
@@ -132,7 +132,8 @@ def call_llm(
         max_retries: Maximum number of retry attempts (default: 3)
         temperature: Temperature for generation (default: 0.0)
         max_tokens: Optional max completion tokens. Default None omits the parameter so OpenAI /
-            LiteLLM use the model/provider default (recommended). Required only when you need an
+            LiteLLM use the model/provider default (recommended), except GPT-5.6 models which
+            receive an explicit budget in ``completion_text_sync``. Required only when you need an
             explicit cap; legacy Anthropic direct calls use ANTHROPIC_MESSAGES_MAX_TOKENS_FALLBACK.
         openai_api_key: OpenAI API key (required for OpenAI models)
         anthropic_api_key: Anthropic API key (required for Anthropic models)

--- a/packages/backfield-ai/src/backfield_ai/completion.py
+++ b/packages/backfield-ai/src/backfield_ai/completion.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import time
 from dataclasses import dataclass
@@ -11,11 +12,15 @@ from typing import Any
 import litellm
 
 from backfield_ai.cost_estimate import litellm_estimated_cost_from_response
+from backfield_ai.json_clean import clean_json_response_text
 
 logger = logging.getLogger(__name__)
 
 # Upper bound when bumping an explicit ``max_tokens`` after empty JSON + finish_reason=length.
 _MAX_OUTPUT_RETRY_CEILING = 1_048_576
+# GPT-5.6 omits a usable provider default for visible JSON; LiteLLM remaps this to
+# ``max_completion_tokens`` (visible + reasoning tokens).
+_GPT56_DEFAULT_MAX_COMPLETION_TOKENS = 8192
 
 
 @dataclass(frozen=True)
@@ -190,11 +195,71 @@ def _litellm_completion_temperature(
     return temperature
 
 
+def _is_gpt56_family(litellm_model: str) -> bool:
+    """True for ``gpt-5.6`` and named variants (sol / terra / luna)."""
+    return _provider_model_id_from_litellm(litellm_model).startswith("gpt-5.6")
+
+
+def _assistant_json_is_parseable(text: str) -> bool:
+    """Whether assistant text is parseable JSON after fence stripping."""
+    candidate = clean_json_response_text(text)
+    if not candidate:
+        return False
+    try:
+        json.loads(candidate)
+    except json.JSONDecodeError:
+        return False
+    return True
+
+
+def _effective_max_tokens(litellm_model: str, max_tokens: int | None) -> int | None:
+    """Caller cap, or a GPT-5.6 default so JSON extract is not left uncapped."""
+    if max_tokens is not None:
+        return max_tokens
+    if _is_gpt56_family(litellm_model):
+        return _GPT56_DEFAULT_MAX_COMPLETION_TOKENS
+    return None
+
+
+def _bumped_max_tokens(current: int) -> int | None:
+    bumped = min(max(current * 2, 8192), _MAX_OUTPUT_RETRY_CEILING)
+    if bumped <= current:
+        return None
+    return bumped
+
+
+def _needs_output_budget_retry(
+    *,
+    text: str,
+    finish: str | None,
+    force_json_response: bool,
+    litellm_model: str,
+) -> bool:
+    """Retry once when the model spent the budget before usable JSON arrived."""
+    if text == "" and finish == "length":
+        return True
+    if (
+        _is_gpt56_family(litellm_model)
+        and force_json_response
+        and text != ""
+        and not _assistant_json_is_parseable(text)
+    ):
+        return True
+    return False
+
+
 def _gpt5_reasoning_effort_for_simple_completion(litellm_model: str) -> str | None:
-    """Use the lowest supported reasoning setting so short completions emit visible text."""
+    """Use the lowest supported reasoning setting so short completions emit visible text.
+
+    GPT-5.6 supports ``none`` and does not support ``minimal``. Force ``none`` even when
+    LiteLLM's model map is missing or stale, so extract/JSON calls do not spend the
+    completion budget on hidden reasoning.
+    """
     model_id = _provider_model_id_from_litellm(litellm_model)
     if not model_id.startswith("gpt-5"):
         return None
+    if _is_gpt56_family(litellm_model):
+        return "none"
     try:
         from litellm.llms.openai.chat.gpt_5_transformation import OpenAIGPT5Config
 
@@ -234,8 +299,10 @@ def completion_text_sync(
 ) -> LiteLLMCompletionResult:
     """Single LiteLLM completion (no Backfield-level retries here).
 
-    When ``max_tokens`` is None, it is omitted so the provider applies model defaults (recommended
-    for OpenAI to avoid caps below the model maximum).
+    When ``max_tokens`` is None, it is omitted so the provider applies model defaults
+    (recommended for most OpenAI models). GPT-5.6 is the exception: those models get an
+    explicit completion budget so JSON extract is not truncated by hidden reasoning.
+    LiteLLM remaps ``max_tokens`` to ``max_completion_tokens`` for the GPT-5 family.
     """
     kwargs: dict[str, Any] = {
         "model": litellm_model,
@@ -243,8 +310,9 @@ def completion_text_sync(
         "timeout": timeout,
         "num_retries": 0,
     }
-    if max_tokens is not None:
-        kwargs["max_tokens"] = max_tokens
+    effective_max_tokens = _effective_max_tokens(litellm_model, max_tokens)
+    if effective_max_tokens is not None:
+        kwargs["max_tokens"] = effective_max_tokens
     if api_key:
         kwargs["api_key"] = api_key
     if api_base and str(api_base).strip():
@@ -292,21 +360,26 @@ def completion_text_sync(
         )
 
     # Reasoning models can exhaust max_completion_tokens on hidden reasoning before any
-    # visible assistant text is emitted. Retry once with a larger cap when that happens.
-    if (
-        allow_max_tokens_bump
-        and text == ""
-        and finish == "length"
+    # visible assistant text is emitted. GPT-5.6 can also stop with truncated nonempty
+    # JSON. Retry once with a larger cap when that happens.
+    if allow_max_tokens_bump and _needs_output_budget_retry(
+        text=text,
+        finish=finish,
+        force_json_response=force_json_response,
+        litellm_model=litellm_model,
     ):
         current = kwargs.get("max_tokens")
         if current is not None:
             current_cap = int(current)
-            bumped = min(max(current_cap * 2, 8192), _MAX_OUTPUT_RETRY_CEILING)
-            if bumped > current_cap:
+            bumped = _bumped_max_tokens(current_cap)
+            if bumped is not None:
                 logger.info(
-                    "LiteLLM empty output + finish_reason=length; retry max_tokens=%s (was %s)",
+                    "LiteLLM unusable JSON output; retry max_tokens=%s (was %s, "
+                    "finish_reason=%s, empty=%s)",
                     bumped,
                     current_cap,
+                    finish,
+                    text == "",
                 )
                 kwargs["max_tokens"] = bumped
                 resp = litellm.completion(**kwargs)
@@ -345,6 +418,31 @@ def completion_text_sync(
             "If finish_reason is 'length', the completion budget was exhausted before any JSON was "
             "emitted—shorten the input or pass a higher explicit max_tokens if your provider "
             "requires one.",
+            result=partial,
+        )
+
+    if (
+        force_json_response
+        and _is_gpt56_family(litellm_model)
+        and text != ""
+        and not _assistant_json_is_parseable(text)
+    ):
+        prompt_chars = sum(len(str(m.get("content", ""))) for m in messages)
+        mt_display = kwargs.get("max_tokens")
+        if mt_display is None:
+            mt_display = "omitted (provider default)"
+        preview = text[:400]
+        partial = _build_completion_result(
+            resp=resp,
+            litellm_model=litellm_model,
+            text=text,
+            latency_ms=latency_ms,
+        )
+        raise LiteLLMCompletionRejectedError(
+            "LiteLLM returned truncated or invalid JSON while JSON output was required "
+            f"(model={litellm_model!r}, finish_reason={finish!r}, "
+            f"max_tokens={mt_display}, approx_prompt_chars={prompt_chars}, "
+            f"preview={preview!r}).",
             result=partial,
         )
 

--- a/packages/backfield-entities/src/backfield_entities/entities/linking/substrate_actions.py
+++ b/packages/backfield-entities/src/backfield_entities/entities/linking/substrate_actions.py
@@ -126,11 +126,12 @@ def unlink_substrate_from_canonical(
     location: SubstrateLocation,
     provenance: str = "stylebook_ui_unlink",
     requeue_after_unlink: bool = True,
-) -> None:
+) -> bool:
     """Clear canonical FK; remove matching alias on old canonical when safe.
 
     When ``requeue_after_unlink`` is true (default), set ``pending`` for the open candidate
     queue. When false, set ``unlinked`` so the row stays out of the queue (story-only remove).
+    Returns True when the leftover ingest-only canonical was pruned.
     """
     if location.id is None:
         raise ValueError("location must be persisted")
@@ -171,7 +172,7 @@ def unlink_substrate_from_canonical(
         label=str(canon.label),
         change="substrate_unlinked",
     )
-    maybe_prune_ingest_orphan_location_canonical(
+    return maybe_prune_ingest_orphan_location_canonical(
         session,
         stylebook_id=stylebook_id,
         canonical_id=old,

--- a/packages/backfield-entities/src/backfield_entities/entities/organization/persist.py
+++ b/packages/backfield-entities/src/backfield_entities/entities/organization/persist.py
@@ -808,7 +808,8 @@ def unlink_substrate_from_canonical(
     organization: SubstrateOrganization,
     provenance: str = "stylebook_ui_unlink",
     requeue_after_unlink: bool = True,
-) -> None:
+) -> bool:
+    """Return True when the leftover ingest-only canonical was pruned."""
     if organization.id is None:
         raise ValueError("organization must be persisted")
     if str(organization.canonical_link_status) != CANONICAL_LINK_LINKED:
@@ -847,7 +848,7 @@ def unlink_substrate_from_canonical(
         label=str(canon.label),
         change="substrate_unlinked",
     )
-    maybe_prune_ingest_orphan_organization_canonical(
+    return maybe_prune_ingest_orphan_organization_canonical(
         session,
         stylebook_id=stylebook_id,
         canonical_id=old,

--- a/packages/backfield-entities/src/backfield_entities/entities/person/persist.py
+++ b/packages/backfield-entities/src/backfield_entities/entities/person/persist.py
@@ -807,7 +807,8 @@ def unlink_substrate_from_canonical(
     person: SubstratePerson,
     provenance: str = "stylebook_ui_unlink",
     requeue_after_unlink: bool = True,
-) -> None:
+) -> bool:
+    """Return True when the leftover ingest-only canonical was pruned."""
     if person.id is None:
         raise ValueError("person must be persisted")
     if str(person.canonical_link_status) != CANONICAL_LINK_LINKED:
@@ -846,7 +847,7 @@ def unlink_substrate_from_canonical(
         label=str(canon.label),
         change="substrate_unlinked",
     )
-    maybe_prune_ingest_orphan_person_canonical(
+    return maybe_prune_ingest_orphan_person_canonical(
         session,
         stylebook_id=stylebook_id,
         canonical_id=old,

--- a/tests/backfield_ai/test_completion_helpers.py
+++ b/tests/backfield_ai/test_completion_helpers.py
@@ -5,8 +5,12 @@ from __future__ import annotations
 import litellm
 import pytest
 from backfield_ai.completion import (
+    _GPT56_DEFAULT_MAX_COMPLETION_TOKENS,
     LiteLLMCompletionRejectedError,
+    _assistant_json_is_parseable,
     _extract_message_content_text,
+    _gpt5_reasoning_effort_for_simple_completion,
+    _is_gpt56_family,
     _litellm_completion_temperature,
     _litellm_json_object_response_format_supported,
     completion_text_sync,
@@ -83,6 +87,160 @@ def test_completion_text_sync_omits_temperature_for_gpt5(
 
     assert "temperature" not in captured
     assert captured.get("reasoning_effort") == "minimal"
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "gpt-5.6",
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
+        "gpt-5.6-luna",
+        "openai/gpt-5.6-terra",
+    ],
+)
+def test_gpt56_family_forces_reasoning_effort_none(model: str) -> None:
+    assert _is_gpt56_family(model) is True
+    assert _gpt5_reasoning_effort_for_simple_completion(model) == "none"
+
+
+def test_gpt55_is_not_gpt56_family() -> None:
+    assert _is_gpt56_family("gpt-5.5") is False
+    assert _is_gpt56_family("openai/gpt-5.5") is False
+
+
+def test_assistant_json_is_parseable() -> None:
+    assert _assistant_json_is_parseable('{"people":[]}') is True
+    assert _assistant_json_is_parseable('```json\n{"people":[]}\n```') is True
+    assert _assistant_json_is_parseable('{"people":[{"n":"Robert Kopp","m":"Kopp') is False
+    assert _assistant_json_is_parseable("") is False
+
+
+def _ok_resp(content: str, finish_reason: str = "stop") -> object:
+    class Msg:
+        refusal = None
+
+        def __init__(self, text: str) -> None:
+            self.content = text
+
+    class Choice:
+        def __init__(self, text: str, finish: str) -> None:
+            self.message = Msg(text)
+            self.finish_reason = finish
+
+    class Resp:
+        def __init__(self, text: str, finish: str) -> None:
+            self.choices = [Choice(text, finish)]
+            self.usage = {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+
+    return Resp(content, finish_reason)
+
+
+def test_completion_text_sync_gpt56_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_completion(**kwargs: object) -> object:
+        captured.update(kwargs)
+        return _ok_resp('{"people":[]}')
+
+    monkeypatch.setattr(litellm, "completion", fake_completion)
+    monkeypatch.setattr(litellm, "completion_cost", lambda **_kw: 0.0)
+
+    completion_text_sync(
+        litellm_model="gpt-5.6-terra",
+        messages=[{"role": "user", "content": "hi"}],
+        api_key="sk-test",
+        max_tokens=None,
+        temperature=None,
+        timeout=30.0,
+        force_json_response=True,
+    )
+
+    assert captured.get("reasoning_effort") == "none"
+    assert captured.get("max_tokens") == _GPT56_DEFAULT_MAX_COMPLETION_TOKENS
+    assert captured.get("response_format") == {"type": "json_object"}
+
+
+def test_completion_text_sync_omits_max_tokens_for_non_gpt56(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_completion(**kwargs: object) -> object:
+        captured.update(kwargs)
+        return _ok_resp("ok")
+
+    monkeypatch.setattr(litellm, "completion", fake_completion)
+    monkeypatch.setattr(litellm, "completion_cost", lambda **_kw: 0.0)
+
+    completion_text_sync(
+        litellm_model="gpt-4o-mini",
+        messages=[{"role": "user", "content": "hi"}],
+        api_key="sk-test",
+        max_tokens=None,
+        temperature=0.0,
+        timeout=30.0,
+        force_json_response=False,
+    )
+
+    assert "max_tokens" not in captured
+
+
+def test_completion_text_sync_gpt56_retries_truncated_json(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict[str, object]] = []
+
+    def fake_completion(**kwargs: object) -> object:
+        calls.append(dict(kwargs))
+        if len(calls) == 1:
+            return _ok_resp('{"people":[{"n":"Robert Kopp","m":"Kopp', "stop")
+        return _ok_resp('{"people":[]}')
+
+    monkeypatch.setattr(litellm, "completion", fake_completion)
+    monkeypatch.setattr(litellm, "completion_cost", lambda **_kw: 0.0)
+
+    result = completion_text_sync(
+        litellm_model="openai/gpt-5.6-luna",
+        messages=[{"role": "user", "content": "hi"}],
+        api_key="sk-test",
+        max_tokens=None,
+        temperature=None,
+        timeout=30.0,
+        force_json_response=True,
+    )
+
+    assert result.text == '{"people":[]}'
+    assert len(calls) == 2
+    assert calls[0]["max_tokens"] == _GPT56_DEFAULT_MAX_COMPLETION_TOKENS
+    assert calls[1]["max_tokens"] == _GPT56_DEFAULT_MAX_COMPLETION_TOKENS * 2
+    assert calls[0]["reasoning_effort"] == "none"
+    assert calls[1]["reasoning_effort"] == "none"
+
+
+def test_completion_text_sync_gpt56_rejects_truncated_json_after_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_completion(**kwargs: object) -> object:
+        return _ok_resp('{"people":[{"n":"Robert Kopp","m":"Kopp')
+
+    monkeypatch.setattr(litellm, "completion", fake_completion)
+    monkeypatch.setattr(litellm, "completion_cost", lambda **_kw: 0.0)
+
+    with pytest.raises(LiteLLMCompletionRejectedError) as ctx:
+        completion_text_sync(
+            litellm_model="gpt-5.6-terra",
+            messages=[{"role": "user", "content": "hi"}],
+            api_key="sk-test",
+            max_tokens=None,
+            temperature=None,
+            timeout=30.0,
+            force_json_response=True,
+        )
+    assert "truncated or invalid JSON" in str(ctx.value)
+    assert ctx.value.result.text.startswith('{"people":')
 
 
 def test_completion_text_sync_retries_empty_output_on_length(

--- a/tests/core_api/test_core_api.py
+++ b/tests/core_api/test_core_api.py
@@ -752,6 +752,86 @@ def test_org_admin_list_projects_and_users_detail(client: TestClient) -> None:
     assert len(wdata[0]["projects"]) >= 1
 
 
+def test_org_admin_patch_disable_and_reenable_user(client: TestClient) -> None:
+    seed_first_admin(client, "admin@example.com", "admin-secret")
+    client.post(
+        "/v1/auth/login",
+        json={"email": "admin@example.com", "password": "admin-secret"},
+    )
+    org_id = client.get("/v1/auth/me").json()["organization_id"]
+
+    create = client.post(
+        f"/v1/organizations/{org_id}/users",
+        json={
+            "email": "member@example.com",
+            "password": "member-secret",
+            "display_name": "Old Name",
+            "role": "member",
+        },
+    )
+    assert create.status_code == 200
+    member_id = create.json()["id"]
+
+    patched = client.patch(
+        f"/v1/organizations/{org_id}/users/{member_id}",
+        json={"display_name": "New Name"},
+    )
+    assert patched.status_code == 200
+    assert patched.json()["display_name"] == "New Name"
+    assert patched.json()["disabled_at"] is None
+
+    disabled = client.delete(f"/v1/organizations/{org_id}/users/{member_id}")
+    assert disabled.status_code == 200
+    assert disabled.json() == {"ok": True}
+
+    listed = client.get(f"/v1/organizations/{org_id}/users").json()
+    member_row = next(u for u in listed if u["id"] == member_id)
+    assert member_row["disabled_at"] is not None
+
+    login_disabled = client.post(
+        "/v1/auth/login",
+        json={"email": "member@example.com", "password": "member-secret"},
+    )
+    assert login_disabled.status_code == 401
+
+    recreate = client.post(
+        f"/v1/organizations/{org_id}/users",
+        json={
+            "email": "member@example.com",
+            "password": "other-secret",
+            "role": "member",
+        },
+    )
+    assert recreate.status_code == 409
+    assert "disabled" in recreate.json()["detail"].lower()
+
+    renamed_while_disabled = client.patch(
+        f"/v1/organizations/{org_id}/users/{member_id}",
+        json={"display_name": "Still Disabled", "disabled": False},
+    )
+    assert renamed_while_disabled.status_code == 200
+    body = renamed_while_disabled.json()
+    assert body["display_name"] == "Still Disabled"
+    assert body["disabled_at"] is None
+
+    login_enabled = client.post(
+        "/v1/auth/login",
+        json={"email": "member@example.com", "password": "member-secret"},
+    )
+    assert login_enabled.status_code == 200
+
+    client.post(
+        "/v1/auth/login",
+        json={"email": "admin@example.com", "password": "admin-secret"},
+    )
+    self_disable = client.patch(
+        f"/v1/organizations/{org_id}/users/{client.get('/v1/auth/me').json()['user_id']}",
+        json={"disabled": True},
+    )
+    assert self_disable.status_code == 400
+    assert "own account" in self_disable.json()["detail"].lower()
+
+
 def test_member_workspace_memberships_grant_project_access(client: TestClient) -> None:
     seed_first_admin(client, "wsadmin@example.com", "ws-admin-secret")
     client.post(

--- a/tests/entities/test_location_orphan_prune.py
+++ b/tests/entities/test_location_orphan_prune.py
@@ -75,7 +75,7 @@ def test_unlink_prunes_ingest_orphan_canonical_when_last_substrate_removed() -> 
         ghost_id = str(location.stylebook_location_canonical_id)
         assert ghost_id
 
-        unlink_substrate_from_canonical(
+        pruned = unlink_substrate_from_canonical(
             session,
             stylebook_id=sb_id,
             location=location,
@@ -84,6 +84,7 @@ def test_unlink_prunes_ingest_orphan_canonical_when_last_substrate_removed() -> 
         )
         session.commit()
 
+        assert pruned is True
         assert session.get(StylebookLocationCanonical, ghost_id) is None
         assert (
             session.exec(
@@ -129,7 +130,7 @@ def test_unlink_keeps_manual_canonical_with_zero_substrates() -> None:
         session.commit()
         session.refresh(location)
 
-        unlink_substrate_from_canonical(
+        pruned = unlink_substrate_from_canonical(
             session,
             stylebook_id=sb_id,
             location=location,
@@ -138,6 +139,7 @@ def test_unlink_keeps_manual_canonical_with_zero_substrates() -> None:
         )
         session.commit()
 
+        assert pruned is False
         assert session.get(StylebookLocationCanonical, canon_id) is not None
 
 

--- a/tests/entities/test_person_persist.py
+++ b/tests/entities/test_person_persist.py
@@ -495,7 +495,7 @@ def test_unlink_prunes_ingest_orphan_canonical_when_last_substrate_removed() -> 
         ghost_id = str(person.stylebook_person_canonical_id)
         assert ghost_id
 
-        unlink_substrate_from_canonical(
+        pruned = unlink_substrate_from_canonical(
             session,
             stylebook_id=sb_id,
             person=person,
@@ -504,6 +504,7 @@ def test_unlink_prunes_ingest_orphan_canonical_when_last_substrate_removed() -> 
         )
         session.commit()
 
+        assert pruned is True
         assert session.get(StylebookPersonCanonical, ghost_id) is None
         assert (
             session.exec(
@@ -547,7 +548,7 @@ def test_unlink_keeps_manual_canonical_with_zero_substrates() -> None:
         session.commit()
         session.refresh(person)
 
-        unlink_substrate_from_canonical(
+        pruned = unlink_substrate_from_canonical(
             session,
             stylebook_id=sb_id,
             person=person,
@@ -556,6 +557,7 @@ def test_unlink_keeps_manual_canonical_with_zero_substrates() -> None:
         )
         session.commit()
 
+        assert pruned is False
         assert session.get(StylebookPersonCanonical, canon_id) is not None
 
 

--- a/tests/stylebook_api/test_stylebook_api.py
+++ b/tests/stylebook_api/test_stylebook_api.py
@@ -35,6 +35,7 @@ from backfield_entities.canonical.link import (
     CANONICAL_LINK_UNLINKED,
     CANONICAL_LINK_WAIVED,
 )
+from backfield_entities.entities.location.persist import materialize_new_canonical_and_link
 from fastapi.testclient import TestClient
 from sqlalchemy import event
 from sqlalchemy.engine import Engine
@@ -2469,13 +2470,14 @@ def test_post_unlink_canonical_prunes_alias_when_sole_substrate(
         headers=_service_headers(),
     )
     assert r_un.status_code == 200
-    assert r_un.json() == {"message": "unlinked"}
+    assert r_un.json() == {"message": "unlinked", "canonical_pruned": False}
 
     with Session(engine) as s:
         row = s.get(SubstrateLocation, sid)
         assert row is not None
         assert row.stylebook_location_canonical_id is None
         assert row.canonical_link_status == CANONICAL_LINK_PENDING
+        assert s.get(StylebookLocationCanonical, cid) is not None
         aliases_after = s.exec(
             select(StylebookLocationAlias).where(
                 StylebookLocationAlias.location_canonical_id == cid,
@@ -2483,6 +2485,43 @@ def test_post_unlink_canonical_prunes_alias_when_sole_substrate(
             )
         ).all()
         assert len(aliases_after) == 0
+
+
+def test_post_unlink_canonical_reports_prune_for_ingest_orphan(
+    client: TestClient, stylebook_test_engine: Engine
+) -> None:
+    engine = stylebook_test_engine
+    with Session(engine) as s:
+        proj = s.exec(select(BackfieldProject).where(BackfieldProject.slug == "demo-proj")).one()
+        pid = int(proj.id)
+        ws = s.get(BackfieldWorkspace, int(proj.workspace_id))  # type: ignore[arg-type]
+        sb_id = int(ws.stylebook_id)
+        loc = SubstrateLocation(
+            project_id=pid,
+            name="Ingest Garage",
+            normalized_name="ingest garage",
+            location_type="place",
+            identity_fingerprint="fp-ingest-orphan-1",
+            canonical_link_status=CANONICAL_LINK_PENDING,
+        )
+        s.add(loc)
+        s.commit()
+        s.refresh(loc)
+        materialize_new_canonical_and_link(s, stylebook_id=sb_id, location=loc)
+        s.commit()
+        s.refresh(loc)
+        sid = int(loc.id)  # type: ignore[arg-type]
+        cid = str(loc.stylebook_location_canonical_id)
+
+    r_un = client.post(
+        f"/v1/locations/{sid}/unlink-canonical?project_slug=demo-proj",
+        headers=_service_headers(),
+    )
+    assert r_un.status_code == 200
+    assert r_un.json() == {"message": "unlinked", "canonical_pruned": True}
+
+    with Session(engine) as s:
+        assert s.get(StylebookLocationCanonical, cid) is None
 
 
 def test_delete_location_article_scoped_removes_orphan_linked_substrate_without_requeue(


### PR DESCRIPTION
## Summary
- Stylebook unlink reports `canonical_pruned` and the UI navigates away instead of refetching a deleted row (avoids CloudFront HTML-as-JSON errors).
- GPT-5.6 completions force `reasoning_effort=none`, set an explicit completion budget, and retry once on truncated JSON so Person/Org/Place extract is less likely to fail mid-object.
- Org admins can edit display name/role and re-enable soft-disabled users (emails stay reserved; recreate with the same address is blocked with a clearer 409).

## Test plan
- [ ] Unlink the last substrate from an ingest-only canonical and confirm Stylebook leaves the detail page without a JSON parse toast
- [ ] Run PersonExtract (or Org) with GPT-5.6 Terra/Luna on a short article and confirm compact JSON completes without `Unterminated string`
- [ ] As an org admin: edit a user's display name; disable then re-enable them; confirm login works after re-enable and create-with-same-email still returns 409
- [ ] `make lint` / `make test` (already run for the AI and Core user-admin slices on this branch)


Made with [Cursor](https://cursor.com)