### PR TITLE
Stop Stylebook shell remount loop on mismatched project_scope

### DIFF
--- a/apps/stylebook-ui/src/components/Layout.tsx
+++ b/apps/stylebook-ui/src/components/Layout.tsx
@@ -47,7 +47,7 @@ import {
 } from "@/lib/stylebookPaths"
 import {
   defaultWorkflowProjectSlug,
-  projectOwnsStylebook,
+  replacementWorkflowProjectSlug,
 } from "@/lib/workflowProjectScope"
 
 function projectSearchSuffix(searchParams: URLSearchParams): string {
@@ -58,6 +58,13 @@ function projectSearchSuffix(searchParams: URLSearchParams): string {
   if (filt) p.set("project", filt)
   const s = p.toString()
   return s ? `?${s}` : ""
+}
+
+/** Keep catalog navigations under ``/org/{slug}`` when the shell already is. */
+function orgPrefixedStylebookPath(pathname: string, stylebookSlug: string, search = ""): string {
+  const orgPrefix = pathname.match(/^(\/org\/[^/]+)/)?.[1] ?? ""
+  const base = `${orgPrefix}/stylebook/${encodeURIComponent(stylebookSlug)}`
+  return search ? `${base}${search.startsWith("?") ? search : `?${search}`}` : base
 }
 
 const STORAGE_WORKSPACES_EXPANDED = "stylebook-sidebar-workspaces-expanded"
@@ -297,28 +304,39 @@ export default function Layout({ children, headerContent }: LayoutProps) {
     if (!routeSlug || projects.length === 0) return
     const stylebook = stylebooks.find((row) => row.slug === routeSlug)
     const stylebookId = stylebook?.id ?? null
-    // Wait for workspace ownership when we know the catalog id, so we do not
-    // briefly pin ``general`` before correcting to an owning project.
-    if (stylebookId != null && workspaceRows.length === 0) return
 
-    const owningSlug = defaultWorkflowProjectSlug(projects, {
+    if (!workflowProjectSlug) {
+      const owningSlug = defaultWorkflowProjectSlug(projects, {
+        stylebookId,
+        workspaces: workspaceRows,
+      })
+      if (!owningSlug) return
+      setSearchParams(
+        (prev) => {
+          if (prev.get("project_scope") === owningSlug) return prev
+          const next = new URLSearchParams(prev)
+          next.set("project_scope", owningSlug)
+          return next
+        },
+        { replace: true },
+      )
+      return
+    }
+
+    if (stylebookId == null) return
+    const nextSlug = replacementWorkflowProjectSlug(
+      workflowProjectSlug,
       stylebookId,
-      workspaces: workspaceRows,
-    })
-    if (!owningSlug) return
-
-    const scopeMismatched =
-      !!workflowProjectSlug &&
-      stylebookId != null &&
-      !projectOwnsStylebook(workflowProjectSlug, stylebookId, workspaceRows)
-
-    if (workflowProjectSlug && !scopeMismatched) return
+      projects,
+      workspaceRows,
+    )
+    if (!nextSlug) return
 
     setSearchParams(
       (prev) => {
-        if (prev.get("project_scope") === owningSlug) return prev
+        if (prev.get("project_scope") === nextSlug) return prev
         const next = new URLSearchParams(prev)
-        next.set("project_scope", owningSlug)
+        next.set("project_scope", nextSlug)
         return next
       },
       { replace: true },
@@ -349,10 +367,14 @@ export default function Layout({ children, headerContent }: LayoutProps) {
       stylebooks.find((b) => b.is_default)?.slug ?? stylebooks[0]?.slug ?? ""
     if (!nextSlug) return
     navigate(
-      `/stylebook/${encodeURIComponent(nextSlug)}${projectSearchSuffix(searchParams)}`,
+      orgPrefixedStylebookPath(
+        location.pathname,
+        nextSlug,
+        projectSearchSuffix(searchParams),
+      ),
       { replace: true },
     )
-  }, [routeSlug, stylebooks, navigate, searchParams])
+  }, [routeSlug, stylebooks, navigate, searchParams, location.pathname])
 
   const onStylebookChange = useCallback(
     (slug: string) => {
@@ -364,9 +386,9 @@ export default function Layout({ children, headerContent }: LayoutProps) {
       const next = new URLSearchParams()
       if (owningSlug) next.set("project_scope", owningSlug)
       const suffix = next.toString() ? `?${next.toString()}` : ""
-      navigate(`/stylebook/${encodeURIComponent(slug)}${suffix}`)
+      navigate(orgPrefixedStylebookPath(location.pathname, slug, suffix))
     },
-    [navigate, projects, stylebooks, workspaceRows],
+    [navigate, projects, stylebooks, workspaceRows, location.pathname],
   )
 
   const handleLogout = async () => {

--- a/apps/stylebook-ui/src/lib/stylebook-api/projects.ts
+++ b/apps/stylebook-ui/src/lib/stylebook-api/projects.ts
@@ -7,6 +7,8 @@ export interface Project {
   id: number
   slug: string
   name: string
+  stylebook_id?: number | null
+  stylebook_slug?: string | null
 }
 
 export async function fetchProjects(): Promise<Project[]> {

--- a/apps/stylebook-ui/src/lib/workflowProjectScope.test.ts
+++ b/apps/stylebook-ui/src/lib/workflowProjectScope.test.ts
@@ -1,14 +1,15 @@
 import { describe, expect, it } from "vitest"
 import {
   defaultWorkflowProjectSlug,
+  owningProjectSlugsForStylebook,
   projectOwnsStylebook,
-  projectSlugsOwningStylebook,
+  replacementWorkflowProjectSlug,
 } from "@/lib/workflowProjectScope"
 
 const projects = [
-  { slug: "general" },
-  { slug: "demo" },
-  { slug: "workbooks" },
+  { slug: "general", stylebook_id: 3, stylebook_slug: "cpm-stylebook" },
+  { slug: "demo", stylebook_id: 5, stylebook_slug: "demo-stylebook" },
+  { slug: "workbooks", stylebook_id: 5, stylebook_slug: "demo-stylebook" },
 ]
 
 const workspaces = [
@@ -23,10 +24,21 @@ const workspaces = [
 ]
 
 describe("workflowProjectScope", () => {
-  it("lists projects that own a stylebook", () => {
-    expect(projectSlugsOwningStylebook(workspaces, 5)).toEqual(["demo", "workbooks"])
-    expect(projectOwnsStylebook("general", 5, workspaces)).toBe(false)
-    expect(projectOwnsStylebook("demo", 5, workspaces)).toBe(true)
+  it("lists projects that own a stylebook from Agate project fields", () => {
+    expect(owningProjectSlugsForStylebook(5, projects, [])).toEqual([
+      "demo",
+      "workbooks",
+    ])
+    expect(projectOwnsStylebook("general", 5, projects, workspaces)).toBe(false)
+    expect(projectOwnsStylebook("demo", 5, projects, workspaces)).toBe(true)
+  })
+
+  it("falls back to workspace ownership when projects omit stylebook_id", () => {
+    const bare = [{ slug: "general" }, { slug: "demo" }, { slug: "workbooks" }]
+    expect(owningProjectSlugsForStylebook(5, bare, workspaces)).toEqual([
+      "demo",
+      "workbooks",
+    ])
   })
 
   it("prefers an owning project over bare general for a catalog", () => {
@@ -52,5 +64,20 @@ describe("workflowProjectScope", () => {
     expect(
       defaultWorkflowProjectSlug(projects, { stylebookId: 99, workspaces }),
     ).toBe("general")
+  })
+
+  it("does not rewrite mismatched scope when no owner exists", () => {
+    expect(
+      replacementWorkflowProjectSlug("general", 99, projects, workspaces),
+    ).toBeNull()
+  })
+
+  it("rewrites mismatched scope to an owning project", () => {
+    expect(
+      replacementWorkflowProjectSlug("general", 5, projects, workspaces),
+    ).toBe("demo")
+    expect(
+      replacementWorkflowProjectSlug("demo", 5, projects, workspaces),
+    ).toBeNull()
   })
 })

--- a/apps/stylebook-ui/src/lib/workflowProjectScope.ts
+++ b/apps/stylebook-ui/src/lib/workflowProjectScope.ts
@@ -1,44 +1,70 @@
 /** Pick workflow ``project_scope`` that matches the path Stylebook catalog. */
 
-export type WorkflowProjectRef = { slug: string }
+export type WorkflowProjectRef = {
+  slug: string
+  stylebook_id?: number | null
+  stylebook_slug?: string | null
+}
 
 export type WorkflowWorkspaceRef = {
   stylebook_id?: number | null
-  projects: WorkflowProjectRef[]
+  projects: { slug: string }[]
 }
 
-/** Project slugs under workspaces assigned to ``stylebookId``. */
-export function projectSlugsOwningStylebook(
-  workspaces: WorkflowWorkspaceRef[],
-  stylebookId: number,
-): string[] {
-  const slugs: string[] = []
+function uniqueSlugs(slugs: string[]): string[] {
+  const out: string[] = []
   const seen = new Set<string>()
+  for (const slug of slugs) {
+    if (seen.has(slug)) continue
+    seen.add(slug)
+    out.push(slug)
+  }
+  return out
+}
+
+/** Prefer Agate project ``stylebook_id``; fall back to workspace assignment. */
+export function owningProjectSlugsForStylebook(
+  stylebookId: number,
+  projects: WorkflowProjectRef[],
+  workspaces: WorkflowWorkspaceRef[] = [],
+): string[] {
+  const fromProjects = projects
+    .filter((project) => project.stylebook_id === stylebookId)
+    .map((project) => project.slug)
+  if (fromProjects.length > 0) {
+    return uniqueSlugs(fromProjects)
+  }
+
+  const visible = new Set(projects.map((project) => project.slug))
+  const fromWorkspaces: string[] = []
   for (const ws of workspaces) {
     if (ws.stylebook_id !== stylebookId) continue
     for (const project of ws.projects) {
-      if (seen.has(project.slug)) continue
-      seen.add(project.slug)
-      slugs.push(project.slug)
+      if (!visible.has(project.slug)) continue
+      fromWorkspaces.push(project.slug)
     }
   }
-  return slugs
+  return uniqueSlugs(fromWorkspaces)
 }
 
 export function projectOwnsStylebook(
   projectSlug: string,
   stylebookId: number,
-  workspaces: WorkflowWorkspaceRef[],
+  projects: WorkflowProjectRef[],
+  workspaces: WorkflowWorkspaceRef[] = [],
 ): boolean {
-  return projectSlugsOwningStylebook(workspaces, stylebookId).includes(projectSlug)
+  return owningProjectSlugsForStylebook(stylebookId, projects, workspaces).includes(
+    projectSlug,
+  )
+}
+
+function preferGeneralThenFirst(slugs: string[]): string {
+  return slugs.find((slug) => slug === "general") ?? slugs[0] ?? ""
 }
 
 /**
- * Default Agate project for catalog workflow when the URL omits scope, or when
- * the current scope does not own the path Stylebook.
- *
- * Prefers ``general`` among projects that own the catalog; otherwise the first
- * owning visible project; then falls back to ``general`` / first project overall.
+ * Default Agate project when the URL omits ``project_scope``.
+ * Prefers an owner of ``stylebookId``, else ``general`` / first visible project.
  */
 export function defaultWorkflowProjectSlug(
   projects: WorkflowProjectRef[],
@@ -47,17 +73,31 @@ export function defaultWorkflowProjectSlug(
     workspaces?: WorkflowWorkspaceRef[]
   },
 ): string {
-  const visible = new Set(projects.map((project) => project.slug))
   const stylebookId = options?.stylebookId
   const workspaces = options?.workspaces ?? []
   if (stylebookId != null) {
-    const owners = projectSlugsOwningStylebook(workspaces, stylebookId).filter((slug) =>
-      visible.has(slug),
-    )
-    const preferredOwner = owners.find((slug) => slug === "general")
-    if (preferredOwner) return preferredOwner
-    if (owners[0]) return owners[0]
+    const owners = owningProjectSlugsForStylebook(stylebookId, projects, workspaces)
+    const owning = preferGeneralThenFirst(owners)
+    if (owning) return owning
   }
-  const preferred = projects.find((project) => project.slug === "general")
-  return preferred?.slug ?? projects[0]?.slug ?? ""
+  return preferGeneralThenFirst(projects.map((project) => project.slug))
+}
+
+/**
+ * When ``project_scope`` does not own the path catalog, return a better owning
+ * slug. Returns null when scope is already fine or no owner is known (do not
+ * rewrite the URL — rewriting to the same mismatched default caused a loop).
+ */
+export function replacementWorkflowProjectSlug(
+  currentProjectSlug: string,
+  stylebookId: number,
+  projects: WorkflowProjectRef[],
+  workspaces: WorkflowWorkspaceRef[] = [],
+): string | null {
+  const owners = owningProjectSlugsForStylebook(stylebookId, projects, workspaces)
+  if (owners.length === 0) return null
+  if (owners.includes(currentProjectSlug)) return null
+  const next = preferGeneralThenFirst(owners)
+  if (!next || next === currentProjectSlug) return null
+  return next
 }

--- a/docs/development/frontend/stylebook.md
+++ b/docs/development/frontend/stylebook.md
@@ -16,9 +16,10 @@ Project scope has two distinct query keys:
 
 - `project_scope` carries workflow and shell context. When the URL omits it, or when
   it names a project that does not own the path Stylebook, the shell picks a visible
-  project under a workspace assigned to that catalog (preferring `general` only among
-  owners). Catalog switches reset `project_scope` the same way so home-card stats stay
-  aligned with `/v1/stats`.
+  project that owns that catalog (from Agate project `stylebook_id`, with workspace
+  assignment as fallback). Prefer `general` only among owners. If no owner is known,
+  leave the mismatched scope alone rather than rewriting in a loop. Catalog switches
+  reset `project_scope` the same way so home-card stats stay aligned with `/v1/stats`.
 - `project` filters evidence, mentions, and linked substrate rows.
 
 Canonical metadata and connections are Stylebook-wide and must not change when the


### PR DESCRIPTION
## Summary

Follow-up to #143. Healing a mismatched `project_scope` fell back to `general` when no owner was resolved, so `setSearchParams` kept firing, remounting the shell, and looping `me` / `workspaces` / `stats`.

- Only rewrite scope when an owning project exists and differs from the current one
- Prefer Agate project `stylebook_id` for ownership (workspace assignment as fallback)
- Keep catalog navigations under `/org/{slug}/…` to avoid org-prefix redirect bounce

## Project scope check

- [x] This change targets local development / source inspection (production self-hosting is unsupported in this repo)
- [x] Docs under `docs/` updated if behavior, architecture, or operations changed
- [x] First-admin provisioning still uses `backfield init` / `backfield seed` only (no HTTP/env bootstrap paths)

## Test plan

- [ ] `make lint`
- [ ] `make test`
- [x] `make ui-typecheck ui-test` (if UI/TypeScript changed) — ran `workflowProjectScope` vitest
- [ ] `make smoke-fast` (if live-stack behavior changed)
- [ ] `make smoke` (if golden-path / provider-dependent runtime changed; configure **Settings → AI models**)
- [ ] Open `/stylebook/demo-stylebook?project_scope=general` and confirm the network tab settles (no repeating `me`/`workspaces`/`stats`)
- [ ] Confirm `project_scope` becomes an owning project (`demo` / `workbooks`) and home cards stay populated

## Notes for reviewers

Cherry-picked from the post-merge commit on `fix/stylebook-stats-project-mismatch` after #143 landed without this loop fix.


Made with [Cursor](https://cursor.com)