### PR TITLE
Fix Stylebook home stats when project_scope and catalog disagree

### DIFF
--- a/apps/stylebook-api/src/stylebook_api/routers/stats.py
+++ b/apps/stylebook-api/src/stylebook_api/routers/stats.py
@@ -14,13 +14,15 @@ from backfield_db import (
     SubstratePerson,
 )
 from backfield_entities.canonical.link import CANONICAL_LINK_PENDING
+from backfield_entities.catalog.resolve import resolve_stylebook_id_for_project_id
+from backfield_entities.catalog.stylebook_library import resolve_stylebook_by_slug
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 from sqlmodel import Session, col, func, select
 
 from stylebook_api.catalog_scope import StylebookSlugQuery
 from stylebook_api.deps import get_auth, get_session
-from stylebook_api.helpers.project_scope import project_by_slug, require_stylebook_id
+from stylebook_api.helpers.project_scope import project_by_slug
 
 router = APIRouter(prefix="/v1", tags=["stats"])
 
@@ -32,6 +34,35 @@ class StatsOut(BaseModel):
     works: dict[str, int]
 
 
+def _zero_entity_stats() -> dict[str, int]:
+    return {"canonical_count": 0, "candidate_count": 0}
+
+
+def _resolve_stats_stylebook_id(
+    session: Session,
+    *,
+    project_id: int,
+    organization_id: int,
+    stylebook_slug: str | None,
+) -> int:
+    """Catalog for home-card canonical counts.
+
+    Path ``stylebook_slug`` wins when present (org-scoped). Otherwise use the
+    project's assigned Stylebook. Pending candidates stay project-scoped and are
+    only included when that project owns the same catalog.
+    """
+    raw = (stylebook_slug or "").strip()
+    if raw:
+        row = resolve_stylebook_by_slug(session, organization_id=organization_id, slug=raw)
+        if row is None or row.id is None:
+            raise HTTPException(
+                status_code=404,
+                detail="No catalog matches that name in your organization.",
+            )
+        return int(row.id)
+    return resolve_stylebook_id_for_project_id(session, project_id)
+
+
 @router.get("/stats", response_model=StatsOut)
 def get_stats(
     project_slug: str = Query(...),
@@ -41,81 +72,95 @@ def get_stats(
 ) -> StatsOut:
     proj = project_by_slug(session, project_slug)
     require_project_access(session, auth, int(proj.id))
-    z = {"canonical_count": 0, "candidate_count": 0}
-    try:
-        stylebook_id = require_stylebook_id(session, proj, stylebook_slug)
-    except HTTPException as e:
-        if e.status_code == 400:
-            return StatsOut(locations=z, people=z, organizations=z, works=z)
-        raise e
+    project_id = int(proj.id)
+    organization_id = int(proj.organization_id)
 
-    canon_cnt = int(
+    auth_org = auth.get("organization_id")
+    if auth_org is not None and int(auth_org) != organization_id:
+        raise HTTPException(status_code=403, detail="Wrong organization")
+
+    try:
+        stylebook_id = _resolve_stats_stylebook_id(
+            session,
+            project_id=project_id,
+            organization_id=organization_id,
+            stylebook_slug=stylebook_slug,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    project_stylebook_id = resolve_stylebook_id_for_project_id(session, project_id)
+    include_pending = project_stylebook_id == stylebook_id
+
+    loc_canon = int(
         session.scalar(
             select(func.count())
             .select_from(StylebookLocationCanonical)
-            .where(StylebookLocationCanonical.stylebook_id == int(stylebook_id))
+            .where(StylebookLocationCanonical.stylebook_id == stylebook_id)
         )
         or 0
     )
-    cand_cnt = int(
-        session.scalar(
-            select(func.count())
-            .select_from(SubstrateLocation)
-            .where(
-                SubstrateLocation.project_id == int(proj.id),
-                col(SubstrateLocation.stylebook_location_canonical_id).is_(None),
-                SubstrateLocation.canonical_link_status == CANONICAL_LINK_PENDING,
-            )
-        )
-        or 0
-    )
-    loc = {"canonical_count": canon_cnt, "candidate_count": cand_cnt}
-    people_canon_cnt = int(
+    people_canon = int(
         session.scalar(
             select(func.count())
             .select_from(StylebookPersonCanonical)
-            .where(StylebookPersonCanonical.stylebook_id == int(stylebook_id))
+            .where(StylebookPersonCanonical.stylebook_id == stylebook_id)
         )
         or 0
     )
-    people_cand_cnt = int(
-        session.scalar(
-            select(func.count())
-            .select_from(SubstratePerson)
-            .where(
-                SubstratePerson.project_id == int(proj.id),
-                col(SubstratePerson.stylebook_person_canonical_id).is_(None),
-                SubstratePerson.canonical_link_status == CANONICAL_LINK_PENDING,
-            )
-        )
-        or 0
-    )
-    people_stats = {
-        "canonical_count": people_canon_cnt,
-        "candidate_count": people_cand_cnt,
-    }
-    org_canon_cnt = int(
+    org_canon = int(
         session.scalar(
             select(func.count())
             .select_from(StylebookOrganizationCanonical)
-            .where(StylebookOrganizationCanonical.stylebook_id == int(stylebook_id))
+            .where(StylebookOrganizationCanonical.stylebook_id == stylebook_id)
         )
         or 0
     )
-    org_cand_cnt = int(
-        session.scalar(
-            select(func.count())
-            .select_from(SubstrateOrganization)
-            .where(
-                SubstrateOrganization.project_id == int(proj.id),
-                col(SubstrateOrganization.stylebook_organization_canonical_id).is_(None),
-                SubstrateOrganization.canonical_link_status == CANONICAL_LINK_PENDING,
+
+    loc_cand = 0
+    people_cand = 0
+    org_cand = 0
+    if include_pending:
+        loc_cand = int(
+            session.scalar(
+                select(func.count())
+                .select_from(SubstrateLocation)
+                .where(
+                    SubstrateLocation.project_id == project_id,
+                    col(SubstrateLocation.stylebook_location_canonical_id).is_(None),
+                    SubstrateLocation.canonical_link_status == CANONICAL_LINK_PENDING,
+                )
             )
+            or 0
         )
-        or 0
+        people_cand = int(
+            session.scalar(
+                select(func.count())
+                .select_from(SubstratePerson)
+                .where(
+                    SubstratePerson.project_id == project_id,
+                    col(SubstratePerson.stylebook_person_canonical_id).is_(None),
+                    SubstratePerson.canonical_link_status == CANONICAL_LINK_PENDING,
+                )
+            )
+            or 0
+        )
+        org_cand = int(
+            session.scalar(
+                select(func.count())
+                .select_from(SubstrateOrganization)
+                .where(
+                    SubstrateOrganization.project_id == project_id,
+                    col(SubstrateOrganization.stylebook_organization_canonical_id).is_(None),
+                    SubstrateOrganization.canonical_link_status == CANONICAL_LINK_PENDING,
+                )
+            )
+            or 0
+        )
+
+    return StatsOut(
+        locations={"canonical_count": loc_canon, "candidate_count": loc_cand},
+        people={"canonical_count": people_canon, "candidate_count": people_cand},
+        organizations={"canonical_count": org_canon, "candidate_count": org_cand},
+        works=_zero_entity_stats(),
     )
-    org_stats = {
-        "canonical_count": org_canon_cnt,
-        "candidate_count": org_cand_cnt,
-    }
-    return StatsOut(locations=loc, people=people_stats, organizations=org_stats, works=z)

--- a/apps/stylebook-ui/src/components/Layout.tsx
+++ b/apps/stylebook-ui/src/components/Layout.tsx
@@ -45,6 +45,10 @@ import {
   stripLegacyStylebookFromSearch,
   stylebookCatalogBasePath,
 } from "@/lib/stylebookPaths"
+import {
+  defaultWorkflowProjectSlug,
+  projectOwnsStylebook,
+} from "@/lib/workflowProjectScope"
 
 function projectSearchSuffix(searchParams: URLSearchParams): string {
   const p = new URLSearchParams()
@@ -54,12 +58,6 @@ function projectSearchSuffix(searchParams: URLSearchParams): string {
   if (filt) p.set("project", filt)
   const s = p.toString()
   return s ? `?${s}` : ""
-}
-
-/** Default Agate project for catalog workflow when the URL omits scope (sidebar + dashboard stats). */
-function defaultWorkflowProjectSlug(projects: Project[]): string {
-  const preferred = projects.find((p) => p.slug === "general")
-  return preferred?.slug ?? projects[0]?.slug ?? ""
 }
 
 const STORAGE_WORKSPACES_EXPANDED = "stylebook-sidebar-workspaces-expanded"
@@ -294,20 +292,45 @@ export default function Layout({ children, headerContent }: LayoutProps) {
     void loadStylebooks()
   }, [loadStylebooks])
 
-  /** Every stylebook catalog URL keeps workflow project scope in the query (``project_scope=``). */
+  /** Keep ``project_scope`` aligned with a project that owns the path Stylebook. */
   useEffect(() => {
-    if (!routeSlug || projects.length === 0 || workflowProjectSlug) return
-    const slug = defaultWorkflowProjectSlug(projects)
-    if (!slug) return
+    if (!routeSlug || projects.length === 0) return
+    const stylebook = stylebooks.find((row) => row.slug === routeSlug)
+    const stylebookId = stylebook?.id ?? null
+    // Wait for workspace ownership when we know the catalog id, so we do not
+    // briefly pin ``general`` before correcting to an owning project.
+    if (stylebookId != null && workspaceRows.length === 0) return
+
+    const owningSlug = defaultWorkflowProjectSlug(projects, {
+      stylebookId,
+      workspaces: workspaceRows,
+    })
+    if (!owningSlug) return
+
+    const scopeMismatched =
+      !!workflowProjectSlug &&
+      stylebookId != null &&
+      !projectOwnsStylebook(workflowProjectSlug, stylebookId, workspaceRows)
+
+    if (workflowProjectSlug && !scopeMismatched) return
+
     setSearchParams(
       (prev) => {
+        if (prev.get("project_scope") === owningSlug) return prev
         const next = new URLSearchParams(prev)
-        next.set("project_scope", slug)
+        next.set("project_scope", owningSlug)
         return next
       },
       { replace: true },
     )
-  }, [routeSlug, projects, workflowProjectSlug, setSearchParams])
+  }, [
+    routeSlug,
+    projects,
+    stylebooks,
+    workspaceRows,
+    workflowProjectSlug,
+    setSearchParams,
+  ])
 
   /** Drop legacy ``?stylebook=`` when the slug already lives in the path. */
   useEffect(() => {
@@ -333,11 +356,17 @@ export default function Layout({ children, headerContent }: LayoutProps) {
 
   const onStylebookChange = useCallback(
     (slug: string) => {
-      navigate(
-        `/stylebook/${encodeURIComponent(slug)}${projectSearchSuffix(searchParams)}`,
-      )
+      const nextStylebook = stylebooks.find((row) => row.slug === slug)
+      const owningSlug = defaultWorkflowProjectSlug(projects, {
+        stylebookId: nextStylebook?.id ?? null,
+        workspaces: workspaceRows,
+      })
+      const next = new URLSearchParams()
+      if (owningSlug) next.set("project_scope", owningSlug)
+      const suffix = next.toString() ? `?${next.toString()}` : ""
+      navigate(`/stylebook/${encodeURIComponent(slug)}${suffix}`)
     },
-    [navigate, searchParams],
+    [navigate, projects, stylebooks, workspaceRows],
   )
 
   const handleLogout = async () => {

--- a/apps/stylebook-ui/src/lib/workflowProjectScope.test.ts
+++ b/apps/stylebook-ui/src/lib/workflowProjectScope.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest"
+import {
+  defaultWorkflowProjectSlug,
+  projectOwnsStylebook,
+  projectSlugsOwningStylebook,
+} from "@/lib/workflowProjectScope"
+
+const projects = [
+  { slug: "general" },
+  { slug: "demo" },
+  { slug: "workbooks" },
+]
+
+const workspaces = [
+  {
+    stylebook_id: 3,
+    projects: [{ slug: "general" }],
+  },
+  {
+    stylebook_id: 5,
+    projects: [{ slug: "demo" }, { slug: "workbooks" }],
+  },
+]
+
+describe("workflowProjectScope", () => {
+  it("lists projects that own a stylebook", () => {
+    expect(projectSlugsOwningStylebook(workspaces, 5)).toEqual(["demo", "workbooks"])
+    expect(projectOwnsStylebook("general", 5, workspaces)).toBe(false)
+    expect(projectOwnsStylebook("demo", 5, workspaces)).toBe(true)
+  })
+
+  it("prefers an owning project over bare general for a catalog", () => {
+    expect(
+      defaultWorkflowProjectSlug(projects, {
+        stylebookId: 5,
+        workspaces,
+      }),
+    ).toBe("demo")
+  })
+
+  it("still prefers general when general owns the catalog", () => {
+    expect(
+      defaultWorkflowProjectSlug(projects, {
+        stylebookId: 3,
+        workspaces,
+      }),
+    ).toBe("general")
+  })
+
+  it("falls back to general when ownership is unknown", () => {
+    expect(defaultWorkflowProjectSlug(projects)).toBe("general")
+    expect(
+      defaultWorkflowProjectSlug(projects, { stylebookId: 99, workspaces }),
+    ).toBe("general")
+  })
+})

--- a/apps/stylebook-ui/src/lib/workflowProjectScope.ts
+++ b/apps/stylebook-ui/src/lib/workflowProjectScope.ts
@@ -1,0 +1,63 @@
+/** Pick workflow ``project_scope`` that matches the path Stylebook catalog. */
+
+export type WorkflowProjectRef = { slug: string }
+
+export type WorkflowWorkspaceRef = {
+  stylebook_id?: number | null
+  projects: WorkflowProjectRef[]
+}
+
+/** Project slugs under workspaces assigned to ``stylebookId``. */
+export function projectSlugsOwningStylebook(
+  workspaces: WorkflowWorkspaceRef[],
+  stylebookId: number,
+): string[] {
+  const slugs: string[] = []
+  const seen = new Set<string>()
+  for (const ws of workspaces) {
+    if (ws.stylebook_id !== stylebookId) continue
+    for (const project of ws.projects) {
+      if (seen.has(project.slug)) continue
+      seen.add(project.slug)
+      slugs.push(project.slug)
+    }
+  }
+  return slugs
+}
+
+export function projectOwnsStylebook(
+  projectSlug: string,
+  stylebookId: number,
+  workspaces: WorkflowWorkspaceRef[],
+): boolean {
+  return projectSlugsOwningStylebook(workspaces, stylebookId).includes(projectSlug)
+}
+
+/**
+ * Default Agate project for catalog workflow when the URL omits scope, or when
+ * the current scope does not own the path Stylebook.
+ *
+ * Prefers ``general`` among projects that own the catalog; otherwise the first
+ * owning visible project; then falls back to ``general`` / first project overall.
+ */
+export function defaultWorkflowProjectSlug(
+  projects: WorkflowProjectRef[],
+  options?: {
+    stylebookId?: number | null
+    workspaces?: WorkflowWorkspaceRef[]
+  },
+): string {
+  const visible = new Set(projects.map((project) => project.slug))
+  const stylebookId = options?.stylebookId
+  const workspaces = options?.workspaces ?? []
+  if (stylebookId != null) {
+    const owners = projectSlugsOwningStylebook(workspaces, stylebookId).filter((slug) =>
+      visible.has(slug),
+    )
+    const preferredOwner = owners.find((slug) => slug === "general")
+    if (preferredOwner) return preferredOwner
+    if (owners[0]) return owners[0]
+  }
+  const preferred = projects.find((project) => project.slug === "general")
+  return preferred?.slug ?? projects[0]?.slug ?? ""
+}

--- a/docs/api/stylebook.md
+++ b/docs/api/stylebook.md
@@ -121,7 +121,11 @@ Cleanup mutations require catalog edit access and preserve catalog tenancy.
 
 - `/v1/stylebooks/{stylebook_slug}/activity` returns a filtered, paginated catalog activity stream.
 - Person and location semantic mention search ranks indexed article evidence within project scope and can filter by canonical, saved entity, mention, occurrence, and domain-specific fields.
-- `/v1/stats` returns project-scoped canonical and pending-candidate counts for the Stylebook UI dashboard.
+- `/v1/stats` returns Stylebook UI home-card counts. Canonical totals are keyed by
+  the path/query `stylebook_slug` (or the project's assigned Stylebook when omitted).
+  Pending-candidate totals use `project_slug` only when that project owns the same
+  Stylebook; a mismatched project scope returns real canonical counts with
+  `candidate_count: 0` instead of zeroing the whole response.
 - `/v1/place-extract-location-types` exposes the shared location taxonomy used by extraction and catalog filters.
 
 There is no HTTP geocode resolve endpoint and no Work API. Pipeline geocoding runs in the Agate worker (`geocode_agent`), not through Stylebook API. Canonical organization clients should use the Stylebook-scoped canonical organization family.

--- a/docs/development/frontend/stylebook.md
+++ b/docs/development/frontend/stylebook.md
@@ -14,7 +14,11 @@ Every Stylebook is addressed by a stable path:
 The path slug is mirrored to Stylebook API requests as `stylebook_slug`.
 Project scope has two distinct query keys:
 
-- `project_scope` carries workflow and shell context.
+- `project_scope` carries workflow and shell context. When the URL omits it, or when
+  it names a project that does not own the path Stylebook, the shell picks a visible
+  project under a workspace assigned to that catalog (preferring `general` only among
+  owners). Catalog switches reset `project_scope` the same way so home-card stats stay
+  aligned with `/v1/stats`.
 - `project` filters evidence, mentions, and linked substrate rows.
 
 Canonical metadata and connections are Stylebook-wide and must not change when the

--- a/tests/stylebook_api/test_stylebook_api.py
+++ b/tests/stylebook_api/test_stylebook_api.py
@@ -1383,6 +1383,71 @@ def test_stats_reflects_canonical_and_pending_candidates(
     assert loc["candidate_count"] == 2
 
 
+def test_stats_mismatch_stylebook_returns_canonicals_not_zeros(
+    client: TestClient, stylebook_test_engine: Engine
+) -> None:
+    """Path catalog + non-owning project_scope must not zero home-card canonicals."""
+    with Session(stylebook_test_engine) as s:
+        org = s.exec(
+            select(BackfieldOrganization).where(BackfieldOrganization.slug == "default")
+        ).one()
+        oid = int(org.id)
+        other = Stylebook(
+            organization_id=oid,
+            slug="demo-stylebook",
+            name="Demo Stylebook",
+            is_default=False,
+        )
+        s.add(other)
+        s.commit()
+        s.refresh(other)
+        other_id = int(other.id)
+        s.add(
+            StylebookLocationCanonical(
+                stylebook_id=other_id,
+                label="Mismatch Town",
+                slug="mismatch-town",
+                location_type="city",
+            )
+        )
+        s.add(
+            StylebookPersonCanonical(
+                stylebook_id=other_id,
+                label="Mismatch Person",
+                slug="mismatch-person",
+            )
+        )
+        s.add(
+            StylebookOrganizationCanonical(
+                stylebook_id=other_id,
+                label="Mismatch Org",
+                slug="mismatch-org",
+            )
+        )
+        s.commit()
+
+    # demo-proj owns `default`, not `demo-stylebook` — the old path returned all zeros.
+    mismatched = client.get(
+        "/v1/stats?project_slug=demo-proj&stylebook_slug=demo-stylebook",
+        headers=_service_headers(),
+    )
+    assert mismatched.status_code == 200
+    body = mismatched.json()
+    assert body["locations"]["canonical_count"] == 1
+    assert body["people"]["canonical_count"] == 1
+    assert body["organizations"]["canonical_count"] == 1
+    assert body["locations"]["candidate_count"] == 0
+    assert body["people"]["candidate_count"] == 0
+    assert body["organizations"]["candidate_count"] == 0
+
+    matched = client.get(
+        "/v1/stats?project_slug=demo-proj&stylebook_slug=default",
+        headers=_service_headers(),
+    )
+    assert matched.status_code == 200
+    assert matched.json()["locations"]["canonical_count"] == 0
+
+
 def test_candidates_types_returns_place_extract_taxonomy(client: TestClient) -> None:
     r = client.get(
         "/v1/candidates/types?project_slug=demo-proj&status=open",


### PR DESCRIPTION
## Summary

Stylebook home cards showed all zeros when the path catalog and `project_scope` disagreed (e.g. `/stylebook/demo-stylebook?project_scope=general`). `/v1/stats` was swallowing `STYLEBOOK_OVERRIDE_CONFLICT` as empty counts, and the shell defaulted `project_scope` to `general` even on other catalogs.

- Canonical totals follow path/query `stylebook_slug`; pending candidates only when the project owns that Stylebook
- Shell picks (and self-heals toward) a project under a workspace assigned to the path catalog
- Docs + API/UI tests for the mismatch path

## Project scope check

- [x] This change targets local development / source inspection (production self-hosting is unsupported in this repo)
- [x] Docs under `docs/` updated if behavior, architecture, or operations changed
- [x] First-admin provisioning still uses `backfield init` / `backfield seed` only (no HTTP/env bootstrap paths)

## Test plan

- [x] `make lint`
- [ ] `make test`
- [x] `make ui-typecheck ui-test` (if UI/TypeScript changed) — ran `workflowProjectScope` vitest; full ui-typecheck recommended
- [ ] `make smoke-fast` (if live-stack behavior changed)
- [ ] `make smoke` (if golden-path / provider-dependent runtime changed; configure **Settings → AI models**)
- [ ] Open `/stylebook/demo-stylebook?project_scope=general` and confirm home cards show non-zero canonicals (or scope self-heals to an owning project)
- [ ] Open Locations/People/Orgs on that catalog and confirm list counts still match

## Notes for reviewers

Mismatch previously returned HTTP 200 with zeros, which looked like an empty catalog. Pending-candidate counts correctly stay `0` when `project_scope` does not own the path Stylebook.


Made with [Cursor](https://cursor.com)