### PR TITLE
Replace freeform canonical metadata with typed attributes

### DIFF
--- a/apps/api-playground/src/lib/presentation.test.ts
+++ b/apps/api-playground/src/lib/presentation.test.ts
@@ -59,6 +59,7 @@ describe("endpoint presentation contract", () => {
         expect(presentation.control).toBeTruthy()
         if (parameter.name === "project_slug") expect(presentation.control).toBe("select")
         if (parameter.name === "meta") expect(presentation.control).toBe("meta-builder")
+        if (parameter.name === "attr") expect(presentation.control).toBe("textarea")
         if (
           parameter.name === "pub_date_from" ||
           parameter.name === "pub_date_to"
@@ -89,9 +90,13 @@ describe("endpoint presentation contract", () => {
     const coverage = operations.find(
       (operation) => operation.displayPath === "/articles/geo-cells",
     )
+    const peopleList = operations.find(
+      (operation) => operation.displayPath === "/people",
+    )
     expect(articleSearch).toBeDefined()
     expect(semanticSearch).toBeDefined()
     expect(coverage).toBeDefined()
+    expect(peopleList).toBeDefined()
 
     expect(
       presentationForField(
@@ -133,6 +138,28 @@ describe("endpoint presentation contract", () => {
         "query",
       ).helperText,
     ).toMatch(/Leave blank/)
+    expect(
+      presentationForField(
+        peopleList!,
+        "attr",
+        { type: "array", items: { type: "string" } },
+        "Attribute filter",
+        blockedContext,
+        "query",
+      ).helperText,
+    ).toMatch(/One clause per line/)
+    const peopleInclude = presentationForField(
+      peopleList!,
+      "include",
+      { type: "array", items: { type: "string" } },
+      "Include extras",
+      blockedContext,
+      "query",
+    )
+    expect(peopleInclude.options).toEqual([
+      { value: "metadata", label: "Stylebook attributes" },
+    ])
+    expect(peopleInclude.helperText).toMatch(/include metadata/i)
   })
 
   it("presents every request-body property through the shared field model", () => {

--- a/apps/api-playground/src/lib/presentation.ts
+++ b/apps/api-playground/src/lib/presentation.ts
@@ -140,7 +140,16 @@ function sortOptions(operation: PlaygroundOperation): SelectOption[] {
   return optionsFromValues(["label", "recent"])
 }
 
+function isEntityCatalogPath(displayPath: string): boolean {
+  return /^\/(people|organizations|locations)(\/(search|geo-search))?$/.test(
+    displayPath,
+  )
+}
+
 function includeOptions(operation: PlaygroundOperation): SelectOption[] {
+  if (isEntityCatalogPath(operation.displayPath)) {
+    return [{ value: "metadata", label: "Stylebook attributes" }]
+  }
   const detailPath = /^\/articles\/\{article_id\}$/.test(operation.displayPath)
   return [
     { value: "counts", label: "Mention counts" },
@@ -165,7 +174,21 @@ function helperTextForField(
   if (name === "radius_miles") {
     return "Required together with center_lng and center_lat."
   }
+  if (name === "attr") {
+    return (
+      "One clause per line. key = has attribute; !key = missing; key:value = equals; " +
+      "key:op:value with eq, neq, ieq, ineq, lt, lte, gt, or gte. " +
+      "OR values with | on eq/ieq (party:eq:Democrat|Independent). " +
+      "Multiple clauses AND together. Distinct from article meta=."
+    )
+  }
   if (name === "include") {
+    if (isEntityCatalogPath(operation.displayPath)) {
+      return (
+        "metadata adds typed Stylebook attributes on each item. " +
+        "Get-by-id responses always include metadata."
+      )
+    }
     return /^\/articles\/\{article_id\}$/.test(operation.displayPath)
       ? "counts adds mention totals; text includes the article body."
       : "counts adds mention totals for each article."
@@ -227,6 +250,16 @@ export function presentationForField(
   if (name === "meta") {
     return {
       control: "meta-builder",
+      typeLabel: "Repeatable string",
+      wide: true,
+    }
+  }
+
+  if (name === "attr") {
+    return {
+      control: "textarea",
+      helperText: helperTextForField(operation, name, location),
+      placeholder: "One clause per line (e.g. party:Democrat)",
       typeLabel: "Repeatable string",
       wide: true,
     }

--- a/apps/core-api/src/core_api/routers/public/articles/helpers.py
+++ b/apps/core-api/src/core_api/routers/public/articles/helpers.py
@@ -50,14 +50,18 @@ INCLUDE_DETAIL_PARAM_DESCRIPTION = (
 
 ENTITY_INCLUDE_PARAM_DESCRIPTION = (
     "Repeatable include token for optional entity extras. Supported: metadata "
-    "(typed Stylebook attributes on each item)."
+    "(typed Stylebook attributes on each item). Entity detail endpoints always "
+    "return metadata; list/search/geo-search omit it unless include=metadata."
 )
 
 ATTR_PARAM_DESCRIPTION = (
-    "Repeatable entity-attribute filter clause (AND across clauses). "
-    "Forms: key (exists), !key (missing), key:value (eq), key:op:value "
-    "(eq|neq|ieq|ineq|lt|lte|gt|gte). OR within eq/ieq via '|'. "
-    "Max 25 clauses. Distinct from article meta= filters."
+    "Repeatable Stylebook attribute filter (AND across clauses; max 25). "
+    "Forms: key (attribute exists), !key (missing), key:value (equals), "
+    "key:op:value where op is eq|neq|ieq|ineq|lt|lte|gt|gte. "
+    "Examples: party, !party, party:Democrat, population:gt:100000, "
+    "party:ieq:democrat. OR within eq/ieq via '|': party:eq:Democrat|Independent. "
+    "Distinct from article meta= filters. To return attributes in list/search "
+    "responses, also pass include=metadata."
 )
 
 ALLOWED_ENTITY_LIST_INCLUDES = frozenset({"metadata"})

--- a/apps/core-api/src/core_api/routers/public/articles/helpers.py
+++ b/apps/core-api/src/core_api/routers/public/articles/helpers.py
@@ -48,6 +48,55 @@ INCLUDE_DETAIL_PARAM_DESCRIPTION = (
     "custom records, embedded flag); text (full article body in addition to preview)."
 )
 
+ENTITY_INCLUDE_PARAM_DESCRIPTION = (
+    "Repeatable include token for optional entity extras. Supported: metadata "
+    "(typed Stylebook attributes on each item)."
+)
+
+ATTR_PARAM_DESCRIPTION = (
+    "Repeatable entity-attribute filter clause (AND across clauses). "
+    "Forms: key (exists), !key (missing), key:value (eq), key:op:value "
+    "(eq|neq|ieq|ineq|lt|lte|gt|gte). OR within eq/ieq via '|'. "
+    "Max 25 clauses. Distinct from article meta= filters."
+)
+
+ALLOWED_ENTITY_LIST_INCLUDES = frozenset({"metadata"})
+
+
+def parse_entity_includes(include: list[str]) -> set[str]:
+    """Validate repeatable ``include`` tokens for entity list routes."""
+    if not include:
+        return set()
+    tokens = {token.strip().lower() for token in include if token.strip()}
+    if not tokens:
+        return set()
+    unknown = tokens - ALLOWED_ENTITY_LIST_INCLUDES
+    if unknown:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"Unknown include token(s): {', '.join(sorted(unknown))}. "
+                "Supported: metadata."
+            ),
+        )
+    return tokens
+
+
+def parse_attr_clauses_or_400(attr: list[str]):
+    from backfield_entities.catalog.canonical_meta import (
+        AttrFilterError,
+        parse_attr_clauses,
+    )
+
+    try:
+        return parse_attr_clauses(attr)
+    except AttrFilterError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+
+
 
 def parse_article_includes(
     include: list[str],

--- a/apps/core-api/src/core_api/routers/public/entities/locations/geo_search.py
+++ b/apps/core-api/src/core_api/routers/public/entities/locations/geo_search.py
@@ -17,8 +17,12 @@ from sqlmodel import Session
 
 from core_api.deps import get_session
 from core_api.routers.public.articles.helpers import (
+    ATTR_PARAM_DESCRIPTION,
+    ENTITY_INCLUDE_PARAM_DESCRIPTION,
     NATURE_PARAM_DESCRIPTION,
+    parse_attr_clauses_or_400,
     parse_bbox,
+    parse_entity_includes,
     parse_natures,
 )
 from core_api.routers.public.deps import get_public_project
@@ -58,6 +62,8 @@ def search_project_locations_by_geo(
         description=NATURE_PARAM_DESCRIPTION,
     ),
     min_mentions: int = Query(0, ge=0, le=1_000_000),
+    attr: list[str] = Query(default=[], description=ATTR_PARAM_DESCRIPTION),
+    include: list[str] = Query(default=[], description=ENTITY_INCLUDE_PARAM_DESCRIPTION),
     limit: int = Query(25, ge=1, le=100),
     offset: int = Query(0, ge=0),
 ) -> PublicLocationGeoSearchResponse:
@@ -75,9 +81,12 @@ def search_project_locations_by_geo(
             detail="Provide center_lng/center_lat/radius_miles or bbox.",
         )
 
+    natures = parse_natures(nature)
+    attr_clauses = parse_attr_clauses_or_400(attr)
+    include_metadata = "metadata" in parse_entity_includes(include)
+
     if has_bbox:
         min_lng, min_lat, max_lng, max_lat = parse_bbox(bbox)
-        natures = parse_natures(nature)
         params = PublicLocationGeoSearchParams(
             mode=PublicLocationGeoSearchMode.bbox,
             min_lng=min_lng,
@@ -88,6 +97,8 @@ def search_project_locations_by_geo(
             location_type=location_type,
             natures=natures,
             min_mentions=min_mentions,
+            attr_clauses=attr_clauses,
+            include_metadata=include_metadata,
             limit=limit,
             offset=offset,
         )
@@ -98,7 +109,6 @@ def search_project_locations_by_geo(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="center_lng, center_lat, and radius_miles are required together.",
             )
-        natures = parse_natures(nature)
         params = PublicLocationGeoSearchParams(
             mode=PublicLocationGeoSearchMode.point,
             center_lng=center_lng,
@@ -108,6 +118,8 @@ def search_project_locations_by_geo(
             location_type=location_type,
             natures=natures,
             min_mentions=min_mentions,
+            attr_clauses=attr_clauses,
+            include_metadata=include_metadata,
             limit=limit,
             offset=offset,
         )

--- a/apps/core-api/src/core_api/routers/public/entities/locations/helpers.py
+++ b/apps/core-api/src/core_api/routers/public/entities/locations/helpers.py
@@ -60,6 +60,8 @@ def build_location_search_params(
     sort: str | None,
     limit: int,
     offset: int,
+    attr_clauses: tuple = (),
+    include_metadata: bool = False,
 ) -> PublicLocationSearchParams:
     sort_value = PublicLocationSort.label
     if sort:
@@ -75,6 +77,8 @@ def build_location_search_params(
         location_type=location_type,
         natures=natures,
         min_mentions=min_mentions,
+        attr_clauses=attr_clauses,
+        include_metadata=include_metadata,
         sort=sort_value,
         limit=limit,
         offset=offset,

--- a/apps/core-api/src/core_api/routers/public/entities/locations/list_search.py
+++ b/apps/core-api/src/core_api/routers/public/entities/locations/list_search.py
@@ -8,7 +8,14 @@ from fastapi import APIRouter, Depends, Query
 from sqlmodel import Session
 
 from core_api.deps import get_session
-from core_api.routers.public.articles.helpers import NATURE_PARAM_DESCRIPTION, parse_natures
+from core_api.routers.public.articles.helpers import (
+    ATTR_PARAM_DESCRIPTION,
+    ENTITY_INCLUDE_PARAM_DESCRIPTION,
+    NATURE_PARAM_DESCRIPTION,
+    parse_attr_clauses_or_400,
+    parse_entity_includes,
+    parse_natures,
+)
 from core_api.routers.public.deps import get_public_project
 from core_api.routers.public.entities.locations.helpers import (
     build_location_search_params,
@@ -29,6 +36,8 @@ def _search_locations(
     location_type: str | None,
     natures: tuple[str, ...],
     min_mentions: int,
+    attr: list[str],
+    include: list[str],
     sort: str | None,
     limit: int,
     offset: int,
@@ -36,11 +45,14 @@ def _search_locations(
     stylebook_id, project_id = resolve_public_locations_scope(
         session, project, stylebook_slug=stylebook_slug
     )
+    includes = parse_entity_includes(include)
     params = build_location_search_params(
         q=q,
         location_type=location_type,
         natures=natures,
         min_mentions=min_mentions,
+        attr_clauses=parse_attr_clauses_or_400(attr),
+        include_metadata="metadata" in includes,
         sort=sort,
         limit=limit,
         offset=offset,
@@ -69,6 +81,8 @@ def list_project_locations(
         description=NATURE_PARAM_DESCRIPTION,
     ),
     min_mentions: int = Query(0, ge=0, le=1_000_000),
+    attr: list[str] = Query(default=[], description=ATTR_PARAM_DESCRIPTION),
+    include: list[str] = Query(default=[], description=ENTITY_INCLUDE_PARAM_DESCRIPTION),
     sort: str | None = Query(
         None,
         description="label (default) or recent",
@@ -86,6 +100,8 @@ def list_project_locations(
         location_type=location_type,
         natures=natures,
         min_mentions=min_mentions,
+        attr=attr,
+        include=include,
         sort=sort,
         limit=limit,
         offset=offset,
@@ -104,6 +120,8 @@ def search_project_locations(
         description=NATURE_PARAM_DESCRIPTION,
     ),
     min_mentions: int = Query(0, ge=0, le=1_000_000),
+    attr: list[str] = Query(default=[], description=ATTR_PARAM_DESCRIPTION),
+    include: list[str] = Query(default=[], description=ENTITY_INCLUDE_PARAM_DESCRIPTION),
     sort: str | None = Query(
         None,
         description="label (default) or recent",
@@ -121,6 +139,8 @@ def search_project_locations(
         location_type=location_type,
         natures=natures,
         min_mentions=min_mentions,
+        attr=attr,
+        include=include,
         sort=sort,
         limit=limit,
         offset=offset,

--- a/apps/core-api/src/core_api/routers/public/entities/organizations/helpers.py
+++ b/apps/core-api/src/core_api/routers/public/entities/organizations/helpers.py
@@ -63,6 +63,8 @@ def build_organization_search_params(
     sort: str | None,
     limit: int,
     offset: int,
+    attr_clauses: tuple = (),
+    include_metadata: bool = False,
 ) -> PublicOrganizationSearchParams:
     sort_value = PublicOrganizationSort.label
     if sort:
@@ -78,6 +80,8 @@ def build_organization_search_params(
         organization_type=organization_type,
         natures=natures,
         min_mentions=min_mentions,
+        attr_clauses=attr_clauses,
+        include_metadata=include_metadata,
         sort=sort_value,
         limit=limit,
         offset=offset,

--- a/apps/core-api/src/core_api/routers/public/entities/organizations/list_search.py
+++ b/apps/core-api/src/core_api/routers/public/entities/organizations/list_search.py
@@ -11,7 +11,14 @@ from fastapi import APIRouter, Depends, Query
 from sqlmodel import Session
 
 from core_api.deps import get_session
-from core_api.routers.public.articles.helpers import NATURE_PARAM_DESCRIPTION, parse_natures
+from core_api.routers.public.articles.helpers import (
+    ATTR_PARAM_DESCRIPTION,
+    ENTITY_INCLUDE_PARAM_DESCRIPTION,
+    NATURE_PARAM_DESCRIPTION,
+    parse_attr_clauses_or_400,
+    parse_entity_includes,
+    parse_natures,
+)
 from core_api.routers.public.deps import get_public_project
 from core_api.routers.public.entities.organizations.helpers import (
     build_organization_search_params,
@@ -32,6 +39,8 @@ def _search_organizations(
     organization_type: str | None,
     natures: tuple[str, ...],
     min_mentions: int,
+    attr: list[str],
+    include: list[str],
     sort: str | None,
     limit: int,
     offset: int,
@@ -39,11 +48,14 @@ def _search_organizations(
     stylebook_id, project_id = resolve_public_organizations_scope(
         session, project, stylebook_slug=stylebook_slug
     )
+    includes = parse_entity_includes(include)
     params = build_organization_search_params(
         q=q,
         organization_type=organization_type,
         natures=natures,
         min_mentions=min_mentions,
+        attr_clauses=parse_attr_clauses_or_400(attr),
+        include_metadata="metadata" in includes,
         sort=sort,
         limit=limit,
         offset=offset,
@@ -72,6 +84,8 @@ def list_project_organizations(
         description=NATURE_PARAM_DESCRIPTION,
     ),
     min_mentions: int = Query(0, ge=0, le=1_000_000),
+    attr: list[str] = Query(default=[], description=ATTR_PARAM_DESCRIPTION),
+    include: list[str] = Query(default=[], description=ENTITY_INCLUDE_PARAM_DESCRIPTION),
     sort: str | None = Query(
         None,
         description="label (default) or recent",
@@ -89,6 +103,8 @@ def list_project_organizations(
         organization_type=organization_type,
         natures=natures,
         min_mentions=min_mentions,
+        attr=attr,
+        include=include,
         sort=sort,
         limit=limit,
         offset=offset,
@@ -107,6 +123,8 @@ def search_project_organizations(
         description=NATURE_PARAM_DESCRIPTION,
     ),
     min_mentions: int = Query(0, ge=0, le=1_000_000),
+    attr: list[str] = Query(default=[], description=ATTR_PARAM_DESCRIPTION),
+    include: list[str] = Query(default=[], description=ENTITY_INCLUDE_PARAM_DESCRIPTION),
     sort: str | None = Query(
         None,
         description="label (default) or recent",
@@ -124,6 +142,8 @@ def search_project_organizations(
         organization_type=organization_type,
         natures=natures,
         min_mentions=min_mentions,
+        attr=attr,
+        include=include,
         sort=sort,
         limit=limit,
         offset=offset,

--- a/apps/core-api/src/core_api/routers/public/entities/people/helpers.py
+++ b/apps/core-api/src/core_api/routers/public/entities/people/helpers.py
@@ -63,6 +63,8 @@ def build_person_search_params(
     sort: str | None,
     limit: int,
     offset: int,
+    attr_clauses: tuple = (),
+    include_metadata: bool = False,
 ) -> PublicPersonSearchParams:
     sort_value = PublicPersonSort.sort_key
     if sort:
@@ -81,6 +83,8 @@ def build_person_search_params(
         affiliation=affiliation,
         natures=natures,
         min_mentions=min_mentions,
+        attr_clauses=attr_clauses,
+        include_metadata=include_metadata,
         sort=sort_value,
         limit=limit,
         offset=offset,

--- a/apps/core-api/src/core_api/routers/public/entities/people/list_search.py
+++ b/apps/core-api/src/core_api/routers/public/entities/people/list_search.py
@@ -8,7 +8,14 @@ from fastapi import APIRouter, Depends, Query
 from sqlmodel import Session
 
 from core_api.deps import get_session
-from core_api.routers.public.articles.helpers import NATURE_PARAM_DESCRIPTION, parse_natures
+from core_api.routers.public.articles.helpers import (
+    ATTR_PARAM_DESCRIPTION,
+    ENTITY_INCLUDE_PARAM_DESCRIPTION,
+    NATURE_PARAM_DESCRIPTION,
+    parse_attr_clauses_or_400,
+    parse_entity_includes,
+    parse_natures,
+)
 from core_api.routers.public.deps import get_public_project
 from core_api.routers.public.entities.people.helpers import (
     build_person_search_params,
@@ -32,6 +39,8 @@ def _search_people(
     affiliation: str | None,
     natures: tuple[str, ...],
     min_mentions: int,
+    attr: list[str],
+    include: list[str],
     sort: str | None,
     limit: int,
     offset: int,
@@ -39,6 +48,7 @@ def _search_people(
     stylebook_id, project_id = resolve_public_people_scope(
         session, project, stylebook_slug=stylebook_slug
     )
+    includes = parse_entity_includes(include)
     params = build_person_search_params(
         q=q,
         person_type=person_type,
@@ -47,6 +57,8 @@ def _search_people(
         affiliation=affiliation,
         natures=natures,
         min_mentions=min_mentions,
+        attr_clauses=parse_attr_clauses_or_400(attr),
+        include_metadata="metadata" in includes,
         sort=sort,
         limit=limit,
         offset=offset,
@@ -81,6 +93,8 @@ def list_project_people(
         description=NATURE_PARAM_DESCRIPTION,
     ),
     min_mentions: int = Query(0, ge=0, le=1_000_000),
+    attr: list[str] = Query(default=[], description=ATTR_PARAM_DESCRIPTION),
+    include: list[str] = Query(default=[], description=ENTITY_INCLUDE_PARAM_DESCRIPTION),
     sort: str | None = Query(
         None,
         description="sort_key (default), recent, or label",
@@ -101,6 +115,8 @@ def list_project_people(
         affiliation=affiliation,
         natures=natures,
         min_mentions=min_mentions,
+        attr=attr,
+        include=include,
         sort=sort,
         limit=limit,
         offset=offset,
@@ -125,6 +141,8 @@ def search_project_people(
         description=NATURE_PARAM_DESCRIPTION,
     ),
     min_mentions: int = Query(0, ge=0, le=1_000_000),
+    attr: list[str] = Query(default=[], description=ATTR_PARAM_DESCRIPTION),
+    include: list[str] = Query(default=[], description=ENTITY_INCLUDE_PARAM_DESCRIPTION),
     sort: str | None = Query(
         None,
         description="sort_key (default), recent, or label",
@@ -145,6 +163,8 @@ def search_project_people(
         affiliation=affiliation,
         natures=natures,
         min_mentions=min_mentions,
+        attr=attr,
+        include=include,
         sort=sort,
         limit=limit,
         offset=offset,

--- a/apps/stylebook-api/src/stylebook_api/entities/location/meta.py
+++ b/apps/stylebook-api/src/stylebook_api/entities/location/meta.py
@@ -1,9 +1,9 @@
-"""CRUD for JSON metadata rows on ``stylebook_location_canonical``."""
+"""CRUD for typed metadata attributes on ``stylebook_location_canonical``."""
 
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, Literal
 from uuid import UUID
 
 from backfield_db import BackfieldProject, StylebookLocationCanonical, StylebookLocationMeta
@@ -12,24 +12,33 @@ from pydantic import BaseModel, Field
 from sqlmodel import Session, select
 
 from stylebook_api.deps import get_auth, get_session
-from stylebook_api.helpers.meta_utils import parse_meta_json, validate_meta_json
+from stylebook_api.helpers.meta_utils import (
+    apply_typed_values_to_row,
+    normalize_meta_type_or_400,
+    parse_meta_write,
+    serialize_meta_row,
+)
 from stylebook_api.stylebook_permissions import require_stylebook_edit_access
 from stylebook_api.stylebook_scope import require_stylebook_by_slug_in_auth_org
 
 router = APIRouter(prefix="/v1", tags=["location-meta"])
 
+ValueTypeLiteral = Literal["text", "number", "boolean"]
+
 
 class UpdateMetaRequest(BaseModel):
     meta_type: str | None = Field(
         default=None,
-        description="When set, replaces the meta type (non-empty after strip)",
+        description="When set, replaces the meta type slug",
     )
-    data: Any = Field(..., description="Meta payload (JSON object, array, or scalar)")
+    value_type: ValueTypeLiteral
+    value: str | int | float | bool
 
 
 class CreateMetaRequest(BaseModel):
     meta_type: str = Field(..., min_length=1)
-    data: Any = Field(..., description="Meta payload (JSON object, array, or scalar)")
+    value_type: ValueTypeLiteral
+    value: str | int | float | bool
 
 
 def _canonical_for_stylebook_or_404(
@@ -80,16 +89,7 @@ def get_stylebook_location_meta(
         .where(StylebookLocationMeta.stylebook_location_canonical_id == cid)
         .order_by(StylebookLocationMeta.meta_type, StylebookLocationMeta.id)
     ).all()
-    meta_out: list[dict[str, Any]] = []
-    for m in rows:
-        meta_out.append(
-            {
-                "id": m.id,
-                "meta_type": m.meta_type,
-                "data": parse_meta_json(m.data_json),
-                "created_at": m.created_at.isoformat() if m.created_at else None,
-            }
-        )
+    meta_out = [serialize_meta_row(m) for m in rows]
     return {
         "location_id": cid,
         "meta": meta_out,
@@ -98,7 +98,7 @@ def get_stylebook_location_meta(
 
 
 @router.post("/stylebooks/{stylebook_slug}/canonical-locations/{canonical_id}/meta")
-def create_stylebook_location_meta(
+def upsert_stylebook_location_meta(
     stylebook_slug: str,
     canonical_id: UUID,
     payload: CreateMetaRequest,
@@ -113,26 +113,48 @@ def create_stylebook_location_meta(
         session, stylebook_slug=stylebook_slug, canonical_id=canonical_id, auth=auth
     )
     cid = str(canonical_id)
-    validate_meta_json(payload.data)
+    write = parse_meta_write(
+        meta_type=payload.meta_type,
+        value_type=payload.value_type,
+        value=payload.value,
+    )
+    existing = session.exec(
+        select(StylebookLocationMeta).where(
+            StylebookLocationMeta.stylebook_location_canonical_id == cid,
+            StylebookLocationMeta.meta_type == write.meta_type,
+        )
+    ).first()
+    if existing is not None:
+        apply_typed_values_to_row(
+            existing,
+            meta_type=write.meta_type,
+            value_type=write.value_type,
+            value=write.value,
+        )
+        existing.edited = True
+        session.add(existing)
+        session.commit()
+        session.refresh(existing)
+        return serialize_meta_row(existing)
+
     row = StylebookLocationMeta(
         project_id=_stylebook_storage_project_id(
             session, organization_id=int(sb.organization_id)
         ),
         stylebook_location_canonical_id=cid,
-        meta_type=payload.meta_type.strip(),
-        data_json=payload.data,
         added=True,
         created_at=datetime.now(UTC),
+    )
+    apply_typed_values_to_row(
+        row,
+        meta_type=write.meta_type,
+        value_type=write.value_type,
+        value=write.value,
     )
     session.add(row)
     session.commit()
     session.refresh(row)
-    return {
-        "id": row.id,
-        "meta_type": row.meta_type,
-        "data": parse_meta_json(row.data_json),
-        "created_at": row.created_at.isoformat() if row.created_at else None,
-    }
+    return serialize_meta_row(row)
 
 
 @router.patch("/stylebooks/{stylebook_slug}/canonical-locations/{canonical_id}/meta/{meta_id}")
@@ -157,23 +179,41 @@ def update_stylebook_location_meta(
     ).first()
     if meta_row is None:
         raise HTTPException(status_code=404, detail="Meta record not found")
-    validate_meta_json(request.data)
-    if request.meta_type is not None:
-        mt = request.meta_type.strip()
-        if not mt:
-            raise HTTPException(status_code=400, detail="meta_type cannot be empty")
-        meta_row.meta_type = mt
-    meta_row.data_json = request.data
+
+    meta_type = (
+        normalize_meta_type_or_400(request.meta_type)
+        if request.meta_type is not None
+        else meta_row.meta_type
+    )
+    write = parse_meta_write(
+        meta_type=meta_type,
+        value_type=request.value_type,
+        value=request.value,
+    )
+    if write.meta_type != meta_row.meta_type:
+        clash = session.exec(
+            select(StylebookLocationMeta).where(
+                StylebookLocationMeta.stylebook_location_canonical_id == cid,
+                StylebookLocationMeta.meta_type == write.meta_type,
+                StylebookLocationMeta.id != meta_id,
+            )
+        ).first()
+        if clash is not None:
+            raise HTTPException(
+                status_code=409,
+                detail=f"Metadata key '{write.meta_type}' already exists on this record",
+            )
+    apply_typed_values_to_row(
+        meta_row,
+        meta_type=write.meta_type,
+        value_type=write.value_type,
+        value=write.value,
+    )
     meta_row.edited = True
     session.add(meta_row)
     session.commit()
     session.refresh(meta_row)
-    return {
-        "id": meta_row.id,
-        "meta_type": meta_row.meta_type,
-        "data": parse_meta_json(meta_row.data_json),
-        "created_at": meta_row.created_at.isoformat() if meta_row.created_at else None,
-    }
+    return serialize_meta_row(meta_row)
 
 
 @router.delete("/stylebooks/{stylebook_slug}/canonical-locations/{canonical_id}/meta/{meta_id}")

--- a/apps/stylebook-api/src/stylebook_api/entities/organization/meta.py
+++ b/apps/stylebook-api/src/stylebook_api/entities/organization/meta.py
@@ -1,9 +1,9 @@
-"""CRUD for JSON metadata rows on ``stylebook_organization_canonical``."""
+"""CRUD for typed metadata attributes on ``stylebook_organization_canonical``."""
 
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, Literal
 from uuid import UUID
 
 from backfield_db import BackfieldProject, StylebookOrganizationCanonical, StylebookOrganizationMeta
@@ -12,24 +12,33 @@ from pydantic import BaseModel, Field
 from sqlmodel import Session, select
 
 from stylebook_api.deps import get_auth, get_session
-from stylebook_api.helpers.meta_utils import parse_meta_json, validate_meta_json
+from stylebook_api.helpers.meta_utils import (
+    apply_typed_values_to_row,
+    normalize_meta_type_or_400,
+    parse_meta_write,
+    serialize_meta_row,
+)
 from stylebook_api.stylebook_permissions import require_stylebook_edit_access
 from stylebook_api.stylebook_scope import require_stylebook_by_slug_in_auth_org
 
 router = APIRouter(prefix="/v1", tags=["organization-meta"])
 
+ValueTypeLiteral = Literal["text", "number", "boolean"]
+
 
 class UpdateMetaRequest(BaseModel):
     meta_type: str | None = Field(
         default=None,
-        description="When set, replaces the meta type (non-empty after strip)",
+        description="When set, replaces the meta type slug",
     )
-    data: Any = Field(..., description="Meta payload (JSON object, array, or scalar)")
+    value_type: ValueTypeLiteral
+    value: str | int | float | bool
 
 
 class CreateMetaRequest(BaseModel):
     meta_type: str = Field(..., min_length=1)
-    data: Any = Field(..., description="Meta payload (JSON object, array, or scalar)")
+    value_type: ValueTypeLiteral
+    value: str | int | float | bool
 
 
 def _canonical_for_stylebook_or_404(
@@ -80,16 +89,7 @@ def get_stylebook_organization_meta(
         .where(StylebookOrganizationMeta.stylebook_organization_canonical_id == cid)
         .order_by(StylebookOrganizationMeta.meta_type, StylebookOrganizationMeta.id)
     ).all()
-    meta_out: list[dict[str, Any]] = []
-    for m in rows:
-        meta_out.append(
-            {
-                "id": m.id,
-                "meta_type": m.meta_type,
-                "data": parse_meta_json(m.data_json),
-                "created_at": m.created_at.isoformat() if m.created_at else None,
-            }
-        )
+    meta_out = [serialize_meta_row(m) for m in rows]
     return {
         "organization_id": cid,
         "meta": meta_out,
@@ -98,7 +98,7 @@ def get_stylebook_organization_meta(
 
 
 @router.post("/stylebooks/{stylebook_slug}/canonical-organizations/{canonical_id}/meta")
-def create_stylebook_organization_meta(
+def upsert_stylebook_organization_meta(
     stylebook_slug: str,
     canonical_id: UUID,
     payload: CreateMetaRequest,
@@ -113,31 +113,51 @@ def create_stylebook_organization_meta(
         session, stylebook_slug=stylebook_slug, canonical_id=canonical_id, auth=auth
     )
     cid = str(canonical_id)
-    validate_meta_json(payload.data)
+    write = parse_meta_write(
+        meta_type=payload.meta_type,
+        value_type=payload.value_type,
+        value=payload.value,
+    )
+    existing = session.exec(
+        select(StylebookOrganizationMeta).where(
+            StylebookOrganizationMeta.stylebook_organization_canonical_id == cid,
+            StylebookOrganizationMeta.meta_type == write.meta_type,
+        )
+    ).first()
+    if existing is not None:
+        apply_typed_values_to_row(
+            existing,
+            meta_type=write.meta_type,
+            value_type=write.value_type,
+            value=write.value,
+        )
+        existing.edited = True
+        session.add(existing)
+        session.commit()
+        session.refresh(existing)
+        return serialize_meta_row(existing)
+
     row = StylebookOrganizationMeta(
         project_id=_stylebook_storage_project_id(
             session, organization_id=int(sb.organization_id)
         ),
         stylebook_organization_canonical_id=cid,
-        meta_type=payload.meta_type.strip(),
-        data_json=payload.data,
         added=True,
         created_at=datetime.now(UTC),
+    )
+    apply_typed_values_to_row(
+        row,
+        meta_type=write.meta_type,
+        value_type=write.value_type,
+        value=write.value,
     )
     session.add(row)
     session.commit()
     session.refresh(row)
-    return {
-        "id": row.id,
-        "meta_type": row.meta_type,
-        "data": parse_meta_json(row.data_json),
-        "created_at": row.created_at.isoformat() if row.created_at else None,
-    }
+    return serialize_meta_row(row)
 
 
-@router.patch(
-    "/stylebooks/{stylebook_slug}/canonical-organizations/{canonical_id}/meta/{meta_id}"
-)
+@router.patch("/stylebooks/{stylebook_slug}/canonical-organizations/{canonical_id}/meta/{meta_id}")
 def update_stylebook_organization_meta(
     stylebook_slug: str,
     canonical_id: UUID,
@@ -159,28 +179,44 @@ def update_stylebook_organization_meta(
     ).first()
     if meta_row is None:
         raise HTTPException(status_code=404, detail="Meta record not found")
-    validate_meta_json(request.data)
-    if request.meta_type is not None:
-        mt = request.meta_type.strip()
-        if not mt:
-            raise HTTPException(status_code=400, detail="meta_type cannot be empty")
-        meta_row.meta_type = mt
-    meta_row.data_json = request.data
+
+    meta_type = (
+        normalize_meta_type_or_400(request.meta_type)
+        if request.meta_type is not None
+        else meta_row.meta_type
+    )
+    write = parse_meta_write(
+        meta_type=meta_type,
+        value_type=request.value_type,
+        value=request.value,
+    )
+    if write.meta_type != meta_row.meta_type:
+        clash = session.exec(
+            select(StylebookOrganizationMeta).where(
+                StylebookOrganizationMeta.stylebook_organization_canonical_id == cid,
+                StylebookOrganizationMeta.meta_type == write.meta_type,
+                StylebookOrganizationMeta.id != meta_id,
+            )
+        ).first()
+        if clash is not None:
+            raise HTTPException(
+                status_code=409,
+                detail=f"Metadata key '{write.meta_type}' already exists on this record",
+            )
+    apply_typed_values_to_row(
+        meta_row,
+        meta_type=write.meta_type,
+        value_type=write.value_type,
+        value=write.value,
+    )
     meta_row.edited = True
     session.add(meta_row)
     session.commit()
     session.refresh(meta_row)
-    return {
-        "id": meta_row.id,
-        "meta_type": meta_row.meta_type,
-        "data": parse_meta_json(meta_row.data_json),
-        "created_at": meta_row.created_at.isoformat() if meta_row.created_at else None,
-    }
+    return serialize_meta_row(meta_row)
 
 
-@router.delete(
-    "/stylebooks/{stylebook_slug}/canonical-organizations/{canonical_id}/meta/{meta_id}"
-)
+@router.delete("/stylebooks/{stylebook_slug}/canonical-organizations/{canonical_id}/meta/{meta_id}")
 def delete_stylebook_organization_meta(
     stylebook_slug: str,
     canonical_id: UUID,

--- a/apps/stylebook-api/src/stylebook_api/entities/person/meta.py
+++ b/apps/stylebook-api/src/stylebook_api/entities/person/meta.py
@@ -1,9 +1,9 @@
-"""CRUD for JSON metadata rows on ``stylebook_person_canonical``."""
+"""CRUD for typed metadata attributes on ``stylebook_person_canonical``."""
 
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, Literal
 from uuid import UUID
 
 from backfield_db import BackfieldProject, StylebookPersonCanonical, StylebookPersonMeta
@@ -12,24 +12,33 @@ from pydantic import BaseModel, Field
 from sqlmodel import Session, select
 
 from stylebook_api.deps import get_auth, get_session
-from stylebook_api.helpers.meta_utils import parse_meta_json, validate_meta_json
+from stylebook_api.helpers.meta_utils import (
+    apply_typed_values_to_row,
+    normalize_meta_type_or_400,
+    parse_meta_write,
+    serialize_meta_row,
+)
 from stylebook_api.stylebook_permissions import require_stylebook_edit_access
 from stylebook_api.stylebook_scope import require_stylebook_by_slug_in_auth_org
 
 router = APIRouter(prefix="/v1", tags=["person-meta"])
 
+ValueTypeLiteral = Literal["text", "number", "boolean"]
+
 
 class UpdateMetaRequest(BaseModel):
     meta_type: str | None = Field(
         default=None,
-        description="When set, replaces the meta type (non-empty after strip)",
+        description="When set, replaces the meta type slug",
     )
-    data: Any = Field(..., description="Meta payload (JSON object, array, or scalar)")
+    value_type: ValueTypeLiteral
+    value: str | int | float | bool
 
 
 class CreateMetaRequest(BaseModel):
     meta_type: str = Field(..., min_length=1)
-    data: Any = Field(..., description="Meta payload (JSON object, array, or scalar)")
+    value_type: ValueTypeLiteral
+    value: str | int | float | bool
 
 
 def _canonical_for_stylebook_or_404(
@@ -80,16 +89,7 @@ def get_stylebook_person_meta(
         .where(StylebookPersonMeta.stylebook_person_canonical_id == cid)
         .order_by(StylebookPersonMeta.meta_type, StylebookPersonMeta.id)
     ).all()
-    meta_out: list[dict[str, Any]] = []
-    for m in rows:
-        meta_out.append(
-            {
-                "id": m.id,
-                "meta_type": m.meta_type,
-                "data": parse_meta_json(m.data_json),
-                "created_at": m.created_at.isoformat() if m.created_at else None,
-            }
-        )
+    meta_out = [serialize_meta_row(m) for m in rows]
     return {
         "person_id": cid,
         "meta": meta_out,
@@ -98,7 +98,7 @@ def get_stylebook_person_meta(
 
 
 @router.post("/stylebooks/{stylebook_slug}/canonical-people/{canonical_id}/meta")
-def create_stylebook_person_meta(
+def upsert_stylebook_person_meta(
     stylebook_slug: str,
     canonical_id: UUID,
     payload: CreateMetaRequest,
@@ -113,26 +113,48 @@ def create_stylebook_person_meta(
         session, stylebook_slug=stylebook_slug, canonical_id=canonical_id, auth=auth
     )
     cid = str(canonical_id)
-    validate_meta_json(payload.data)
+    write = parse_meta_write(
+        meta_type=payload.meta_type,
+        value_type=payload.value_type,
+        value=payload.value,
+    )
+    existing = session.exec(
+        select(StylebookPersonMeta).where(
+            StylebookPersonMeta.stylebook_person_canonical_id == cid,
+            StylebookPersonMeta.meta_type == write.meta_type,
+        )
+    ).first()
+    if existing is not None:
+        apply_typed_values_to_row(
+            existing,
+            meta_type=write.meta_type,
+            value_type=write.value_type,
+            value=write.value,
+        )
+        existing.edited = True
+        session.add(existing)
+        session.commit()
+        session.refresh(existing)
+        return serialize_meta_row(existing)
+
     row = StylebookPersonMeta(
         project_id=_stylebook_storage_project_id(
             session, organization_id=int(sb.organization_id)
         ),
         stylebook_person_canonical_id=cid,
-        meta_type=payload.meta_type.strip(),
-        data_json=payload.data,
         added=True,
         created_at=datetime.now(UTC),
+    )
+    apply_typed_values_to_row(
+        row,
+        meta_type=write.meta_type,
+        value_type=write.value_type,
+        value=write.value,
     )
     session.add(row)
     session.commit()
     session.refresh(row)
-    return {
-        "id": row.id,
-        "meta_type": row.meta_type,
-        "data": parse_meta_json(row.data_json),
-        "created_at": row.created_at.isoformat() if row.created_at else None,
-    }
+    return serialize_meta_row(row)
 
 
 @router.patch("/stylebooks/{stylebook_slug}/canonical-people/{canonical_id}/meta/{meta_id}")
@@ -157,23 +179,41 @@ def update_stylebook_person_meta(
     ).first()
     if meta_row is None:
         raise HTTPException(status_code=404, detail="Meta record not found")
-    validate_meta_json(request.data)
-    if request.meta_type is not None:
-        mt = request.meta_type.strip()
-        if not mt:
-            raise HTTPException(status_code=400, detail="meta_type cannot be empty")
-        meta_row.meta_type = mt
-    meta_row.data_json = request.data
+
+    meta_type = (
+        normalize_meta_type_or_400(request.meta_type)
+        if request.meta_type is not None
+        else meta_row.meta_type
+    )
+    write = parse_meta_write(
+        meta_type=meta_type,
+        value_type=request.value_type,
+        value=request.value,
+    )
+    if write.meta_type != meta_row.meta_type:
+        clash = session.exec(
+            select(StylebookPersonMeta).where(
+                StylebookPersonMeta.stylebook_person_canonical_id == cid,
+                StylebookPersonMeta.meta_type == write.meta_type,
+                StylebookPersonMeta.id != meta_id,
+            )
+        ).first()
+        if clash is not None:
+            raise HTTPException(
+                status_code=409,
+                detail=f"Metadata key '{write.meta_type}' already exists on this record",
+            )
+    apply_typed_values_to_row(
+        meta_row,
+        meta_type=write.meta_type,
+        value_type=write.value_type,
+        value=write.value,
+    )
     meta_row.edited = True
     session.add(meta_row)
     session.commit()
     session.refresh(meta_row)
-    return {
-        "id": meta_row.id,
-        "meta_type": meta_row.meta_type,
-        "data": parse_meta_json(meta_row.data_json),
-        "created_at": meta_row.created_at.isoformat() if meta_row.created_at else None,
-    }
+    return serialize_meta_row(meta_row)
 
 
 @router.delete("/stylebooks/{stylebook_slug}/canonical-people/{canonical_id}/meta/{meta_id}")

--- a/apps/stylebook-api/src/stylebook_api/helpers/meta_utils.py
+++ b/apps/stylebook-api/src/stylebook_api/helpers/meta_utils.py
@@ -1,25 +1,53 @@
-"""JSON helpers for Stylebook location meta payloads."""
+"""Helpers for Stylebook typed canonical metadata payloads."""
 
 from __future__ import annotations
 
-import json
 from typing import Any
 
+from backfield_entities.catalog.canonical_meta import (
+    CanonicalMetaWrite,
+    apply_typed_values_to_row,
+    meta_row_to_api,
+    normalize_meta_type,
+)
 from fastapi import HTTPException
+from pydantic import ValidationError
 
 
-def parse_meta_json(data_json: Any) -> Any:
-    """Normalize DB JSON (dict/list/primitive or legacy string) for API responses."""
-    if data_json is None:
-        return None
-    if isinstance(data_json, (dict, list, str, int, float, bool)):
-        return data_json
-    return data_json
-
-
-def validate_meta_json(data: Any) -> None:
-    """Ensure value is JSON-serializable (agate-compatible)."""
+def parse_meta_write(
+    *,
+    meta_type: str,
+    value_type: str,
+    value: Any,
+) -> CanonicalMetaWrite:
+    """Validate a Stylebook meta write payload or raise HTTP 400."""
     try:
-        json.dumps(data)
-    except (TypeError, ValueError) as e:
-        raise HTTPException(status_code=400, detail=f"Invalid JSON data: {e!s}") from e
+        return CanonicalMetaWrite(meta_type=meta_type, value_type=value_type, value=value)
+    except ValidationError as exc:
+        message = "; ".join(
+            str(err.get("msg") or err) for err in exc.errors()
+        ) or "Invalid metadata payload"
+        raise HTTPException(status_code=400, detail=message) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+def normalize_meta_type_or_400(raw: str) -> str:
+    try:
+        return normalize_meta_type(raw)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+def serialize_meta_row(row: Any) -> dict[str, Any]:
+    out = meta_row_to_api(row, include_id=True)
+    out["created_at"] = row.created_at.isoformat() if row.created_at else None
+    return out
+
+
+__all__ = [
+    "apply_typed_values_to_row",
+    "normalize_meta_type_or_400",
+    "parse_meta_write",
+    "serialize_meta_row",
+]

--- a/apps/stylebook-api/src/stylebook_api/routers/imports.py
+++ b/apps/stylebook-api/src/stylebook_api/routers/imports.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from backfield_auth.gate import require_project_access
 from backfield_db import BackfieldProject, StylebookLocationMeta
+from backfield_entities.catalog.canonical_meta import coerce_import_scalar
 from backfield_entities.entities.location.persist import create_standalone_canonical
 from fastapi import APIRouter, Body, Depends, HTTPException, Query, Request
 from pydantic import BaseModel, Field
@@ -16,7 +17,11 @@ from sqlmodel import Session, select
 
 from stylebook_api.catalog_scope import StylebookSlugQuery
 from stylebook_api.deps import get_auth, get_session
-from stylebook_api.helpers.meta_utils import validate_meta_json
+from stylebook_api.helpers.meta_utils import (
+    apply_typed_values_to_row,
+    normalize_meta_type_or_400,
+    parse_meta_write,
+)
 from stylebook_api.helpers.project_scope import (
     project_by_slug as _project_by_slug,
 )
@@ -139,13 +144,8 @@ def _normalize_and_validate_meta_mappings_or_400(
 ) -> list[tuple[str, str]]:
     out: list[tuple[str, str]] = []
     for i, m in enumerate(raw):
-        mt = (m.meta_type or "").strip()
+        mt = normalize_meta_type_or_400((m.meta_type or "").strip())
         pk = (m.property_key or "").strip()
-        if not mt:
-            raise HTTPException(
-                status_code=400,
-                detail=f"meta_property_mappings[{i}].meta_type must be non-empty",
-            )
         if not pk:
             raise HTTPException(
                 status_code=400,
@@ -343,22 +343,33 @@ class _GeoJsonLocationsImporter:
                         raw_val = props.get(pk)
                         if _meta_value_skipped_as_empty(raw_val):
                             continue
-                        # Single-key object so catalog UI shows Key / Value (property name → value).
-                        data_payload: dict[str, Any] = {pk: raw_val}
                         try:
-                            validate_meta_json(data_payload)
-                        except HTTPException as exc:
-                            raise _ImportMetaJsonError(str(exc.detail)) from exc
-                        session.add(
-                            StylebookLocationMeta(
-                                project_id=project_id,
-                                stylebook_location_canonical_id=canon_id,
+                            value_type, value = coerce_import_scalar(raw_val)
+                            write = parse_meta_write(
                                 meta_type=mt,
-                                data_json=data_payload,
-                                added=True,
-                                created_at=datetime.now(UTC),
+                                value_type=value_type,
+                                value=value if value_type != "number" else float(value),
                             )
+                        except (ValueError, HTTPException) as exc:
+                            detail = (
+                                str(exc.detail)
+                                if isinstance(exc, HTTPException)
+                                else str(exc)
+                            )
+                            raise _ImportMetaJsonError(detail) from exc
+                        row = StylebookLocationMeta(
+                            project_id=project_id,
+                            stylebook_location_canonical_id=canon_id,
+                            added=True,
+                            created_at=datetime.now(UTC),
                         )
+                        apply_typed_values_to_row(
+                            row,
+                            meta_type=write.meta_type,
+                            value_type=write.value_type,
+                            value=write.value,
+                        )
+                        session.add(row)
                     session.flush()
                     created.append(
                         ImportGeoJSONCreatedRow(
@@ -630,21 +641,33 @@ def import_geojson_stylebook(
                     raw_value = props.get(property_key)
                     if _meta_value_skipped_as_empty(raw_value):
                         continue
-                    data_payload: dict[str, Any] = {property_key: raw_value}
                     try:
-                        validate_meta_json(data_payload)
-                    except HTTPException as exc:
-                        raise _ImportMetaJsonError(str(exc.detail)) from exc
-                    session.add(
-                        StylebookLocationMeta(
-                            project_id=metadata_project_id,
-                            stylebook_location_canonical_id=canon_id,
+                        value_type, value = coerce_import_scalar(raw_value)
+                        write = parse_meta_write(
                             meta_type=meta_type,
-                            data_json=data_payload,
-                            added=True,
-                            created_at=datetime.now(UTC),
+                            value_type=value_type,
+                            value=value if value_type != "number" else float(value),
                         )
+                    except (ValueError, HTTPException) as exc:
+                        detail = (
+                            str(exc.detail)
+                            if isinstance(exc, HTTPException)
+                            else str(exc)
+                        )
+                        raise _ImportMetaJsonError(detail) from exc
+                    row = StylebookLocationMeta(
+                        project_id=metadata_project_id,
+                        stylebook_location_canonical_id=canon_id,
+                        added=True,
+                        created_at=datetime.now(UTC),
                     )
+                    apply_typed_values_to_row(
+                        row,
+                        meta_type=write.meta_type,
+                        value_type=write.value_type,
+                        value=write.value,
+                    )
+                    session.add(row)
                 session.flush()
                 created.append(
                     ImportGeoJSONCreatedRow(

--- a/apps/stylebook-ui/src/components/MetaTab.tsx
+++ b/apps/stylebook-ui/src/components/MetaTab.tsx
@@ -11,39 +11,27 @@ import {
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
-import { Textarea } from "@/components/ui/textarea"
+import { Edit, Save, X, Loader2, Trash2, Plus } from "lucide-react"
 import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table"
-import { Edit, Save, X, Loader2, Trash2, Plus, Code2, Table2 } from "lucide-react"
-import {
-  emptyKeyValueRows,
-  flatRecordToRows,
-  isFlatScalarRecord,
-  newKeyValueRow,
-  rowsToFlatRecord,
-  valueToCellString,
-  type KeyValueRow,
-  type ScalarJson,
+  formatMetaValue,
+  isValidMetaTypeSlug,
+  normalizeMetaTypeSlug,
+  parseMetaValueInput,
+  type MetaValueType,
 } from "@/lib/metaDataHeuristic"
+import type { CanonicalMetaWriteBody } from "@/lib/stylebook-api/meta"
 
 export interface MetaItem {
   id: number
   meta_type: string
-  data: unknown
+  value_type: MetaValueType
+  value: string | number | boolean
   created_at?: string
-  updated_at?: string
 }
 
 export interface MetaResponse {
   meta: MetaItem[]
   count: number
-  location_id?: string | number
 }
 
 export interface MetaTabConfig {
@@ -56,27 +44,23 @@ export interface MetaTabConfig {
     createMeta: (
       entityId: string | number,
       projectSlug: string,
-      data: { meta_type: string; data: unknown },
+      data: CanonicalMetaWriteBody,
     ) => Promise<unknown>
     updateMeta: (
       entityId: string | number,
       metaId: number,
       projectSlug: string,
-      data: { data: unknown; meta_type?: string },
+      data: CanonicalMetaWriteBody,
     ) => Promise<unknown>
     deleteMeta: (entityId: string | number, metaId: number, projectSlug: string) => Promise<unknown>
   }
 }
 
-type EditorMode = "table" | "json"
-
 interface PerItemEdit {
-  jsonText: string
-  jsonError: string | null
   metaType: string
-  editorMode: EditorMode
-  kvRows: KeyValueRow[]
-  tableError: string | null
+  valueType: MetaValueType
+  valueText: string
+  error: string | null
 }
 
 interface MetaTabProps {
@@ -86,36 +70,15 @@ interface MetaTabProps {
   onMetaUpdated?: () => void
 }
 
-function MetaDataReadOnly({ data }: { data: unknown }) {
-  if (isFlatScalarRecord(data)) {
-    const keys = Object.keys(data).sort((a, b) => a.localeCompare(b, undefined, { sensitivity: "base" }))
-    if (keys.length === 0) {
-      return <p className="text-sm text-muted-foreground">Empty object</p>
-    }
-    return (
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead className="w-[40%]">Key</TableHead>
-            <TableHead>Value</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {keys.map((k) => (
-            <TableRow key={k}>
-              <TableCell className="font-medium align-top">{k}</TableCell>
-              <TableCell className="text-muted-foreground align-top font-mono text-sm">
-                {valueToCellString(data[k] as ScalarJson)}
-              </TableCell>
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table>
-    )
-  }
-  return (
-    <pre className="bg-muted p-4 rounded-md overflow-x-auto text-sm">{JSON.stringify(data, null, 2)}</pre>
-  )
+const VALUE_TYPE_OPTIONS: { value: MetaValueType; label: string }[] = [
+  { value: "text", label: "Text" },
+  { value: "number", label: "Number" },
+  { value: "boolean", label: "Yes / no" },
+]
+
+function valueToEditorText(valueType: MetaValueType, value: string | number | boolean): string {
+  if (valueType === "boolean") return value ? "true" : "false"
+  return String(value)
 }
 
 export default function MetaTab({ entityId, projectSlug, config, onMetaUpdated }: MetaTabProps) {
@@ -128,9 +91,8 @@ export default function MetaTab({ entityId, projectSlug, config, onMetaUpdated }
   const [metaToDelete, setMetaToDelete] = useState<MetaItem | null>(null)
   const [showCreateDialog, setShowCreateDialog] = useState(false)
   const [newMetaType, setNewMetaType] = useState("")
-  const [createEditorMode, setCreateEditorMode] = useState<EditorMode>("table")
-  const [createKvRows, setCreateKvRows] = useState<KeyValueRow[]>(() => emptyKeyValueRows())
-  const [createJsonText, setCreateJsonText] = useState("{}")
+  const [newValueType, setNewValueType] = useState<MetaValueType>("text")
+  const [newValueText, setNewValueText] = useState("")
   const [createError, setCreateError] = useState<string | null>(null)
   const [creating, setCreating] = useState(false)
 
@@ -157,736 +119,429 @@ export default function MetaTab({ entityId, projectSlug, config, onMetaUpdated }
     void loadMeta()
   }, [loadMeta])
 
-  const validateJSON = useCallback((jsonText: string): { valid: boolean; data?: unknown; error?: string } => {
-    try {
-      const parsed: unknown = JSON.parse(jsonText)
-      return { valid: true, data: parsed }
-    } catch (error) {
-      return {
-        valid: false,
-        error: error instanceof Error ? error.message : "Invalid JSON",
-      }
-    }
-  }, [])
-
   const handleStartEdit = useCallback((metaItem: MetaItem) => {
-    const data = metaItem.data
-    let jsonText: string
-    try {
-      jsonText = JSON.stringify(data, null, 2)
-    } catch {
-      setEditingMeta((prev) => ({
-        ...prev,
-        [metaItem.id]: {
-          jsonText: String(data),
-          jsonError: "Failed to serialize JSON",
-          metaType: metaItem.meta_type,
-          editorMode: "json",
-          kvRows: emptyKeyValueRows(),
-          tableError: null,
-        },
-      }))
-      return
-    }
-
-    const useTable = isFlatScalarRecord(data)
     setEditingMeta((prev) => ({
       ...prev,
       [metaItem.id]: {
-        jsonText,
-        jsonError: null,
         metaType: metaItem.meta_type,
-        editorMode: useTable ? "table" : "json",
-        kvRows: useTable ? flatRecordToRows(data) : emptyKeyValueRows(),
-        tableError: null,
+        valueType: metaItem.value_type,
+        valueText: valueToEditorText(metaItem.value_type, metaItem.value),
+        error: null,
       },
     }))
   }, [])
 
   const handleCancelEdit = useCallback((metaId: number) => {
     setEditingMeta((prev) => {
-      const newState = { ...prev }
-      delete newState[metaId]
-      return newState
+      const next = { ...prev }
+      delete next[metaId]
+      return next
     })
   }, [])
-
-  const setEditToJsonMode = useCallback((metaId: number) => {
-    setEditingMeta((prev) => {
-      const cur = prev[metaId]
-      if (!cur) return prev
-      if (cur.editorMode === "json") {
-        return prev
-      }
-      const built = rowsToFlatRecord(cur.kvRows)
-      if (!built.ok) {
-        return {
-          ...prev,
-          [metaId]: { ...cur, tableError: built.error },
-        }
-      }
-      return {
-        ...prev,
-        [metaId]: {
-          ...cur,
-          editorMode: "json",
-          jsonText: JSON.stringify(built.data, null, 2),
-          jsonError: null,
-          tableError: null,
-        },
-      }
-    })
-  }, [])
-
-  const setEditToTableMode = useCallback((metaId: number) => {
-    setEditingMeta((prev) => {
-      const cur = prev[metaId]
-      if (!cur) return prev
-      if (cur.editorMode === "table") {
-        return prev
-      }
-      const validation = validateJSON(cur.jsonText)
-      if (!validation.valid) {
-        return {
-          ...prev,
-          [metaId]: { ...cur, jsonError: validation.error || "Invalid JSON" },
-        }
-      }
-      if (!isFlatScalarRecord(validation.data)) {
-        return {
-          ...prev,
-          [metaId]: {
-            ...cur,
-            jsonError: "Only flat key/value objects (string keys, scalar values) can use table view.",
-          },
-        }
-      }
-      return {
-        ...prev,
-        [metaId]: {
-          ...cur,
-          editorMode: "table",
-          kvRows: flatRecordToRows(validation.data),
-          jsonError: null,
-          tableError: null,
-        },
-      }
-    })
-  }, [validateJSON])
 
   const handleSaveEdit = useCallback(
     async (metaItem: MetaItem) => {
       if (!entityId) return
+      const edit = editingMeta[metaItem.id]
+      if (!edit) return
 
-      const editState = editingMeta[metaItem.id]
-      if (!editState) return
-
-      const typeTrim = editState.metaType.trim()
-      if (!typeTrim) {
+      if (!isValidMetaTypeSlug(edit.metaType)) {
         setEditingMeta((prev) => ({
           ...prev,
           [metaItem.id]: {
-            ...prev[metaItem.id],
-            jsonError: "Meta type is required",
-            tableError: null,
+            ...edit,
+            error: "Use a short key with lowercase letters, numbers, and underscores.",
           },
         }))
         return
       }
-
-      let payload: unknown
-      if (editState.editorMode === "table") {
-        const built = rowsToFlatRecord(editState.kvRows)
-        if (!built.ok) {
-          setEditingMeta((prev) => ({
-            ...prev,
-            [metaItem.id]: { ...prev[metaItem.id], tableError: built.error, jsonError: null },
-          }))
-          return
-        }
-        payload = built.data
-      } else {
-        const validation = validateJSON(editState.jsonText)
-        if (!validation.valid) {
-          setEditingMeta((prev) => ({
-            ...prev,
-            [metaItem.id]: {
-              ...prev[metaItem.id],
-              jsonError: validation.error || "Invalid JSON",
-              tableError: null,
-            },
-          }))
-          return
-        }
-        payload = validation.data
+      const parsed = parseMetaValueInput(edit.valueType, edit.valueText)
+      if (!parsed.ok) {
+        setEditingMeta((prev) => ({
+          ...prev,
+          [metaItem.id]: { ...edit, error: parsed.error },
+        }))
+        return
       }
 
       try {
         setSaving((prev) => ({ ...prev, [metaItem.id]: true }))
         await config.api.updateMeta(entityId, metaItem.id, projectSlug, {
-          data: payload,
-          meta_type: typeTrim,
+          meta_type: normalizeMetaTypeSlug(edit.metaType),
+          value_type: edit.valueType,
+          value: parsed.value,
         })
-        await loadMeta()
         handleCancelEdit(metaItem.id)
+        await loadMeta()
         onMetaUpdated?.()
       } catch (error) {
         console.error("Failed to update meta:", error)
         setEditingMeta((prev) => ({
           ...prev,
           [metaItem.id]: {
-            ...prev[metaItem.id],
-            jsonError: error instanceof Error ? error.message : "Failed to update",
-            tableError: null,
+            ...edit,
+            error: error instanceof Error ? error.message : "Could not save this detail.",
           },
         }))
       } finally {
-        setSaving((prev) => {
-          const newState = { ...prev }
-          delete newState[metaItem.id]
-          return newState
-        })
+        setSaving((prev) => ({ ...prev, [metaItem.id]: false }))
       }
     },
-    [entityId, projectSlug, editingMeta, config, validateJSON, loadMeta, handleCancelEdit, onMetaUpdated],
+    [entityId, projectSlug, config, editingMeta, handleCancelEdit, loadMeta, onMetaUpdated],
   )
 
-  const handleDelete = useCallback((item: MetaItem) => {
-    setMetaToDelete(item)
-    setShowDeleteDialog(true)
-  }, [])
-
-  const confirmDelete = useCallback(async () => {
-    if (!entityId || !metaToDelete) return
-
-    try {
-      setDeleting((prev) => ({ ...prev, [metaToDelete.id]: true }))
-      await config.api.deleteMeta(entityId, metaToDelete.id, projectSlug)
-      await loadMeta()
-      onMetaUpdated?.()
-    } catch (error) {
-      console.error("Failed to delete meta:", error)
-    } finally {
-      setDeleting((prev) => {
-        const newState = { ...prev }
-        delete newState[metaToDelete.id]
-        return newState
-      })
-      setShowDeleteDialog(false)
-      setMetaToDelete(null)
-    }
-  }, [entityId, metaToDelete, projectSlug, config, loadMeta, onMetaUpdated])
-
-  const openCreateDialog = useCallback(() => {
-    setNewMetaType("")
-    setCreateEditorMode("table")
-    setCreateKvRows(emptyKeyValueRows())
-    setCreateJsonText("{}")
-    setCreateError(null)
-    setShowCreateDialog(true)
-  }, [])
-
   const handleCreate = useCallback(async () => {
-    if (!entityId || !newMetaType.trim()) return
-
-    let data: unknown
-    if (createEditorMode === "table") {
-      const built = rowsToFlatRecord(createKvRows)
-      if (!built.ok) {
-        setCreateError(built.error)
-        return
-      }
-      data = built.data
-    } else {
-      const validation = validateJSON(createJsonText.trim() || "{}")
-      if (!validation.valid) {
-        setCreateError(validation.error || "Invalid JSON")
-        return
-      }
-      data = validation.data
+    if (!entityId) return
+    if (!isValidMetaTypeSlug(newMetaType)) {
+      setCreateError("Use a short key with lowercase letters, numbers, and underscores.")
+      return
     }
-
+    const parsed = parseMetaValueInput(newValueType, newValueText)
+    if (!parsed.ok) {
+      setCreateError(parsed.error)
+      return
+    }
     try {
       setCreating(true)
       setCreateError(null)
       await config.api.createMeta(entityId, projectSlug, {
-        meta_type: newMetaType.trim(),
-        data,
+        meta_type: normalizeMetaTypeSlug(newMetaType),
+        value_type: newValueType,
+        value: parsed.value,
       })
-      await loadMeta()
       setShowCreateDialog(false)
+      setNewMetaType("")
+      setNewValueType("text")
+      setNewValueText("")
+      await loadMeta()
       onMetaUpdated?.()
     } catch (error) {
       console.error("Failed to create meta:", error)
-      setCreateError(error instanceof Error ? error.message : "Failed to create")
+      setCreateError(error instanceof Error ? error.message : "Could not add this detail.")
     } finally {
       setCreating(false)
     }
   }, [
     entityId,
     projectSlug,
-    newMetaType,
-    createEditorMode,
-    createKvRows,
-    createJsonText,
     config,
-    validateJSON,
+    newMetaType,
+    newValueType,
+    newValueText,
     loadMeta,
     onMetaUpdated,
   ])
 
-  const switchCreateToJson = useCallback(() => {
-    if (createEditorMode === "json") return
-    const built = rowsToFlatRecord(createKvRows)
-    if (!built.ok) {
-      setCreateError(built.error)
-      return
+  const confirmDelete = useCallback(async () => {
+    if (!entityId || !metaToDelete) return
+    try {
+      setDeleting((prev) => ({ ...prev, [metaToDelete.id]: true }))
+      await config.api.deleteMeta(entityId, metaToDelete.id, projectSlug)
+      setShowDeleteDialog(false)
+      setMetaToDelete(null)
+      await loadMeta()
+      onMetaUpdated?.()
+    } catch (error) {
+      console.error("Failed to delete meta:", error)
+    } finally {
+      setDeleting((prev) => ({ ...prev, [metaToDelete.id]: false }))
     }
-    setCreateJsonText(JSON.stringify(built.data, null, 2))
-    setCreateEditorMode("json")
-    setCreateError(null)
-  }, [createEditorMode, createKvRows])
+  }, [entityId, metaToDelete, projectSlug, config, loadMeta, onMetaUpdated])
 
-  const switchCreateToTable = useCallback(() => {
-    if (createEditorMode === "table") return
-    const validation = validateJSON(createJsonText.trim() || "{}")
-    if (!validation.valid) {
-      setCreateError(validation.error || "Invalid JSON")
-      return
-    }
-    if (!isFlatScalarRecord(validation.data)) {
-      setCreateError("Only flat key/value objects can use table view. Edit JSON to simplify, or stay in JSON mode.")
-      return
-    }
-    setCreateKvRows(flatRecordToRows(validation.data))
-    setCreateEditorMode("table")
-    setCreateError(null)
-  }, [createEditorMode, createJsonText, validateJSON])
+  if (!entityId) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Details</CardTitle>
+          <CardDescription>Save this record before adding details.</CardDescription>
+        </CardHeader>
+      </Card>
+    )
+  }
 
-  const description =
-    loading || !meta
-      ? loading
-        ? "Loading…"
-        : "Could not load metadata."
-      : (config.subtitle ??
-          `${meta.count} meta item${meta.count !== 1 ? "s" : ""} for this ${config.displayName.singular.toLowerCase()}`)
+  if (loading) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Details</CardTitle>
+        </CardHeader>
+        <CardContent className="flex items-center gap-2 text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Loading…
+        </CardContent>
+      </Card>
+    )
+  }
+
+  const items = meta?.meta ?? []
 
   return (
     <>
       <Card>
-        <CardHeader>
-          <div className="flex flex-row items-start justify-between gap-4">
-            <div className="space-y-1.5 min-w-0">
-              <CardTitle>Metadata</CardTitle>
-              <CardDescription>{description}</CardDescription>
-            </div>
-            <Button type="button" className="shrink-0" onClick={openCreateDialog} disabled={!entityId || loading}>
-              <Plus className="h-4 w-4 mr-2" />
-              Add metadata
-            </Button>
+        <CardHeader className="flex flex-row items-start justify-between gap-4">
+          <div>
+            <CardTitle>Details</CardTitle>
+            <CardDescription>
+              {config.subtitle ??
+                (items.length === 1
+                  ? "1 detail"
+                  : `${items.length} details`)}
+            </CardDescription>
           </div>
+          <Button
+            type="button"
+            size="sm"
+            onClick={() => {
+              setCreateError(null)
+              setShowCreateDialog(true)
+            }}
+          >
+            <Plus className="h-4 w-4 mr-1" />
+            Add detail
+          </Button>
         </CardHeader>
-        <CardContent>
-          {loading ? (
-            <div className="py-8 text-center">
-              <Loader2 className="h-6 w-6 animate-spin mx-auto mb-2" />
-              <p className="text-muted-foreground">Loading meta…</p>
-            </div>
-          ) : !meta ? (
-            <div className="py-6 text-center text-muted-foreground">No metadata available.</div>
-          ) : meta.meta.length === 0 ? (
-            <div className="text-center py-8 text-muted-foreground">No metadata yet.</div>
+        <CardContent className="space-y-4">
+          {items.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No extra details yet.</p>
           ) : (
-            <div className="space-y-4">
-              {meta.meta.map((item) => {
-                const isEditing = editingMeta[item.id] !== undefined
-                const editState = editingMeta[item.id]
-
-                return (
-                  <Card key={item.id}>
-                    <CardHeader className="pb-3">
-                      <div className="flex items-center justify-between gap-2">
-                        <div className="min-w-0">
-                          {!isEditing ? (
-                            <CardTitle className="text-base">{item.meta_type}</CardTitle>
+            items.map((item) => {
+              const edit = editingMeta[item.id]
+              const isEditing = Boolean(edit)
+              return (
+                <div key={item.id} className="rounded-md border p-4 space-y-3">
+                  {isEditing && edit ? (
+                    <>
+                      <div className="grid gap-3 sm:grid-cols-3">
+                        <div className="space-y-1">
+                          <Label htmlFor={`meta-type-${item.id}`}>Key</Label>
+                          <Input
+                            id={`meta-type-${item.id}`}
+                            value={edit.metaType}
+                            onChange={(e) =>
+                              setEditingMeta((prev) => ({
+                                ...prev,
+                                [item.id]: {
+                                  ...edit,
+                                  metaType: e.target.value,
+                                  error: null,
+                                },
+                              }))
+                            }
+                          />
+                        </div>
+                        <div className="space-y-1">
+                          <Label htmlFor={`meta-vt-${item.id}`}>Type</Label>
+                          <select
+                            id={`meta-vt-${item.id}`}
+                            className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm"
+                            value={edit.valueType}
+                            onChange={(e) =>
+                              setEditingMeta((prev) => ({
+                                ...prev,
+                                [item.id]: {
+                                  ...edit,
+                                  valueType: e.target.value as MetaValueType,
+                                  valueText:
+                                    e.target.value === "boolean" ? "true" : edit.valueText,
+                                  error: null,
+                                },
+                              }))
+                            }
+                          >
+                            {VALUE_TYPE_OPTIONS.map((opt) => (
+                              <option key={opt.value} value={opt.value}>
+                                {opt.label}
+                              </option>
+                            ))}
+                          </select>
+                        </div>
+                        <div className="space-y-1">
+                          <Label htmlFor={`meta-val-${item.id}`}>Value</Label>
+                          {edit.valueType === "boolean" ? (
+                            <select
+                              id={`meta-val-${item.id}`}
+                              className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm"
+                              value={edit.valueText}
+                              onChange={(e) =>
+                                setEditingMeta((prev) => ({
+                                  ...prev,
+                                  [item.id]: {
+                                    ...edit,
+                                    valueText: e.target.value,
+                                    error: null,
+                                  },
+                                }))
+                              }
+                            >
+                              <option value="true">Yes</option>
+                              <option value="false">No</option>
+                            </select>
                           ) : (
-                            <div className="space-y-1">
-                              <Label className="text-xs text-muted-foreground">Meta type</Label>
-                              <Input
-                                value={editState.metaType}
-                                onChange={(e) =>
-                                  setEditingMeta((prev) => ({
-                                    ...prev,
-                                    [item.id]: {
-                                      ...prev[item.id],
-                                      metaType: e.target.value,
-                                      jsonError: null,
-                                      tableError: null,
-                                    },
-                                  }))
-                                }
-                                className="max-w-md font-medium"
-                              />
-                            </div>
+                            <Input
+                              id={`meta-val-${item.id}`}
+                              type={edit.valueType === "number" ? "number" : "text"}
+                              value={edit.valueText}
+                              onChange={(e) =>
+                                setEditingMeta((prev) => ({
+                                  ...prev,
+                                  [item.id]: {
+                                    ...edit,
+                                    valueText: e.target.value,
+                                    error: null,
+                                  },
+                                }))
+                              }
+                            />
                           )}
                         </div>
-                        {!isEditing ? (
-                          <div className="flex shrink-0 gap-2">
-                            <Button variant="outline" size="sm" onClick={() => handleStartEdit(item)}>
-                              <Edit className="h-4 w-4 mr-2" />
-                              Edit
-                            </Button>
-                            <Button
-                              variant="outline"
-                              size="sm"
-                              onClick={() => handleDelete(item)}
-                              disabled={deleting[item.id]}
-                            >
-                              {deleting[item.id] ? (
-                                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                              ) : (
-                                <Trash2 className="h-4 w-4 mr-2" />
-                              )}
-                              Delete
-                            </Button>
-                          </div>
-                        ) : (
-                          <div className="flex shrink-0 flex-wrap gap-2">
-                            <Button
-                              size="sm"
-                              onClick={() => void handleSaveEdit(item)}
-                              disabled={saving[item.id]}
-                            >
-                              {saving[item.id] ? (
-                                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                              ) : (
-                                <Save className="h-4 w-4 mr-2" />
-                              )}
-                              Save
-                            </Button>
-                            <Button
-                              variant="outline"
-                              size="sm"
-                              onClick={() => handleCancelEdit(item.id)}
-                              disabled={saving[item.id]}
-                            >
-                              <X className="h-4 w-4 mr-2" />
-                              Cancel
-                            </Button>
-                          </div>
-                        )}
                       </div>
-                    </CardHeader>
-                    <CardContent className="space-y-3">
-                      {isEditing ? (
-                        <div className="space-y-3">
-                          <div className="flex flex-wrap items-center gap-2">
-                            <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-                              Data
-                            </span>
-                            <div className="flex rounded-md border border-border p-0.5">
-                              <Button
-                                type="button"
-                                variant={editState.editorMode === "table" ? "secondary" : "ghost"}
-                                size="sm"
-                                className="h-8 px-2"
-                                onClick={() => setEditToTableMode(item.id)}
-                              >
-                                <Table2 className="h-4 w-4 mr-1.5" />
-                                Table
-                              </Button>
-                              <Button
-                                type="button"
-                                variant={editState.editorMode === "json" ? "secondary" : "ghost"}
-                                size="sm"
-                                className="h-8 px-2"
-                                onClick={() => setEditToJsonMode(item.id)}
-                              >
-                                <Code2 className="h-4 w-4 mr-1.5" />
-                                JSON
-                              </Button>
-                            </div>
-                          </div>
-                          {editState.editorMode === "table" ? (
-                            <div className="space-y-2">
-                              <Table>
-                                <TableHeader>
-                                  <TableRow>
-                                    <TableHead className="w-[38%]">Key</TableHead>
-                                    <TableHead>Value</TableHead>
-                                    <TableHead className="w-[52px] text-right"> </TableHead>
-                                  </TableRow>
-                                </TableHeader>
-                                <TableBody>
-                                  {editState.kvRows.map((row) => (
-                                    <TableRow key={row.id}>
-                                      <TableCell>
-                                        <Input
-                                          value={row.key}
-                                          onChange={(e) => {
-                                            const v = e.target.value
-                                            setEditingMeta((prev) => ({
-                                              ...prev,
-                                              [item.id]: {
-                                                ...prev[item.id],
-                                                kvRows: prev[item.id].kvRows.map((r) =>
-                                                  r.id === row.id ? { ...r, key: v } : r,
-                                                ),
-                                                tableError: null,
-                                              },
-                                            }))
-                                          }}
-                                          placeholder="e.g. Party"
-                                          className="h-9"
-                                        />
-                                      </TableCell>
-                                      <TableCell>
-                                        <Input
-                                          value={row.valueStr}
-                                          onChange={(e) => {
-                                            const v = e.target.value
-                                            setEditingMeta((prev) => ({
-                                              ...prev,
-                                              [item.id]: {
-                                                ...prev[item.id],
-                                                kvRows: prev[item.id].kvRows.map((r) =>
-                                                  r.id === row.id ? { ...r, valueStr: v } : r,
-                                                ),
-                                                tableError: null,
-                                              },
-                                            }))
-                                          }}
-                                          placeholder='e.g. Democrat or 1000 or "quoted"'
-                                          className="h-9 font-mono text-sm"
-                                        />
-                                      </TableCell>
-                                      <TableCell className="text-right">
-                                        <Button
-                                          type="button"
-                                          variant="ghost"
-                                          size="icon"
-                                          className="h-8 w-8 shrink-0"
-                                          disabled={editState.kvRows.length <= 1}
-                                          onClick={() =>
-                                            setEditingMeta((prev) => ({
-                                              ...prev,
-                                              [item.id]: {
-                                                ...prev[item.id],
-                                                kvRows: prev[item.id].kvRows.filter((r) => r.id !== row.id),
-                                                tableError: null,
-                                              },
-                                            }))
-                                          }
-                                          aria-label="Remove row"
-                                        >
-                                          <Trash2 className="h-4 w-4" />
-                                        </Button>
-                                      </TableCell>
-                                    </TableRow>
-                                  ))}
-                                </TableBody>
-                              </Table>
-                              <Button
-                                type="button"
-                                variant="outline"
-                                size="sm"
-                                onClick={() =>
-                                  setEditingMeta((prev) => {
-                                    const cur = prev[item.id]
-                                    if (!cur) return prev
-                                    return {
-                                      ...prev,
-                                      [item.id]: {
-                                        ...cur,
-                                        kvRows: [...cur.kvRows, newKeyValueRow()],
-                                        tableError: null,
-                                      },
-                                    }
-                                  })
-                                }
-                              >
-                                <Plus className="h-4 w-4 mr-2" />
-                                Add row
-                              </Button>
-                              <p className="text-xs text-muted-foreground">
-                                Values can be plain text, or JSON literals for numbers and booleans (
-                                <code className="text-xs">42</code>, <code className="text-xs">true</code>,{" "}
-                                <code className="text-xs">null</code>, <code className="text-xs">{`"text"`}</code>
-                                ). Use JSON mode for nested structures.
-                              </p>
-                              {editState.tableError && (
-                                <p className="text-sm text-destructive">{editState.tableError}</p>
-                              )}
-                            </div>
+                      {edit.error ? (
+                        <p className="text-sm text-destructive">{edit.error}</p>
+                      ) : null}
+                      <div className="flex gap-2">
+                        <Button
+                          type="button"
+                          size="sm"
+                          disabled={saving[item.id]}
+                          onClick={() => void handleSaveEdit(item)}
+                        >
+                          {saving[item.id] ? (
+                            <Loader2 className="h-4 w-4 animate-spin mr-1" />
                           ) : (
-                            <div>
-                              <Textarea
-                                value={editState.jsonText}
-                                onChange={(e) => {
-                                  setEditingMeta((prev) => ({
-                                    ...prev,
-                                    [item.id]: {
-                                      ...prev[item.id],
-                                      jsonText: e.target.value,
-                                      jsonError: null,
-                                    },
-                                  }))
-                                }}
-                                className={`font-mono text-sm ${editState.jsonError ? "border-destructive" : ""}`}
-                                rows={12}
-                              />
-                              {editState.jsonError && (
-                                <p className="text-sm text-destructive mt-2">{editState.jsonError}</p>
-                              )}
-                            </div>
+                            <Save className="h-4 w-4 mr-1" />
                           )}
+                          Save
+                        </Button>
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant="outline"
+                          onClick={() => handleCancelEdit(item.id)}
+                        >
+                          <X className="h-4 w-4 mr-1" />
+                          Cancel
+                        </Button>
+                      </div>
+                    </>
+                  ) : (
+                    <div className="flex items-start justify-between gap-4">
+                      <div>
+                        <div className="font-medium">{item.meta_type}</div>
+                        <div className="text-sm text-muted-foreground">
+                          {VALUE_TYPE_OPTIONS.find((o) => o.value === item.value_type)?.label ??
+                            item.value_type}
+                          {" · "}
+                          {formatMetaValue(item.value)}
                         </div>
-                      ) : (
-                        <MetaDataReadOnly data={item.data} />
-                      )}
-                    </CardContent>
-                  </Card>
-                )
-              })}
-            </div>
+                      </div>
+                      <div className="flex gap-2">
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant="outline"
+                          onClick={() => handleStartEdit(item)}
+                        >
+                          <Edit className="h-4 w-4" />
+                        </Button>
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant="outline"
+                          disabled={deleting[item.id]}
+                          onClick={() => {
+                            setMetaToDelete(item)
+                            setShowDeleteDialog(true)
+                          }}
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )
+            })
           )}
         </CardContent>
       </Card>
 
       <Dialog open={showCreateDialog} onOpenChange={setShowCreateDialog}>
-        <DialogContent className="max-w-lg max-h-[90vh] overflow-y-auto">
+        <DialogContent>
           <DialogHeader>
-            <DialogTitle>Add Metadata</DialogTitle>
+            <DialogTitle>Add detail</DialogTitle>
             <DialogDescription>
-              Add new metadata for this {config.displayName.singular.toLowerCase()}. Use the table for simple
-              fields, or JSON for nested data.
+              Give this a short key, choose a type, and enter a value.
             </DialogDescription>
           </DialogHeader>
-          <div className="space-y-4">
-            <div>
-              <Label>Meta type *</Label>
+          <div className="grid gap-3">
+            <div className="space-y-1">
+              <Label htmlFor="new-meta-type">Key</Label>
               <Input
+                id="new-meta-type"
+                placeholder="population"
                 value={newMetaType}
-                onChange={(e) => setNewMetaType(e.target.value)}
-                placeholder="e.g., demographics, source, notes"
+                onChange={(e) => {
+                  setNewMetaType(e.target.value)
+                  setCreateError(null)
+                }}
               />
             </div>
-            <div className="space-y-2">
-              <div className="flex flex-wrap items-center gap-2">
-                <Label className="text-sm">Data</Label>
-                <div className="flex rounded-md border border-border p-0.5">
-                  <Button
-                    type="button"
-                    variant={createEditorMode === "table" ? "secondary" : "ghost"}
-                    size="sm"
-                    className="h-8 px-2"
-                    onClick={switchCreateToTable}
-                  >
-                    <Table2 className="h-4 w-4 mr-1.5" />
-                    Table
-                  </Button>
-                  <Button
-                    type="button"
-                    variant={createEditorMode === "json" ? "secondary" : "ghost"}
-                    size="sm"
-                    className="h-8 px-2"
-                    onClick={switchCreateToJson}
-                  >
-                    <Code2 className="h-4 w-4 mr-1.5" />
-                    JSON
-                  </Button>
-                </div>
-              </div>
-              {createEditorMode === "table" ? (
-                <div className="space-y-2">
-                  <Table>
-                    <TableHeader>
-                      <TableRow>
-                        <TableHead className="w-[38%]">Key</TableHead>
-                        <TableHead>Value</TableHead>
-                        <TableHead className="w-[52px] text-right"> </TableHead>
-                      </TableRow>
-                    </TableHeader>
-                    <TableBody>
-                      {createKvRows.map((row) => (
-                        <TableRow key={row.id}>
-                          <TableCell>
-                            <Input
-                              value={row.key}
-                              onChange={(e) => {
-                                const v = e.target.value
-                                setCreateKvRows((rows) => rows.map((r) => (r.id === row.id ? { ...r, key: v } : r)))
-                                setCreateError(null)
-                              }}
-                              placeholder="Key"
-                              className="h-9"
-                            />
-                          </TableCell>
-                          <TableCell>
-                            <Input
-                              value={row.valueStr}
-                              onChange={(e) => {
-                                const v = e.target.value
-                                setCreateKvRows((rows) => rows.map((r) => (r.id === row.id ? { ...r, valueStr: v } : r)))
-                                setCreateError(null)
-                              }}
-                              placeholder="Value"
-                              className="h-9 font-mono text-sm"
-                            />
-                          </TableCell>
-                          <TableCell className="text-right">
-                            <Button
-                              type="button"
-                              variant="ghost"
-                              size="icon"
-                              className="h-8 w-8"
-                              disabled={createKvRows.length <= 1}
-                              onClick={() => setCreateKvRows((rows) => rows.filter((r) => r.id !== row.id))}
-                              aria-label="Remove row"
-                            >
-                              <Trash2 className="h-4 w-4" />
-                            </Button>
-                          </TableCell>
-                        </TableRow>
-                      ))}
-                    </TableBody>
-                  </Table>
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    onClick={() => setCreateKvRows((rows) => [...rows, newKeyValueRow()])}
-                  >
-                    <Plus className="h-4 w-4 mr-2" />
-                    Add row
-                  </Button>
-                </div>
-              ) : (
-                <Textarea
-                  value={createJsonText}
+            <div className="space-y-1">
+              <Label htmlFor="new-meta-vt">Type</Label>
+              <select
+                id="new-meta-vt"
+                className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm"
+                value={newValueType}
+                onChange={(e) => {
+                  const next = e.target.value as MetaValueType
+                  setNewValueType(next)
+                  setNewValueText(next === "boolean" ? "true" : "")
+                  setCreateError(null)
+                }}
+              >
+                {VALUE_TYPE_OPTIONS.map((opt) => (
+                  <option key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="new-meta-val">Value</Label>
+              {newValueType === "boolean" ? (
+                <select
+                  id="new-meta-val"
+                  className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm"
+                  value={newValueText || "true"}
                   onChange={(e) => {
-                    setCreateJsonText(e.target.value)
+                    setNewValueText(e.target.value)
                     setCreateError(null)
                   }}
-                  placeholder="{}"
-                  rows={10}
-                  className="font-mono text-sm"
+                >
+                  <option value="true">Yes</option>
+                  <option value="false">No</option>
+                </select>
+              ) : (
+                <Input
+                  id="new-meta-val"
+                  type={newValueType === "number" ? "number" : "text"}
+                  value={newValueText}
+                  onChange={(e) => {
+                    setNewValueText(e.target.value)
+                    setCreateError(null)
+                  }}
                 />
               )}
-              {createError && <p className="text-sm text-destructive">{createError}</p>}
             </div>
+            {createError ? <p className="text-sm text-destructive">{createError}</p> : null}
           </div>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setShowCreateDialog(false)}>
+            <Button type="button" variant="outline" onClick={() => setShowCreateDialog(false)}>
               Cancel
             </Button>
-            <Button onClick={() => void handleCreate()} disabled={creating || !newMetaType.trim()}>
-              {creating ? (
-                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-              ) : (
-                <Plus className="h-4 w-4 mr-2" />
-              )}
-              Create
+            <Button type="button" disabled={creating} onClick={() => void handleCreate()}>
+              {creating ? <Loader2 className="h-4 w-4 animate-spin mr-1" /> : null}
+              Add
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -895,17 +550,17 @@ export default function MetaTab({ entityId, projectSlug, config, onMetaUpdated }
       <Dialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Delete Metadata</DialogTitle>
+            <DialogTitle>Remove detail?</DialogTitle>
             <DialogDescription>
-              Are you sure you want to delete this metadata? This action cannot be undone.
+              This removes “{metaToDelete?.meta_type}” from the record.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setShowDeleteDialog(false)}>
+            <Button type="button" variant="outline" onClick={() => setShowDeleteDialog(false)}>
               Cancel
             </Button>
-            <Button variant="destructive" onClick={() => void confirmDelete()}>
-              Delete
+            <Button type="button" variant="destructive" onClick={() => void confirmDelete()}>
+              Remove
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/apps/stylebook-ui/src/lib/metaDataHeuristic.ts
+++ b/apps/stylebook-ui/src/lib/metaDataHeuristic.ts
@@ -1,100 +1,46 @@
 /**
- * Heuristics for Stylebook location meta `data_json`: treat plain objects whose
- * values are JSON scalars as "simple key / value" for a table UI; everything
- * else uses the raw JSON editor.
+ * Helpers for Stylebook typed canonical metadata (slug keys + scalar values).
  */
 
-export type ScalarJson = null | boolean | number | string
+export type MetaValueType = "text" | "number" | "boolean"
 
-export function isScalarJson(value: unknown): value is ScalarJson {
-  return value === null || typeof value === "string" || typeof value === "number" || typeof value === "boolean"
+const META_TYPE_PATTERN = /^[a-z0-9_]+$/
+
+export function normalizeMetaTypeSlug(raw: string): string {
+  return raw.trim().toLowerCase().replace(/-/g, "_").replace(/\s+/g, "_")
 }
 
-/** Non-null plain object with only scalar values (no nested objects/arrays). */
-export function isFlatScalarRecord(data: unknown): data is Record<string, ScalarJson> {
-  if (data === null || typeof data !== "object" || Array.isArray(data)) return false
-  const o = data as Record<string, unknown>
-  return Object.values(o).every(isScalarJson)
+export function isValidMetaTypeSlug(raw: string): boolean {
+  const slug = normalizeMetaTypeSlug(raw)
+  return slug.length > 0 && META_TYPE_PATTERN.test(slug)
 }
 
-export type KeyValueRow = { id: string; key: string; valueStr: string }
-
-function newRowId(): string {
-  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
-    return crypto.randomUUID()
-  }
-  return `row-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`
+export function formatMetaValue(value: string | number | boolean): string {
+  if (typeof value === "boolean") return value ? "True" : "False"
+  return String(value)
 }
 
-/** Build editable rows from a flat scalar map (stable key order). */
-export function flatRecordToRows(data: Record<string, ScalarJson>): KeyValueRow[] {
-  const keys = Object.keys(data).sort((a, b) => a.localeCompare(b, undefined, { sensitivity: "base" }))
-  if (keys.length === 0) {
-    return [{ id: newRowId(), key: "", valueStr: "" }]
-  }
-  return keys.map((key) => ({
-    id: newRowId(),
-    key,
-    valueStr: valueToCellString(data[key]),
-  }))
-}
-
-export function valueToCellString(value: ScalarJson): string {
-  if (value === null) return "null"
-  if (typeof value === "string") return value
-  return JSON.stringify(value)
-}
-
-/**
- * Parse a single table cell into a JSON scalar. Accepts JSON literals (`42`, `"x"`, `true`);
- * otherwise treats the trimmed string as a plain string (so typing `hello` works without quotes).
- */
-export function parseScalarCell(text: string): { ok: true; value: ScalarJson } | { ok: false; error: string } {
-  const t = text.trim()
-  if (t === "") return { ok: true, value: "" }
-  try {
-    const v: unknown = JSON.parse(t)
-    if (v !== null && typeof v === "object") {
-      return {
-        ok: false,
-        error: "Objects and arrays belong in JSON mode; use a primitive here or switch editor.",
-      }
+export function parseMetaValueInput(
+  valueType: MetaValueType,
+  text: string,
+): { ok: true; value: string | number | boolean } | { ok: false; error: string } {
+  if (valueType === "text") {
+    const trimmed = text.trim()
+    if (!trimmed) return { ok: false, error: "Enter a value." }
+    if (trimmed.includes(":")) {
+      return { ok: false, error: "Text values cannot include a colon." }
     }
-    return { ok: true, value: v as ScalarJson }
-  } catch {
-    return { ok: true, value: t }
+    return { ok: true, value: trimmed }
   }
-}
-
-export function rowsToFlatRecord(
-  rows: KeyValueRow[],
-): { ok: true; data: Record<string, ScalarJson> } | { ok: false; error: string } {
-  const out: Record<string, ScalarJson> = {}
-  const seen = new Set<string>()
-
-  for (const row of rows) {
-    const k = row.key.trim()
-    if (k === "" && row.valueStr.trim() === "") continue
-    if (k === "") {
-      return { ok: false, error: "Each row needs a key, or remove empty rows." }
-    }
-    if (seen.has(k)) {
-      return { ok: false, error: `Duplicate key: "${k}"` }
-    }
-    seen.add(k)
-    const parsed = parseScalarCell(row.valueStr)
-    if (!parsed.ok) return { ok: false, error: parsed.error }
-    out[k] = parsed.value
+  if (valueType === "boolean") {
+    const t = text.trim().toLowerCase()
+    if (t === "true") return { ok: true, value: true }
+    if (t === "false") return { ok: true, value: false }
+    return { ok: false, error: "Choose true or false." }
   }
-
-  return { ok: true, data: out }
-}
-
-export function emptyKeyValueRows(): KeyValueRow[] {
-  return [{ id: newRowId(), key: "", valueStr: "" }]
-}
-
-/** One blank row (use when appending to an existing table). */
-export function newKeyValueRow(): KeyValueRow {
-  return { id: newRowId(), key: "", valueStr: "" }
+  const trimmed = text.trim()
+  if (!trimmed) return { ok: false, error: "Enter a number." }
+  const n = Number(trimmed)
+  if (!Number.isFinite(n)) return { ok: false, error: "Enter a valid number." }
+  return { ok: true, value: n }
 }

--- a/apps/stylebook-ui/src/lib/stylebook-api/meta.ts
+++ b/apps/stylebook-ui/src/lib/stylebook-api/meta.ts
@@ -1,15 +1,30 @@
 import { stylebookJsonFetch } from "@/lib/stylebook-api/client"
 
-export interface LocationMetaItem {
+export type MetaValueType = "text" | "number" | "boolean"
+
+export interface CanonicalMetaItem {
   id: number
   meta_type: string
-  data: unknown
+  value_type: MetaValueType
+  value: string | number | boolean
   created_at?: string
+}
+
+export interface CanonicalMetaWriteBody {
+  meta_type: string
+  value_type: MetaValueType
+  value: string | number | boolean
+}
+
+export interface CanonicalMetaUpdateBody {
+  meta_type?: string
+  value_type: MetaValueType
+  value: string | number | boolean
 }
 
 export interface LocationMetaListResponse {
   location_id: string
-  meta: LocationMetaItem[]
+  meta: CanonicalMetaItem[]
   count: number
 }
 
@@ -25,9 +40,9 @@ export async function getStylebookCanonicalLocationMeta(
 export async function createStylebookCanonicalLocationMeta(
   stylebookSlug: string,
   canonicalId: string,
-  body: { meta_type: string; data: unknown },
-): Promise<LocationMetaItem> {
-  return stylebookJsonFetch<LocationMetaItem>(
+  body: CanonicalMetaWriteBody,
+): Promise<CanonicalMetaItem> {
+  return stylebookJsonFetch<CanonicalMetaItem>(
     `/v1/stylebooks/${encodeURIComponent(stylebookSlug)}/canonical-locations/${encodeURIComponent(canonicalId)}/meta`,
     { method: "POST", body: JSON.stringify(body) },
   )
@@ -37,9 +52,9 @@ export async function updateStylebookCanonicalLocationMeta(
   stylebookSlug: string,
   canonicalId: string,
   metaId: number,
-  body: { data: unknown; meta_type?: string },
-): Promise<LocationMetaItem> {
-  return stylebookJsonFetch<LocationMetaItem>(
+  body: CanonicalMetaUpdateBody,
+): Promise<CanonicalMetaItem> {
+  return stylebookJsonFetch<CanonicalMetaItem>(
     `/v1/stylebooks/${encodeURIComponent(stylebookSlug)}/canonical-locations/${encodeURIComponent(canonicalId)}/meta/${metaId}`,
     { method: "PATCH", body: JSON.stringify(body) },
   )
@@ -56,16 +71,9 @@ export async function deleteStylebookCanonicalLocationMeta(
   )
 }
 
-export interface PersonMetaItem {
-  id: number
-  meta_type: string
-  data: unknown
-  created_at?: string
-}
-
 export interface PersonMetaListResponse {
   person_id: string
-  meta: PersonMetaItem[]
+  meta: CanonicalMetaItem[]
   count: number
 }
 
@@ -81,9 +89,9 @@ export async function getStylebookCanonicalPersonMeta(
 export async function createStylebookCanonicalPersonMeta(
   stylebookSlug: string,
   canonicalId: string,
-  body: { meta_type: string; data: unknown },
-): Promise<PersonMetaItem> {
-  return stylebookJsonFetch<PersonMetaItem>(
+  body: CanonicalMetaWriteBody,
+): Promise<CanonicalMetaItem> {
+  return stylebookJsonFetch<CanonicalMetaItem>(
     `/v1/stylebooks/${encodeURIComponent(stylebookSlug)}/canonical-people/${encodeURIComponent(canonicalId)}/meta`,
     { method: "POST", body: JSON.stringify(body) },
   )
@@ -93,9 +101,9 @@ export async function updateStylebookCanonicalPersonMeta(
   stylebookSlug: string,
   canonicalId: string,
   metaId: number,
-  body: { data: unknown; meta_type?: string },
-): Promise<PersonMetaItem> {
-  return stylebookJsonFetch<PersonMetaItem>(
+  body: CanonicalMetaUpdateBody,
+): Promise<CanonicalMetaItem> {
+  return stylebookJsonFetch<CanonicalMetaItem>(
     `/v1/stylebooks/${encodeURIComponent(stylebookSlug)}/canonical-people/${encodeURIComponent(canonicalId)}/meta/${metaId}`,
     { method: "PATCH", body: JSON.stringify(body) },
   )
@@ -112,16 +120,9 @@ export async function deleteStylebookCanonicalPersonMeta(
   )
 }
 
-export interface OrganizationMetaItem {
-  id: number
-  meta_type: string
-  data: unknown
-  created_at?: string
-}
-
 export interface OrganizationMetaListResponse {
   organization_id: string
-  meta: OrganizationMetaItem[]
+  meta: CanonicalMetaItem[]
   count: number
 }
 
@@ -137,9 +138,9 @@ export async function getStylebookCanonicalOrganizationMeta(
 export async function createStylebookCanonicalOrganizationMeta(
   stylebookSlug: string,
   canonicalId: string,
-  body: { meta_type: string; data: unknown },
-): Promise<OrganizationMetaItem> {
-  return stylebookJsonFetch<OrganizationMetaItem>(
+  body: CanonicalMetaWriteBody,
+): Promise<CanonicalMetaItem> {
+  return stylebookJsonFetch<CanonicalMetaItem>(
     `/v1/stylebooks/${encodeURIComponent(stylebookSlug)}/canonical-organizations/${encodeURIComponent(canonicalId)}/meta`,
     { method: "POST", body: JSON.stringify(body) },
   )
@@ -149,9 +150,9 @@ export async function updateStylebookCanonicalOrganizationMeta(
   stylebookSlug: string,
   canonicalId: string,
   metaId: number,
-  body: { data: unknown; meta_type?: string },
-): Promise<OrganizationMetaItem> {
-  return stylebookJsonFetch<OrganizationMetaItem>(
+  body: CanonicalMetaUpdateBody,
+): Promise<CanonicalMetaItem> {
+  return stylebookJsonFetch<CanonicalMetaItem>(
     `/v1/stylebooks/${encodeURIComponent(stylebookSlug)}/canonical-organizations/${encodeURIComponent(canonicalId)}/meta/${metaId}`,
     { method: "PATCH", body: JSON.stringify(body) },
   )

--- a/docs/api/public.md
+++ b/docs/api/public.md
@@ -128,6 +128,13 @@ Article and mention metadata filters use repeatable `meta` values. Publication
 filters use `external_source`; compatibility aliases and single metadata-field
 parameters are not part of the v1 contract.
 
+People, organizations, and locations list/search (and locations geo-search) accept
+repeatable entity-attribute filters via `attr` (distinct from article `meta=`). Forms:
+`key` (exists), `!key` (missing), `key:value` (eq), and `key:op:value` with
+`eq|neq|ieq|ineq|lt|lte|gt|gte`. OR within `eq`/`ieq` uses `|`; repeated clauses AND.
+Entity detail always returns typed `metadata`; list/search/geo-search include it only
+with `include=metadata`.
+
 Article keyword search accepts `sort=relevance|pub_date` and
 `sort_direction=asc|desc`. With `q`, the default is relevance descending;
 without `q`, the default is publication date descending. Relevance sorting

--- a/docs/api/public.md
+++ b/docs/api/public.md
@@ -132,8 +132,10 @@ People, organizations, and locations list/search (and locations geo-search) acce
 repeatable entity-attribute filters via `attr` (distinct from article `meta=`). Forms:
 `key` (exists), `!key` (missing), `key:value` (eq), and `key:op:value` with
 `eq|neq|ieq|ineq|lt|lte|gt|gte`. OR within `eq`/`ieq` uses `|`; repeated clauses AND.
-Entity detail always returns typed `metadata`; list/search/geo-search include it only
-with `include=metadata`.
+Examples: `party`, `!party`, `party:Democrat`, `population:gt:100000`,
+`party:eq:Democrat|Independent`. Entity detail always returns typed `metadata`;
+list/search/geo-search include it only with `include=metadata` (otherwise the
+field is an empty array).
 
 Article keyword search accepts `sort=relevance|pub_date` and
 `sort_direction=asc|desc`. With `q`, the default is relevance descending;

--- a/docs/api/public.openapi.json
+++ b/docs/api/public.openapi.json
@@ -2026,6 +2026,44 @@
         "title": "PublicArticleTypeCountsOut",
         "type": "object"
       },
+      "PublicCanonicalMetaOut": {
+        "properties": {
+          "meta_type": {
+            "title": "Meta Type",
+            "type": "string"
+          },
+          "value": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              }
+            ],
+            "title": "Value"
+          },
+          "value_type": {
+            "enum": [
+              "text",
+              "number",
+              "boolean"
+            ],
+            "title": "Value Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "meta_type",
+          "value_type",
+          "value"
+        ],
+        "title": "PublicCanonicalMetaOut",
+        "type": "object"
+      },
       "PublicCanonicalSummaryOut": {
         "properties": {
           "id": {
@@ -2811,6 +2849,13 @@
             ],
             "title": "Location Type"
           },
+          "metadata": {
+            "items": {
+              "$ref": "#/components/schemas/PublicCanonicalMetaOut"
+            },
+            "title": "Metadata",
+            "type": "array"
+          },
           "slug": {
             "title": "Slug",
             "type": "string"
@@ -3526,6 +3571,13 @@
             "title": "Label",
             "type": "string"
           },
+          "metadata": {
+            "items": {
+              "$ref": "#/components/schemas/PublicCanonicalMetaOut"
+            },
+            "title": "Metadata",
+            "type": "array"
+          },
           "organization_type": {
             "anyOf": [
               {
@@ -3818,6 +3870,13 @@
           "label": {
             "title": "Label",
             "type": "string"
+          },
+          "metadata": {
+            "items": {
+              "$ref": "#/components/schemas/PublicCanonicalMetaOut"
+            },
+            "title": "Metadata",
+            "type": "array"
           },
           "person_type": {
             "anyOf": [
@@ -9352,6 +9411,36 @@
             }
           },
           {
+            "description": "Repeatable entity-attribute filter clause (AND across clauses). Forms: key (exists), !key (missing), key:value (eq), key:op:value (eq|neq|ieq|ineq|lt|lte|gt|gte). OR within eq/ieq via '|'. Max 25 clauses. Distinct from article meta= filters.",
+            "in": "query",
+            "name": "attr",
+            "required": false,
+            "schema": {
+              "default": [],
+              "description": "Repeatable entity-attribute filter clause (AND across clauses). Forms: key (exists), !key (missing), key:value (eq), key:op:value (eq|neq|ieq|ineq|lt|lte|gt|gte). OR within eq/ieq via '|'. Max 25 clauses. Distinct from article meta= filters.",
+              "items": {
+                "type": "string"
+              },
+              "title": "Attr",
+              "type": "array"
+            }
+          },
+          {
+            "description": "Repeatable include token for optional entity extras. Supported: metadata (typed Stylebook attributes on each item).",
+            "in": "query",
+            "name": "include",
+            "required": false,
+            "schema": {
+              "default": [],
+              "description": "Repeatable include token for optional entity extras. Supported: metadata (typed Stylebook attributes on each item).",
+              "items": {
+                "type": "string"
+              },
+              "title": "Include",
+              "type": "array"
+            }
+          },
+          {
             "description": "label (default) or recent",
             "in": "query",
             "name": "sort",
@@ -9758,6 +9847,36 @@
             }
           },
           {
+            "description": "Repeatable entity-attribute filter clause (AND across clauses). Forms: key (exists), !key (missing), key:value (eq), key:op:value (eq|neq|ieq|ineq|lt|lte|gt|gte). OR within eq/ieq via '|'. Max 25 clauses. Distinct from article meta= filters.",
+            "in": "query",
+            "name": "attr",
+            "required": false,
+            "schema": {
+              "default": [],
+              "description": "Repeatable entity-attribute filter clause (AND across clauses). Forms: key (exists), !key (missing), key:value (eq), key:op:value (eq|neq|ieq|ineq|lt|lte|gt|gte). OR within eq/ieq via '|'. Max 25 clauses. Distinct from article meta= filters.",
+              "items": {
+                "type": "string"
+              },
+              "title": "Attr",
+              "type": "array"
+            }
+          },
+          {
+            "description": "Repeatable include token for optional entity extras. Supported: metadata (typed Stylebook attributes on each item).",
+            "in": "query",
+            "name": "include",
+            "required": false,
+            "schema": {
+              "default": [],
+              "description": "Repeatable include token for optional entity extras. Supported: metadata (typed Stylebook attributes on each item).",
+              "items": {
+                "type": "string"
+              },
+              "title": "Include",
+              "type": "array"
+            }
+          },
+          {
             "in": "query",
             "name": "limit",
             "required": false,
@@ -10068,6 +10187,36 @@
               "minimum": 0,
               "title": "Min Mentions",
               "type": "integer"
+            }
+          },
+          {
+            "description": "Repeatable entity-attribute filter clause (AND across clauses). Forms: key (exists), !key (missing), key:value (eq), key:op:value (eq|neq|ieq|ineq|lt|lte|gt|gte). OR within eq/ieq via '|'. Max 25 clauses. Distinct from article meta= filters.",
+            "in": "query",
+            "name": "attr",
+            "required": false,
+            "schema": {
+              "default": [],
+              "description": "Repeatable entity-attribute filter clause (AND across clauses). Forms: key (exists), !key (missing), key:value (eq), key:op:value (eq|neq|ieq|ineq|lt|lte|gt|gte). OR within eq/ieq via '|'. Max 25 clauses. Distinct from article meta= filters.",
+              "items": {
+                "type": "string"
+              },
+              "title": "Attr",
+              "type": "array"
+            }
+          },
+          {
+            "description": "Repeatable include token for optional entity extras. Supported: metadata (typed Stylebook attributes on each item).",
+            "in": "query",
+            "name": "include",
+            "required": false,
+            "schema": {
+              "default": [],
+              "description": "Repeatable include token for optional entity extras. Supported: metadata (typed Stylebook attributes on each item).",
+              "items": {
+                "type": "string"
+              },
+              "title": "Include",
+              "type": "array"
             }
           },
           {
@@ -13059,6 +13208,36 @@
             }
           },
           {
+            "description": "Repeatable entity-attribute filter clause (AND across clauses). Forms: key (exists), !key (missing), key:value (eq), key:op:value (eq|neq|ieq|ineq|lt|lte|gt|gte). OR within eq/ieq via '|'. Max 25 clauses. Distinct from article meta= filters.",
+            "in": "query",
+            "name": "attr",
+            "required": false,
+            "schema": {
+              "default": [],
+              "description": "Repeatable entity-attribute filter clause (AND across clauses). Forms: key (exists), !key (missing), key:value (eq), key:op:value (eq|neq|ieq|ineq|lt|lte|gt|gte). OR within eq/ieq via '|'. Max 25 clauses. Distinct from article meta= filters.",
+              "items": {
+                "type": "string"
+              },
+              "title": "Attr",
+              "type": "array"
+            }
+          },
+          {
+            "description": "Repeatable include token for optional entity extras. Supported: metadata (typed Stylebook attributes on each item).",
+            "in": "query",
+            "name": "include",
+            "required": false,
+            "schema": {
+              "default": [],
+              "description": "Repeatable include token for optional entity extras. Supported: metadata (typed Stylebook attributes on each item).",
+              "items": {
+                "type": "string"
+              },
+              "title": "Include",
+              "type": "array"
+            }
+          },
+          {
             "description": "label (default) or recent",
             "in": "query",
             "name": "sort",
@@ -13387,6 +13566,36 @@
               "minimum": 0,
               "title": "Min Mentions",
               "type": "integer"
+            }
+          },
+          {
+            "description": "Repeatable entity-attribute filter clause (AND across clauses). Forms: key (exists), !key (missing), key:value (eq), key:op:value (eq|neq|ieq|ineq|lt|lte|gt|gte). OR within eq/ieq via '|'. Max 25 clauses. Distinct from article meta= filters.",
+            "in": "query",
+            "name": "attr",
+            "required": false,
+            "schema": {
+              "default": [],
+              "description": "Repeatable entity-attribute filter clause (AND across clauses). Forms: key (exists), !key (missing), key:value (eq), key:op:value (eq|neq|ieq|ineq|lt|lte|gt|gte). OR within eq/ieq via '|'. Max 25 clauses. Distinct from article meta= filters.",
+              "items": {
+                "type": "string"
+              },
+              "title": "Attr",
+              "type": "array"
+            }
+          },
+          {
+            "description": "Repeatable include token for optional entity extras. Supported: metadata (typed Stylebook attributes on each item).",
+            "in": "query",
+            "name": "include",
+            "required": false,
+            "schema": {
+              "default": [],
+              "description": "Repeatable include token for optional entity extras. Supported: metadata (typed Stylebook attributes on each item).",
+              "items": {
+                "type": "string"
+              },
+              "title": "Include",
+              "type": "array"
             }
           },
           {
@@ -15514,6 +15723,36 @@
             }
           },
           {
+            "description": "Repeatable entity-attribute filter clause (AND across clauses). Forms: key (exists), !key (missing), key:value (eq), key:op:value (eq|neq|ieq|ineq|lt|lte|gt|gte). OR within eq/ieq via '|'. Max 25 clauses. Distinct from article meta= filters.",
+            "in": "query",
+            "name": "attr",
+            "required": false,
+            "schema": {
+              "default": [],
+              "description": "Repeatable entity-attribute filter clause (AND across clauses). Forms: key (exists), !key (missing), key:value (eq), key:op:value (eq|neq|ieq|ineq|lt|lte|gt|gte). OR within eq/ieq via '|'. Max 25 clauses. Distinct from article meta= filters.",
+              "items": {
+                "type": "string"
+              },
+              "title": "Attr",
+              "type": "array"
+            }
+          },
+          {
+            "description": "Repeatable include token for optional entity extras. Supported: metadata (typed Stylebook attributes on each item).",
+            "in": "query",
+            "name": "include",
+            "required": false,
+            "schema": {
+              "default": [],
+              "description": "Repeatable include token for optional entity extras. Supported: metadata (typed Stylebook attributes on each item).",
+              "items": {
+                "type": "string"
+              },
+              "title": "Include",
+              "type": "array"
+            }
+          },
+          {
             "description": "sort_key (default), recent, or label",
             "in": "query",
             "name": "sort",
@@ -15894,6 +16133,36 @@
               "minimum": 0,
               "title": "Min Mentions",
               "type": "integer"
+            }
+          },
+          {
+            "description": "Repeatable entity-attribute filter clause (AND across clauses). Forms: key (exists), !key (missing), key:value (eq), key:op:value (eq|neq|ieq|ineq|lt|lte|gt|gte). OR within eq/ieq via '|'. Max 25 clauses. Distinct from article meta= filters.",
+            "in": "query",
+            "name": "attr",
+            "required": false,
+            "schema": {
+              "default": [],
+              "description": "Repeatable entity-attribute filter clause (AND across clauses). Forms: key (exists), !key (missing), key:value (eq), key:op:value (eq|neq|ieq|ineq|lt|lte|gt|gte). OR within eq/ieq via '|'. Max 25 clauses. Distinct from article meta= filters.",
+              "items": {
+                "type": "string"
+              },
+              "title": "Attr",
+              "type": "array"
+            }
+          },
+          {
+            "description": "Repeatable include token for optional entity extras. Supported: metadata (typed Stylebook attributes on each item).",
+            "in": "query",
+            "name": "include",
+            "required": false,
+            "schema": {
+              "default": [],
+              "description": "Repeatable include token for optional entity extras. Supported: metadata (typed Stylebook attributes on each item).",
+              "items": {
+                "type": "string"
+              },
+              "title": "Include",
+              "type": "array"
             }
           },
           {

--- a/docs/api/public.openapi.json
+++ b/docs/api/public.openapi.json
@@ -9411,13 +9411,13 @@
             }
           },
           {
-            "description": "Repeatable entity-attribute filter clause (AND across clauses). Forms: key (exists), !key (missing), key:value (eq), key:op:value (eq|neq|ieq|ineq|lt|lte|gt|gte). OR within eq/ieq via '|'. Max 25 clauses. Distinct from article meta= filters.",
+            "description": "Repeatable Stylebook attribute filter (AND across clauses; max 25). Forms: key (attribute exists), !key (missing), key:value (equals), key:op:value where op is eq|neq|ieq|ineq|lt|lte|gt|gte. Examples: party, !party, party:Democrat, population:gt:100000, party:ieq:democrat. OR within eq/ieq via '|': party:eq:Democrat|Independent. Distinct from article meta= filters. To return attributes in list/search responses, also pass include=metadata.",
             "in": "query",
             "name": "attr",
             "required": false,
             "schema": {
               "default": [],
-              "description": "Repeatable entity-attribute filter clause (AND across clauses). Forms: key (exists), !key (missing), key:value (eq), key:op:value (eq|neq|ieq|ineq|lt|lte|gt|gte). OR within eq/ieq via '|'. Max 25 clauses. Distinct from article meta= filters.",
+              "description": "Repeatable Stylebook attribute filter (AND across clauses; max 25). Forms: key (attribute exists), !key (missing), key:value (equals), key:op:value where op is eq|neq|ieq|ineq|lt|lte|gt|gte. Examples: party, !party, party:Democrat, population:gt:100000, party:ieq:democrat. OR within eq/ieq via '|': party:eq:Democrat|Independent. Distinct from article meta= filters. To return attributes in list/search responses, also pass include=metadata.",
               "items": {
                 "type": "string"
               },
@@ -9426,13 +9426,13 @@
             }
           },
           {
-            "description": "Repeatable include token for optional entity extras. Supported: metadata (typed Stylebook attributes on each item).",
+            "description": "Repeatable include token for optional entity extras. Supported: metadata (typed Stylebook attributes on each item). Entity detail endpoints always return metadata; list/search/geo-search omit it unless include=metadata.",
             "in": "query",
             "name": "include",
             "required": false,
             "schema": {
               "default": [],
-              "description": "Repeatable include token for optional entity extras. Supported: metadata (typed Stylebook attributes on each item).",
+              "description": "Repeatable include token for optional entity extras. Supported: metadata (typed Stylebook attributes on each item). Entity detail endpoints always return metadata; list/search/geo-search omit it unless include=metadata.",
               "items": {
                 "type": "string"
               },
@@ -9847,13 +9847,13 @@
             }
           },
           {
-            "description": "Repeatable entity-attribute filter clause (AND across clauses). Forms: key (exists), !key (missing), key:value (eq), key:op:value (eq|neq|ieq|ineq|lt|lte|gt|gte). OR within eq/ieq via '|'. Max 25 clauses. Distinct from article meta= filters.",
+            "description": "Repeatable Stylebook attribute filter (AND across clauses; max 25). Forms: key (attribute exists), !key (missing), key:value (equals), key:op:value where op is eq|neq|ieq|ineq|lt|lte|gt|gte. Examples: party, !party, party:Democrat, population:gt:100000, party:ieq:democrat. OR within eq/ieq via '|': party:eq:Democrat|Independent. Distinct from article meta= filters. To return attributes in list/search responses, also pass include=metadata.",
             "in": "query",
             "name": "attr",
             "required": false,
             "schema": {
               "default": [],
-              "description": "Repeatable entity-attribute filter clause (AND across clauses). Forms: key (exists), !key (missing), key:value (eq), key:op:value (eq|neq|ieq|ineq|lt|lte|gt|gte). OR within eq/ieq via '|'. Max 25 clauses. Distinct from article meta= filters.",
+              "description": "Repeatable Stylebook attribute filter (AND across clauses; max 25). Forms: key (attribute exists), !key (missing), key:value (equals), key:op:value where op is eq|neq|ieq|ineq|lt|lte|gt|gte. Examples: party, !party, party:Democrat, population:gt:100000, party:ieq:democrat. OR within eq/ieq via '|': party:eq:Democrat|Independent. Distinct from article meta= filters. To return attributes in list/search responses, also pass include=metadata.",
               "items": {
                 "type": "string"
               },
@@ -9862,13 +9862,13 @@
             }
           },
           {
-            "description": "Repeatable include token for optional entity extras. Supported: metadata (typed Stylebook attributes on each item).",
+            "description": "Repeatable include token for optional entity extras. Supported: metadata (typed Stylebook attributes on each item). Entity detail endpoints always return metadata; list/search/geo-search omit it unless include=metadata.",
             "in": "query",
             "name": "include",
             "required": false,
             "schema": {
               "default": [],
-              "description": "Repeatable include token for optional entity extras. Supported: metadata (typed Stylebook attributes on each item).",
+              "description": "Repeatable include token for optional entity extras. Supported: metadata (typed Stylebook attributes on each item). Entity detail endpoints always return metadata; list/search/geo-search omit it unless include=metadata.",
               "items": {
                 "type": "string"
               },
@@ -10190,13 +10190,13 @@
             }
           },
           {
-            "description": "Repeatable entity-attribute filter clause (AND across clauses). Forms: key (exists), !key (missing), key:value (eq), key:op:value (eq|neq|ieq|ineq|lt|lte|gt|gte). OR within eq/ieq via '|'. Max 25 clauses. Distinct from article meta= filters.",
+            "description": "Repeatable Stylebook attribute filter (AND across clauses; max 25). Forms: key (attribute exists), !key (missing), key:value (equals), key:op:value where op is eq|neq|ieq|ineq|lt|lte|gt|gte. Examples: party, !party, party:Democrat, population:gt:100000, party:ieq:democrat. OR within eq/ieq via '|': party:eq:Democrat|Independent. Distinct from article meta= filters. To return attributes in list/search responses, also pass include=metadata.",
             "in": "query",
             "name": "attr",
             "required": false,
             "schema": {
               "default": [],
-              "description": "Repeatable entity-attribute filter clause (AND across clauses). Forms: key (exists), !key (missing), key:value (eq), key:op:value (eq|neq|ieq|ineq|lt|lte|gt|gte). OR within eq/ieq via '|'. Max 25 clauses. Distinct from article meta= filters.",
+              "description": "Repeatable Stylebook attribute filter (AND across clauses; max 25). Forms: key (attribute exists), !key (missing), key:value (equals), key:op:value where op is eq|neq|ieq|ineq|lt|lte|gt|gte. Examples: party, !party, party:Democrat, population:gt:100000, party:ieq:democrat. OR within eq/ieq via '|': party:eq:Democrat|Independent. Distinct from article meta= filters. To return attributes in list/search responses, also pass include=metadata.",
               "items": {
                 "type": "string"
               },
@@ -10205,13 +10205,13 @@
             }
           },
           {
-            "description": "Repeatable include token for optional entity extras. Supported: metadata (typed Stylebook attributes on each item).",
+            "description": "Repeatable include token for optional entity extras. Supported: metadata (typed Stylebook attributes on each item). Entity detail endpoints always return metadata; list/search/geo-search omit it unless include=metadata.",
             "in": "query",
             "name": "include",
             "required": false,
             "schema": {
               "default": [],
-              "description": "Repeatable include token for optional entity extras. Supported: metadata (typed Stylebook attributes on each item).",
+              "description": "Repeatable include token for optional entity extras. Supported: metadata (typed Stylebook attributes on each item). Entity detail endpoints always return metadata; list/search/geo-search omit it unless include=metadata.",
               "items": {
                 "type": "string"
               },
@@ -13208,13 +13208,13 @@
             }
           },
           {
-            "description": "Repeatable entity-attribute filter clause (AND across clauses). Forms: key (exists), !key (missing), key:value (eq), key:op:value (eq|neq|ieq|ineq|lt|lte|gt|gte). OR within eq/ieq via '|'. Max 25 clauses. Distinct from article meta= filters.",
+            "description": "Repeatable Stylebook attribute filter (AND across clauses; max 25). Forms: key (attribute exists), !key (missing), key:value (equals), key:op:value where op is eq|neq|ieq|ineq|lt|lte|gt|gte. Examples: party, !party, party:Democrat, population:gt:100000, party:ieq:democrat. OR within eq/ieq via '|': party:eq:Democrat|Independent. Distinct from article meta= filters. To return attributes in list/search responses, also pass include=metadata.",
             "in": "query",
             "name": "attr",
             "required": false,
             "schema": {
               "default": [],
-              "description": "Repeatable entity-attribute filter clause (AND across clauses). Forms: key (exists), !key (missing), key:value (eq), key:op:value (eq|neq|ieq|ineq|lt|lte|gt|gte). OR within eq/ieq via '|'. Max 25 clauses. Distinct from article meta= filters.",
+              "description": "Repeatable Stylebook attribute filter (AND across clauses; max 25). Forms: key (attribute exists), !key (missing), key:value (equals), key:op:value where op is eq|neq|ieq|ineq|lt|lte|gt|gte. Examples: party, !party, party:Democrat, population:gt:100000, party:ieq:democrat. OR within eq/ieq via '|': party:eq:Democrat|Independent. Distinct from article meta= filters. To return attributes in list/search responses, also pass include=metadata.",
               "items": {
                 "type": "string"
               },
@@ -13223,13 +13223,13 @@
             }
           },
           {
-            "description": "Repeatable include token for optional entity extras. Supported: metadata (typed Stylebook attributes on each item).",
+            "description": "Repeatable include token for optional entity extras. Supported: metadata (typed Stylebook attributes on each item). Entity detail endpoints always return metadata; list/search/geo-search omit it unless include=metadata.",
             "in": "query",
             "name": "include",
             "required": false,
             "schema": {
               "default": [],
-              "description": "Repeatable include token for optional entity extras. Supported: metadata (typed Stylebook attributes on each item).",
+              "description": "Repeatable include token for optional entity extras. Supported: metadata (typed Stylebook attributes on each item). Entity detail endpoints always return metadata; list/search/geo-search omit it unless include=metadata.",
               "items": {
                 "type": "string"
               },
@@ -13569,13 +13569,13 @@
             }
           },
           {
-            "description": "Repeatable entity-attribute filter clause (AND across clauses). Forms: key (exists), !key (missing), key:value (eq), key:op:value (eq|neq|ieq|ineq|lt|lte|gt|gte). OR within eq/ieq via '|'. Max 25 clauses. Distinct from article meta= filters.",
+            "description": "Repeatable Stylebook attribute filter (AND across clauses; max 25). Forms: key (attribute exists), !key (missing), key:value (equals), key:op:value where op is eq|neq|ieq|ineq|lt|lte|gt|gte. Examples: party, !party, party:Democrat, population:gt:100000, party:ieq:democrat. OR within eq/ieq via '|': party:eq:Democrat|Independent. Distinct from article meta= filters. To return attributes in list/search responses, also pass include=metadata.",
             "in": "query",
             "name": "attr",
             "required": false,
             "schema": {
               "default": [],
-              "description": "Repeatable entity-attribute filter clause (AND across clauses). Forms: key (exists), !key (missing), key:value (eq), key:op:value (eq|neq|ieq|ineq|lt|lte|gt|gte). OR within eq/ieq via '|'. Max 25 clauses. Distinct from article meta= filters.",
+              "description": "Repeatable Stylebook attribute filter (AND across clauses; max 25). Forms: key (attribute exists), !key (missing), key:value (equals), key:op:value where op is eq|neq|ieq|ineq|lt|lte|gt|gte. Examples: party, !party, party:Democrat, population:gt:100000, party:ieq:democrat. OR within eq/ieq via '|': party:eq:Democrat|Independent. Distinct from article meta= filters. To return attributes in list/search responses, also pass include=metadata.",
               "items": {
                 "type": "string"
               },
@@ -13584,13 +13584,13 @@
             }
           },
           {
-            "description": "Repeatable include token for optional entity extras. Supported: metadata (typed Stylebook attributes on each item).",
+            "description": "Repeatable include token for optional entity extras. Supported: metadata (typed Stylebook attributes on each item). Entity detail endpoints always return metadata; list/search/geo-search omit it unless include=metadata.",
             "in": "query",
             "name": "include",
             "required": false,
             "schema": {
               "default": [],
-              "description": "Repeatable include token for optional entity extras. Supported: metadata (typed Stylebook attributes on each item).",
+              "description": "Repeatable include token for optional entity extras. Supported: metadata (typed Stylebook attributes on each item). Entity detail endpoints always return metadata; list/search/geo-search omit it unless include=metadata.",
               "items": {
                 "type": "string"
               },
@@ -15723,13 +15723,13 @@
             }
           },
           {
-            "description": "Repeatable entity-attribute filter clause (AND across clauses). Forms: key (exists), !key (missing), key:value (eq), key:op:value (eq|neq|ieq|ineq|lt|lte|gt|gte). OR within eq/ieq via '|'. Max 25 clauses. Distinct from article meta= filters.",
+            "description": "Repeatable Stylebook attribute filter (AND across clauses; max 25). Forms: key (attribute exists), !key (missing), key:value (equals), key:op:value where op is eq|neq|ieq|ineq|lt|lte|gt|gte. Examples: party, !party, party:Democrat, population:gt:100000, party:ieq:democrat. OR within eq/ieq via '|': party:eq:Democrat|Independent. Distinct from article meta= filters. To return attributes in list/search responses, also pass include=metadata.",
             "in": "query",
             "name": "attr",
             "required": false,
             "schema": {
               "default": [],
-              "description": "Repeatable entity-attribute filter clause (AND across clauses). Forms: key (exists), !key (missing), key:value (eq), key:op:value (eq|neq|ieq|ineq|lt|lte|gt|gte). OR within eq/ieq via '|'. Max 25 clauses. Distinct from article meta= filters.",
+              "description": "Repeatable Stylebook attribute filter (AND across clauses; max 25). Forms: key (attribute exists), !key (missing), key:value (equals), key:op:value where op is eq|neq|ieq|ineq|lt|lte|gt|gte. Examples: party, !party, party:Democrat, population:gt:100000, party:ieq:democrat. OR within eq/ieq via '|': party:eq:Democrat|Independent. Distinct from article meta= filters. To return attributes in list/search responses, also pass include=metadata.",
               "items": {
                 "type": "string"
               },
@@ -15738,13 +15738,13 @@
             }
           },
           {
-            "description": "Repeatable include token for optional entity extras. Supported: metadata (typed Stylebook attributes on each item).",
+            "description": "Repeatable include token for optional entity extras. Supported: metadata (typed Stylebook attributes on each item). Entity detail endpoints always return metadata; list/search/geo-search omit it unless include=metadata.",
             "in": "query",
             "name": "include",
             "required": false,
             "schema": {
               "default": [],
-              "description": "Repeatable include token for optional entity extras. Supported: metadata (typed Stylebook attributes on each item).",
+              "description": "Repeatable include token for optional entity extras. Supported: metadata (typed Stylebook attributes on each item). Entity detail endpoints always return metadata; list/search/geo-search omit it unless include=metadata.",
               "items": {
                 "type": "string"
               },
@@ -16136,13 +16136,13 @@
             }
           },
           {
-            "description": "Repeatable entity-attribute filter clause (AND across clauses). Forms: key (exists), !key (missing), key:value (eq), key:op:value (eq|neq|ieq|ineq|lt|lte|gt|gte). OR within eq/ieq via '|'. Max 25 clauses. Distinct from article meta= filters.",
+            "description": "Repeatable Stylebook attribute filter (AND across clauses; max 25). Forms: key (attribute exists), !key (missing), key:value (equals), key:op:value where op is eq|neq|ieq|ineq|lt|lte|gt|gte. Examples: party, !party, party:Democrat, population:gt:100000, party:ieq:democrat. OR within eq/ieq via '|': party:eq:Democrat|Independent. Distinct from article meta= filters. To return attributes in list/search responses, also pass include=metadata.",
             "in": "query",
             "name": "attr",
             "required": false,
             "schema": {
               "default": [],
-              "description": "Repeatable entity-attribute filter clause (AND across clauses). Forms: key (exists), !key (missing), key:value (eq), key:op:value (eq|neq|ieq|ineq|lt|lte|gt|gte). OR within eq/ieq via '|'. Max 25 clauses. Distinct from article meta= filters.",
+              "description": "Repeatable Stylebook attribute filter (AND across clauses; max 25). Forms: key (attribute exists), !key (missing), key:value (equals), key:op:value where op is eq|neq|ieq|ineq|lt|lte|gt|gte. Examples: party, !party, party:Democrat, population:gt:100000, party:ieq:democrat. OR within eq/ieq via '|': party:eq:Democrat|Independent. Distinct from article meta= filters. To return attributes in list/search responses, also pass include=metadata.",
               "items": {
                 "type": "string"
               },
@@ -16151,13 +16151,13 @@
             }
           },
           {
-            "description": "Repeatable include token for optional entity extras. Supported: metadata (typed Stylebook attributes on each item).",
+            "description": "Repeatable include token for optional entity extras. Supported: metadata (typed Stylebook attributes on each item). Entity detail endpoints always return metadata; list/search/geo-search omit it unless include=metadata.",
             "in": "query",
             "name": "include",
             "required": false,
             "schema": {
               "default": [],
-              "description": "Repeatable include token for optional entity extras. Supported: metadata (typed Stylebook attributes on each item).",
+              "description": "Repeatable include token for optional entity extras. Supported: metadata (typed Stylebook attributes on each item). Entity detail endpoints always return metadata; list/search/geo-search omit it unless include=metadata.",
               "items": {
                 "type": "string"
               },

--- a/docs/api/stylebook.md
+++ b/docs/api/stylebook.md
@@ -41,7 +41,11 @@ Canonical identifiers are UUID strings. Catalog responses expose immutable slugs
 
 Location geometry uses GeoJSON `Point`, `Polygon`, or `MultiPolygon` with longitude-latitude coordinate order.
 
-Canonical metadata is Stylebook-wide editorial data. Its rows retain a project association for storage and bundle transfer, but reads are not filtered to that project. Writes use the organization's first project as that association, so the organization must contain at least one project.
+Canonical metadata is Stylebook-wide editorial data: one typed scalar attribute per
+`meta_type` slug on a canonical (`text`, `number`, or `boolean`). Rows retain a project
+association for storage and bundle transfer, but reads are not filtered to that project.
+Writes use the organization's first project as that association, so the organization must
+contain at least one project. POST upserts by `meta_type`; DELETE hard-deletes.
 
 ## Saved entities and candidate review
 
@@ -92,7 +96,7 @@ Analysis returns detected input information before mutation. Imports allow parti
 
 ### Catalog transfer
 
-Organization bundle-job routes export and import complete Stylebook catalog bundles asynchronously. Current bundles carry location, person, and organization canonicals and their catalog relationships, including aliases, metadata, and connections.
+Organization bundle-job routes export and import complete Stylebook catalog bundles asynchronously. Current bundles (schema version 5) carry location, person, and organization canonicals and their catalog relationships, including aliases, typed metadata, and connections. Legacy freeform `data_json` metadata rows are not rehydrated on import.
 
 Successful export downloads use a presigned GET whose `Content-Disposition` save-as name is
 `{stylebook-slug}-stylebook-export-{YYYY-MM-DD}.zip` (UTC date from the job). Object keys in the

--- a/docs/architecture/database.md
+++ b/docs/architecture/database.md
@@ -130,8 +130,10 @@ New entity domains follow the executable field-name contracts in
   compatibility link, and timestamps.
 - An alias carries its type-specific canonical foreign key, original and normalized text,
   provenance, suppression state, and timestamps.
-- A metadata row carries a project association, its type-specific canonical foreign key, metadata
-  type and JSON value, editor-change flags, and creation time.
+- A metadata row carries a project association, its type-specific canonical foreign key, a
+  normalized metadata type slug, a typed scalar value (`text` / `number` / `boolean` columns),
+  editor-change flags (`added` / `edited`), and creation time. Each canonical allows at most one
+  live row per metadata type.
 
 Type-specific models may add fields, but should not omit the shared contract without an explicit
 architecture decision and matching test changes.

--- a/packages/backfield-db/alembic/versions/076_typed_canonical_meta.py
+++ b/packages/backfield-db/alembic/versions/076_typed_canonical_meta.py
@@ -1,0 +1,88 @@
+"""Replace freeform Stylebook canonical meta JSON with typed scalar columns."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# Revision IDs must fit alembic_version.version_num (varchar(32)).
+revision: str = "076_typed_canonical_meta"
+down_revision: str | None = "075_event_scopes_all_flows"
+branch_labels: Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_META_TABLES: tuple[tuple[str, str, str], ...] = (
+    (
+        "stylebook_location_meta",
+        "stylebook_location_canonical_id",
+        "ix_stylebook_location_meta_canonical_type",
+    ),
+    (
+        "stylebook_person_meta",
+        "stylebook_person_canonical_id",
+        "ix_stylebook_person_meta_canonical_type",
+    ),
+    (
+        "stylebook_organization_meta",
+        "stylebook_organization_canonical_id",
+        "ix_stylebook_organization_meta_canonical_type",
+    ),
+)
+
+
+def upgrade() -> None:
+    for table, canonical_col, old_index in _META_TABLES:
+        op.execute(sa.text(f"TRUNCATE TABLE {table}"))
+        op.drop_index(old_index, table_name=table)
+        op.drop_column(table, "data_json")
+        op.drop_column(table, "deleted")
+        op.add_column(table, sa.Column("value_type", sa.Text(), nullable=False))
+        op.add_column(table, sa.Column("value_text", sa.Text(), nullable=True))
+        op.add_column(table, sa.Column("value_number", sa.Numeric(24, 8), nullable=True))
+        op.add_column(table, sa.Column("value_boolean", sa.Boolean(), nullable=True))
+        op.create_unique_constraint(
+            f"uq_{table}_canonical_type",
+            table,
+            [canonical_col, "meta_type"],
+        )
+        op.create_index(
+            f"ix_{table}_type_text",
+            table,
+            ["meta_type", "value_text"],
+        )
+        op.create_index(
+            f"ix_{table}_type_number",
+            table,
+            ["meta_type", "value_number"],
+        )
+        op.create_check_constraint(
+            f"ck_{table}_value_type",
+            table,
+            "value_type IN ('text', 'number', 'boolean')",
+        )
+
+
+def downgrade() -> None:
+    for table, canonical_col, old_index in reversed(_META_TABLES):
+        op.execute(sa.text(f"TRUNCATE TABLE {table}"))
+        op.drop_constraint(f"ck_{table}_value_type", table, type_="check")
+        op.drop_index(f"ix_{table}_type_number", table_name=table)
+        op.drop_index(f"ix_{table}_type_text", table_name=table)
+        op.drop_constraint(f"uq_{table}_canonical_type", table, type_="unique")
+        op.drop_column(table, "value_boolean")
+        op.drop_column(table, "value_number")
+        op.drop_column(table, "value_text")
+        op.drop_column(table, "value_type")
+        op.add_column(
+            table,
+            sa.Column(
+                "deleted",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.text("false"),
+            ),
+        )
+        op.add_column(table, sa.Column("data_json", sa.JSON(), nullable=True))
+        op.create_index(old_index, table, [canonical_col, "meta_type"])

--- a/packages/backfield-db/src/backfield_db/entity_contracts.py
+++ b/packages/backfield-db/src/backfield_db/entity_contracts.py
@@ -93,10 +93,12 @@ STYLEBOOK_META_FIELD_NAMES: tuple[str, ...] = (
     "project_id",
     "stylebook_location_canonical_id",  # per-type FK
     "meta_type",
-    "data_json",
+    "value_type",
+    "value_text",
+    "value_number",
+    "value_boolean",
     "added",
     "edited",
-    "deleted",
     "created_at",
 )
 

--- a/packages/backfield-db/src/backfield_db/models.py
+++ b/packages/backfield-db/src/backfield_db/models.py
@@ -789,14 +789,20 @@ class StylebookLocationAlias(SQLModel, table=True):
 
 
 class StylebookLocationMeta(SQLModel, table=True):
-    """Arbitrary JSON metadata rows for a canonical location (tags, research blobs, etc.)."""
+    """Typed scalar metadata attributes for a canonical location."""
 
     __tablename__ = "stylebook_location_meta"
     __table_args__ = (
-        Index(
-            "ix_stylebook_location_meta_canonical_type",
+        UniqueConstraint(
             "stylebook_location_canonical_id",
             "meta_type",
+            name="uq_stylebook_location_meta_canonical_type",
+        ),
+        Index("ix_stylebook_location_meta_type_text", "meta_type", "value_text"),
+        Index("ix_stylebook_location_meta_type_number", "meta_type", "value_number"),
+        CheckConstraint(
+            "value_type IN ('text', 'number', 'boolean')",
+            name="ck_stylebook_location_meta_value_type",
         ),
     )
 
@@ -807,16 +813,18 @@ class StylebookLocationMeta(SQLModel, table=True):
         index=True,
     )
     meta_type: str = Field(sa_column=Column(Text, nullable=False, index=True))
-    data_json: Any | None = Field(default=None, sa_column=Column(JSON, nullable=True))
+    value_type: str = Field(sa_column=Column(Text, nullable=False))
+    value_text: str | None = Field(default=None, sa_column=Column(Text, nullable=True))
+    value_number: Decimal | None = Field(
+        default=None,
+        sa_column=Column(Numeric(24, 8), nullable=True),
+    )
+    value_boolean: bool | None = Field(default=None, sa_column=Column(Boolean, nullable=True))
     added: bool = Field(
         default=False,
         sa_column=Column(Boolean, nullable=False, server_default="false"),
     )
     edited: bool = Field(
-        default=False,
-        sa_column=Column(Boolean, nullable=False, server_default="false"),
-    )
-    deleted: bool = Field(
         default=False,
         sa_column=Column(Boolean, nullable=False, server_default="false"),
     )
@@ -908,14 +916,20 @@ class StylebookPersonAlias(SQLModel, table=True):
 
 
 class StylebookPersonMeta(SQLModel, table=True):
-    """Arbitrary JSON metadata rows for a canonical person (tags, research blobs, etc.)."""
+    """Typed scalar metadata attributes for a canonical person."""
 
     __tablename__ = "stylebook_person_meta"
     __table_args__ = (
-        Index(
-            "ix_stylebook_person_meta_canonical_type",
+        UniqueConstraint(
             "stylebook_person_canonical_id",
             "meta_type",
+            name="uq_stylebook_person_meta_canonical_type",
+        ),
+        Index("ix_stylebook_person_meta_type_text", "meta_type", "value_text"),
+        Index("ix_stylebook_person_meta_type_number", "meta_type", "value_number"),
+        CheckConstraint(
+            "value_type IN ('text', 'number', 'boolean')",
+            name="ck_stylebook_person_meta_value_type",
         ),
     )
 
@@ -926,16 +940,18 @@ class StylebookPersonMeta(SQLModel, table=True):
         index=True,
     )
     meta_type: str = Field(sa_column=Column(Text, nullable=False, index=True))
-    data_json: Any | None = Field(default=None, sa_column=Column(JSON, nullable=True))
+    value_type: str = Field(sa_column=Column(Text, nullable=False))
+    value_text: str | None = Field(default=None, sa_column=Column(Text, nullable=True))
+    value_number: Decimal | None = Field(
+        default=None,
+        sa_column=Column(Numeric(24, 8), nullable=True),
+    )
+    value_boolean: bool | None = Field(default=None, sa_column=Column(Boolean, nullable=True))
     added: bool = Field(
         default=False,
         sa_column=Column(Boolean, nullable=False, server_default="false"),
     )
     edited: bool = Field(
-        default=False,
-        sa_column=Column(Boolean, nullable=False, server_default="false"),
-    )
-    deleted: bool = Field(
         default=False,
         sa_column=Column(Boolean, nullable=False, server_default="false"),
     )
@@ -1017,14 +1033,20 @@ class StylebookOrganizationAlias(SQLModel, table=True):
 
 
 class StylebookOrganizationMeta(SQLModel, table=True):
-    """Arbitrary JSON metadata rows for a canonical organization."""
+    """Typed scalar metadata attributes for a canonical organization."""
 
     __tablename__ = "stylebook_organization_meta"
     __table_args__ = (
-        Index(
-            "ix_stylebook_organization_meta_canonical_type",
+        UniqueConstraint(
             "stylebook_organization_canonical_id",
             "meta_type",
+            name="uq_stylebook_organization_meta_canonical_type",
+        ),
+        Index("ix_stylebook_organization_meta_type_text", "meta_type", "value_text"),
+        Index("ix_stylebook_organization_meta_type_number", "meta_type", "value_number"),
+        CheckConstraint(
+            "value_type IN ('text', 'number', 'boolean')",
+            name="ck_stylebook_organization_meta_value_type",
         ),
     )
 
@@ -1035,16 +1057,18 @@ class StylebookOrganizationMeta(SQLModel, table=True):
         index=True,
     )
     meta_type: str = Field(sa_column=Column(Text, nullable=False, index=True))
-    data_json: Any | None = Field(default=None, sa_column=Column(JSON, nullable=True))
+    value_type: str = Field(sa_column=Column(Text, nullable=False))
+    value_text: str | None = Field(default=None, sa_column=Column(Text, nullable=True))
+    value_number: Decimal | None = Field(
+        default=None,
+        sa_column=Column(Numeric(24, 8), nullable=True),
+    )
+    value_boolean: bool | None = Field(default=None, sa_column=Column(Boolean, nullable=True))
     added: bool = Field(
         default=False,
         sa_column=Column(Boolean, nullable=False, server_default="false"),
     )
     edited: bool = Field(
-        default=False,
-        sa_column=Column(Boolean, nullable=False, server_default="false"),
-    )
-    deleted: bool = Field(
         default=False,
         sa_column=Column(Boolean, nullable=False, server_default="false"),
     )

--- a/packages/backfield-entities/src/backfield_entities/catalog/canonical_meta.py
+++ b/packages/backfield-entities/src/backfield_entities/catalog/canonical_meta.py
@@ -1,0 +1,406 @@
+"""Typed Stylebook canonical metadata: validation, serialization, and attr filters."""
+
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+from typing import Any, Literal, TypeAlias
+
+from pydantic import BaseModel, Field, model_validator
+from sqlalchemy import ColumnElement, exists, func
+from sqlmodel import col
+
+MetaValueType = Literal["text", "number", "boolean"]
+AttrOp = Literal["eq", "neq", "ieq", "ineq", "lt", "lte", "gt", "gte", "exists"]
+
+META_TYPE_PATTERN = re.compile(r"^[a-z0-9_]+$")
+MAX_ATTR_CLAUSES = 25
+MAX_ATTR_VALUES_PER_CLAUSE = 50
+
+CanonicalMetaScalar: TypeAlias = str | int | float | bool | Decimal
+
+
+class CanonicalMetaItemOut(BaseModel):
+    """Public/Stylebook metadata item: discriminated scalar ``value``."""
+
+    meta_type: str
+    value_type: MetaValueType
+    value: str | float | bool
+    id: int | None = None
+
+
+class CanonicalMetaWrite(BaseModel):
+    """Validated write payload for a typed metadata attribute."""
+
+    meta_type: str = Field(..., min_length=1)
+    value_type: MetaValueType
+    value: str | int | float | bool
+
+    @model_validator(mode="after")
+    def _normalize_and_validate(self) -> CanonicalMetaWrite:
+        normalized = normalize_meta_type(self.meta_type)
+        validate_typed_value(self.value_type, self.value)
+        if self.value_type == "text":
+            text = str(self.value).strip()
+            if ":" in text:
+                raise ValueError("text metadata values cannot contain ':'")
+            object.__setattr__(self, "value", text)
+        object.__setattr__(self, "meta_type", normalized)
+        return self
+
+
+@dataclass(frozen=True)
+class AttrClause:
+    meta_type: str
+    op: AttrOp
+    values: tuple[str, ...] = ()
+    negate: bool = False
+
+
+class AttrFilterError(ValueError):
+    """Invalid ``attr`` filter clause."""
+
+
+def normalize_meta_type(raw: str) -> str:
+    """Normalize a metadata key to a slug; raise ValueError if invalid."""
+    slug = raw.strip().lower().replace("-", "_").replace(" ", "_")
+    if not slug or not META_TYPE_PATTERN.fullmatch(slug):
+        raise ValueError(
+            "meta_type must be a lowercase slug using letters, digits, and underscores"
+        )
+    return slug
+
+
+def validate_typed_value(value_type: MetaValueType, value: object) -> None:
+    """Raise ValueError when ``value`` does not match ``value_type``."""
+    if value_type == "text":
+        if not isinstance(value, str):
+            raise ValueError("text metadata requires a string value")
+        if not value.strip():
+            raise ValueError("text metadata cannot be empty")
+        return
+    if value_type == "boolean":
+        if type(value) is not bool:
+            raise ValueError("boolean metadata requires a boolean value")
+        return
+    if value_type == "number":
+        if isinstance(value, bool) or not isinstance(value, (int, float, Decimal, str)):
+            raise ValueError("number metadata requires a numeric value")
+        number = _coerce_number(value)
+        if number is None:
+            raise ValueError("number metadata must be a finite number")
+        return
+    raise ValueError(f"unsupported value_type: {value_type}")
+
+
+def _coerce_number(value: object) -> Decimal | None:
+    try:
+        if isinstance(value, bool):
+            return None
+        if isinstance(value, Decimal):
+            number = value
+        elif isinstance(value, int):
+            number = Decimal(value)
+        elif isinstance(value, float):
+            if not math.isfinite(value):
+                return None
+            number = Decimal(str(value))
+        elif isinstance(value, str):
+            text = value.strip()
+            if not text:
+                return None
+            number = Decimal(text)
+        else:
+            return None
+    except (InvalidOperation, ValueError):
+        return None
+    if not number.is_finite():
+        return None
+    return number
+
+
+def typed_columns_for_value(
+    value_type: MetaValueType,
+    value: object,
+) -> tuple[str | None, Decimal | None, bool | None]:
+    """Return ``(value_text, value_number, value_boolean)`` for storage."""
+    validate_typed_value(value_type, value)
+    if value_type == "text":
+        return str(value).strip(), None, None
+    if value_type == "number":
+        number = _coerce_number(value)
+        assert number is not None
+        return None, number, None
+    assert type(value) is bool
+    return None, None, value
+
+
+def api_value_from_row(
+    *,
+    value_type: str,
+    value_text: str | None,
+    value_number: Decimal | None,
+    value_boolean: bool | None,
+) -> str | float | bool:
+    """Build the discriminated API ``value`` from typed columns."""
+    if value_type == "text":
+        return value_text or ""
+    if value_type == "number":
+        if value_number is None:
+            return 0.0
+        # Prefer int when integral for cleaner JSON.
+        if value_number == value_number.to_integral_value():
+            return int(value_number)
+        return float(value_number)
+    return bool(value_boolean)
+
+
+def meta_row_to_api(
+    row: Any,
+    *,
+    include_id: bool = True,
+) -> dict[str, Any]:
+    """Serialize a Stylebook*Meta ORM row to the public/Stylebook JSON shape."""
+    value = api_value_from_row(
+        value_type=str(row.value_type),
+        value_text=row.value_text,
+        value_number=row.value_number,
+        value_boolean=row.value_boolean,
+    )
+    out: dict[str, Any] = {
+        "meta_type": str(row.meta_type),
+        "value_type": str(row.value_type),
+        "value": value,
+    }
+    if include_id and getattr(row, "id", None) is not None:
+        out["id"] = int(row.id)
+    return out
+
+
+def apply_typed_values_to_row(
+    row: Any,
+    *,
+    meta_type: str,
+    value_type: MetaValueType,
+    value: object,
+) -> None:
+    """Set typed columns on an existing meta ORM row."""
+    value_text, value_number, value_boolean = typed_columns_for_value(value_type, value)
+    row.meta_type = meta_type
+    row.value_type = value_type
+    row.value_text = value_text
+    row.value_number = value_number
+    row.value_boolean = value_boolean
+
+
+def infer_eq_value_type(raw: str) -> MetaValueType:
+    """Infer value type for ``eq``/``neq`` filter literals."""
+    if raw in ("true", "false"):
+        return "boolean"
+    if _coerce_number(raw) is not None:
+        return "number"
+    return "text"
+
+
+def parse_attr_clauses(attr: list[str]) -> tuple[AttrClause, ...]:
+    """Parse repeatable ``attr`` query tokens into filter clauses."""
+    if not attr:
+        return ()
+    if len(attr) > MAX_ATTR_CLAUSES:
+        raise AttrFilterError(f"Too many attr clauses. Maximum is {MAX_ATTR_CLAUSES}.")
+
+    clauses: list[AttrClause] = []
+    for raw_token in attr:
+        token = raw_token.strip()
+        if not token:
+            raise AttrFilterError("Invalid attr clause: empty token.")
+        negate = False
+        if token.startswith("!"):
+            negate = True
+            token = token[1:].strip()
+            if not token:
+                raise AttrFilterError("Invalid attr clause: missing key after '!'.")
+
+        parts = token.split(":")
+        if any(part == "" for part in parts):
+            raise AttrFilterError(f"Invalid attr clause: {raw_token!r}.")
+
+        try:
+            meta_type = normalize_meta_type(parts[0])
+        except ValueError as exc:
+            raise AttrFilterError(str(exc)) from exc
+
+        if len(parts) == 1:
+            clauses.append(AttrClause(meta_type=meta_type, op="exists", negate=negate))
+            continue
+
+        if len(parts) == 2:
+            op: AttrOp = "eq"
+            values_raw = parts[1]
+        elif len(parts) == 3:
+            op_raw = parts[1].strip().lower()
+            if op_raw not in {"eq", "neq", "ieq", "ineq", "lt", "lte", "gt", "gte"}:
+                raise AttrFilterError(f"Unsupported attr operator: {op_raw!r}.")
+            op = op_raw  # type: ignore[assignment]
+            values_raw = parts[2]
+        else:
+            raise AttrFilterError(
+                "Invalid attr clause: too many ':' segments "
+                "(text values cannot contain ':')."
+            )
+
+        values = tuple(v for v in (part.strip() for part in values_raw.split("|")) if v)
+        if not values:
+            raise AttrFilterError(f"Invalid attr clause for '{meta_type}': missing value.")
+        if len(values) > MAX_ATTR_VALUES_PER_CLAUSE:
+            raise AttrFilterError(
+                f"Too many values in attr clause for '{meta_type}'. "
+                f"Maximum is {MAX_ATTR_VALUES_PER_CLAUSE}."
+            )
+        if len(values) > 1 and op not in {"eq", "ieq"}:
+            raise AttrFilterError(
+                f"OR ('|') is only supported for eq/ieq (got {op} on '{meta_type}')."
+            )
+        if op in {"ieq", "ineq"}:
+            for value in values:
+                if infer_eq_value_type(value) != "text":
+                    raise AttrFilterError(
+                        f"Operator {op} requires text values (got {value!r})."
+                    )
+        if op in {"lt", "lte", "gt", "gte"}:
+            if _coerce_number(values[0]) is None:
+                raise AttrFilterError(
+                    f"Operator {op} requires a numeric value (got {values[0]!r})."
+                )
+        if op in {"eq", "neq"}:
+            inferred = {infer_eq_value_type(v) for v in values}
+            if len(inferred) != 1:
+                raise AttrFilterError(
+                    f"OR values for '{meta_type}' must share one value type."
+                )
+        clauses.append(
+            AttrClause(meta_type=meta_type, op=op, values=values, negate=negate)
+        )
+    return tuple(clauses)
+
+
+def _value_predicate(
+    meta_model: type[Any],
+    clause: AttrClause,
+) -> ColumnElement[bool]:
+    """Build the value-matching predicate for one attr clause (excluding existence)."""
+    op = clause.op
+    if op == "exists":
+        return True  # type: ignore[return-value]
+
+    if op in {"ieq", "ineq"}:
+        lowered = [v.lower() for v in clause.values]
+        pred = func.lower(col(meta_model.value_text)).in_(lowered)
+        typed = col(meta_model.value_type) == "text"
+        match = typed & pred
+        if op == "ineq":
+            # "not equal to any" for multi-value is unusual; single-value ineq:
+            # value_type text AND lower(text) not in values — still require the row exists
+            # with that meta_type (caller wraps exists). For ineq, match rows whose text
+            # is not in the set.
+            match = typed & ~pred
+        return match
+
+    if op in {"lt", "lte", "gt", "gte"}:
+        number = _coerce_number(clause.values[0])
+        assert number is not None
+        column = col(meta_model.value_number)
+        typed = col(meta_model.value_type) == "number"
+        if op == "lt":
+            return typed & (column < number)
+        if op == "lte":
+            return typed & (column <= number)
+        if op == "gt":
+            return typed & (column > number)
+        return typed & (column >= number)
+
+    # eq / neq
+    value_type = infer_eq_value_type(clause.values[0])
+    typed = col(meta_model.value_type) == value_type
+    if value_type == "text":
+        pred = col(meta_model.value_text).in_(clause.values)
+    elif value_type == "number":
+        numbers = [_coerce_number(v) for v in clause.values]
+        assert all(n is not None for n in numbers)
+        pred = col(meta_model.value_number).in_(numbers)
+    else:
+        bools = [v == "true" for v in clause.values]
+        pred = col(meta_model.value_boolean).in_(bools)
+    match = typed & pred
+    if op == "neq":
+        match = typed & ~pred
+    return match
+
+
+def canonical_attr_exists_filter(
+    *,
+    meta_model: type[Any],
+    canonical_fk_attr: str,
+    canonical_id_column: Any,
+    clause: AttrClause,
+) -> ColumnElement[bool]:
+    """Return an EXISTS (or NOT EXISTS) filter linking a canonical row to meta."""
+    fk = getattr(meta_model, canonical_fk_attr)
+    conditions = [
+        fk == canonical_id_column,
+        col(meta_model.meta_type) == clause.meta_type,
+    ]
+    if clause.op != "exists":
+        conditions.append(_value_predicate(meta_model, clause))
+    statement = exists().where(*conditions)
+    if clause.negate:
+        # For exists, negate means lacking the key.
+        # For value ops, negate means NOT matching the value predicate (still via NOT EXISTS
+        # of matching rows). Note: "not equal" is also available as neq/ineq without '!'.
+        return ~statement
+    return statement
+
+
+def apply_attr_clauses_to_filters(
+    filters: list[ColumnElement[bool]],
+    *,
+    meta_model: type[Any],
+    canonical_fk_attr: str,
+    canonical_id_column: Any,
+    clauses: tuple[AttrClause, ...],
+) -> None:
+    """Append AND-combined attr clause filters onto ``filters``."""
+    for clause in clauses:
+        filters.append(
+            canonical_attr_exists_filter(
+                meta_model=meta_model,
+                canonical_fk_attr=canonical_fk_attr,
+                canonical_id_column=canonical_id_column,
+                clause=clause,
+            )
+        )
+
+
+def coerce_import_scalar(raw: object) -> tuple[MetaValueType, CanonicalMetaScalar]:
+    """Infer a typed scalar from a GeoJSON/CSV property value."""
+    if isinstance(raw, bool):
+        return "boolean", raw
+    if isinstance(raw, (int, float)) and not isinstance(raw, bool):
+        number = _coerce_number(raw)
+        if number is None:
+            raise ValueError("non-finite numeric metadata")
+        return "number", number
+    if isinstance(raw, Decimal):
+        if not raw.is_finite():
+            raise ValueError("non-finite numeric metadata")
+        return "number", raw
+    if isinstance(raw, (dict, list)):
+        raise ValueError("metadata values must be text, number, or boolean (not nested JSON)")
+    text = str(raw).strip()
+    if not text:
+        raise ValueError("empty metadata value")
+    if ":" in text:
+        raise ValueError("text metadata values cannot contain ':'")
+    return "text", text

--- a/packages/backfield-entities/src/backfield_entities/catalog/full_bundle.py
+++ b/packages/backfield-entities/src/backfield_entities/catalog/full_bundle.py
@@ -29,9 +29,15 @@ from backfield_db import (
     StylebookPersonCanonical,
     StylebookPersonMeta,
 )
+from pydantic import ValidationError
 from sqlmodel import Session, col, select
 
 from backfield_entities.canonical.slug import allocate_unique_canonical_slug
+from backfield_entities.catalog.canonical_meta import (
+    CanonicalMetaWrite,
+    api_value_from_row,
+    apply_typed_values_to_row,
+)
 from backfield_entities.catalog.stylebook_library import (
     StylebookLibraryError,
     create_stylebook_for_import,
@@ -55,8 +61,9 @@ from backfield_entities.entities.person.types import derive_person_sort_key
 # v2: location canonical rows only (legacy path ``canonicals/part-*.jsonl``, kind ``canonical``).
 # v3: per-entity shards under ``canonicals/{entity}/`` with kinds ``canonical_location``, …
 # v4: adds aliases, project-scoped meta, and connections (see docs/api/stylebook.md).
-BUNDLE_SCHEMA_VERSION = 4
-ALLOWED_MANIFEST_SCHEMA_VERSIONS = frozenset({1, 2, 3, 4})
+# v5: typed scalar canonical metadata (value_type + value); no freeform data_json.
+BUNDLE_SCHEMA_VERSION = 5
+ALLOWED_MANIFEST_SCHEMA_VERSIONS = frozenset({1, 2, 3, 4, 5})
 BUNDLE_KIND_LEGACY_LOCATION = "canonical"
 BUNDLE_KIND_LOCATION = "canonical_location"
 BUNDLE_KIND_PERSON = "canonical_person"
@@ -406,6 +413,23 @@ def _iter_organization_aliases(
         offset += page
 
 
+def _meta_row_to_export_dict(meta: Any, *, canonical_id: str, project_slug: str) -> dict[str, Any]:
+    return {
+        "canonical_id": canonical_id,
+        "project_slug": project_slug,
+        "meta_type": meta.meta_type,
+        "value_type": meta.value_type,
+        "value": api_value_from_row(
+            value_type=str(meta.value_type),
+            value_text=meta.value_text,
+            value_number=meta.value_number,
+            value_boolean=meta.value_boolean,
+        ),
+        "added": bool(meta.added),
+        "edited": bool(meta.edited),
+    }
+
+
 def _iter_location_meta(session: Session, stylebook_id: int) -> Iterator[dict[str, Any]]:
     offset = 0
     page = 500
@@ -426,15 +450,11 @@ def _iter_location_meta(session: Session, stylebook_id: int) -> Iterator[dict[st
         if not batch:
             break
         for meta, project_slug in batch:
-            yield {
-                "canonical_id": str(meta.stylebook_location_canonical_id),
-                "project_slug": str(project_slug),
-                "meta_type": meta.meta_type,
-                "data_json": meta.data_json,
-                "added": bool(meta.added),
-                "edited": bool(meta.edited),
-                "deleted": bool(meta.deleted),
-            }
+            yield _meta_row_to_export_dict(
+                meta,
+                canonical_id=str(meta.stylebook_location_canonical_id),
+                project_slug=str(project_slug),
+            )
         offset += page
 
 
@@ -457,15 +477,11 @@ def _iter_person_meta(session: Session, stylebook_id: int) -> Iterator[dict[str,
         if not batch:
             break
         for meta, project_slug in batch:
-            yield {
-                "canonical_id": str(meta.stylebook_person_canonical_id),
-                "project_slug": str(project_slug),
-                "meta_type": meta.meta_type,
-                "data_json": meta.data_json,
-                "added": bool(meta.added),
-                "edited": bool(meta.edited),
-                "deleted": bool(meta.deleted),
-            }
+            yield _meta_row_to_export_dict(
+                meta,
+                canonical_id=str(meta.stylebook_person_canonical_id),
+                project_slug=str(project_slug),
+            )
         offset += page
 
 
@@ -489,15 +505,11 @@ def _iter_organization_meta(session: Session, stylebook_id: int) -> Iterator[dic
         if not batch:
             break
         for meta, project_slug in batch:
-            yield {
-                "canonical_id": str(meta.stylebook_organization_canonical_id),
-                "project_slug": str(project_slug),
-                "meta_type": meta.meta_type,
-                "data_json": meta.data_json,
-                "added": bool(meta.added),
-                "edited": bool(meta.edited),
-                "deleted": bool(meta.deleted),
-            }
+            yield _meta_row_to_export_dict(
+                meta,
+                canonical_id=str(meta.stylebook_organization_canonical_id),
+                project_slug=str(project_slug),
+            )
         offset += page
 
 
@@ -1041,6 +1053,20 @@ def _import_organization_alias_row(
     stats["aliases"] += 1
 
 
+def _typed_meta_write_from_bundle_row(row: dict[str, Any]) -> CanonicalMetaWrite | None:
+    """Parse typed meta from a bundle row; skip legacy ``data_json`` payloads."""
+    if "value_type" not in row or "value" not in row:
+        return None
+    try:
+        return CanonicalMetaWrite(
+            meta_type=str(row["meta_type"]),
+            value_type=row["value_type"],
+            value=row["value"],
+        )
+    except (ValueError, TypeError, ValidationError):
+        return None
+
+
 def _import_location_meta_row(
     session: Session,
     *,
@@ -1052,20 +1078,23 @@ def _import_location_meta_row(
     project_slug = str(row.get("project_slug") or "").strip()
     project_id = project_id_by_slug.get(project_slug)
     new_cid = _remap_canonical_id(id_map, str(row["canonical_id"]))
-    if project_id is None or new_cid is None:
+    write = _typed_meta_write_from_bundle_row(row)
+    if project_id is None or new_cid is None or write is None:
         stats["skipped_meta"] += 1
         return
-    session.add(
-        StylebookLocationMeta(
-            project_id=project_id,
-            stylebook_location_canonical_id=new_cid,
-            meta_type=str(row["meta_type"]),
-            data_json=row.get("data_json"),
-            added=bool(row.get("added")),
-            edited=bool(row.get("edited")),
-            deleted=bool(row.get("deleted")),
-        )
+    meta = StylebookLocationMeta(
+        project_id=project_id,
+        stylebook_location_canonical_id=new_cid,
+        added=bool(row.get("added")),
+        edited=bool(row.get("edited")),
     )
+    apply_typed_values_to_row(
+        meta,
+        meta_type=write.meta_type,
+        value_type=write.value_type,
+        value=write.value,
+    )
+    session.add(meta)
     stats["meta"] += 1
 
 
@@ -1080,20 +1109,23 @@ def _import_person_meta_row(
     project_slug = str(row.get("project_slug") or "").strip()
     project_id = project_id_by_slug.get(project_slug)
     new_cid = _remap_canonical_id(id_map, str(row["canonical_id"]))
-    if project_id is None or new_cid is None:
+    write = _typed_meta_write_from_bundle_row(row)
+    if project_id is None or new_cid is None or write is None:
         stats["skipped_meta"] += 1
         return
-    session.add(
-        StylebookPersonMeta(
-            project_id=project_id,
-            stylebook_person_canonical_id=new_cid,
-            meta_type=str(row["meta_type"]),
-            data_json=row.get("data_json"),
-            added=bool(row.get("added")),
-            edited=bool(row.get("edited")),
-            deleted=bool(row.get("deleted")),
-        )
+    meta = StylebookPersonMeta(
+        project_id=project_id,
+        stylebook_person_canonical_id=new_cid,
+        added=bool(row.get("added")),
+        edited=bool(row.get("edited")),
     )
+    apply_typed_values_to_row(
+        meta,
+        meta_type=write.meta_type,
+        value_type=write.value_type,
+        value=write.value,
+    )
+    session.add(meta)
     stats["meta"] += 1
 
 
@@ -1108,20 +1140,23 @@ def _import_organization_meta_row(
     project_slug = str(row.get("project_slug") or "").strip()
     project_id = project_id_by_slug.get(project_slug)
     new_cid = _remap_canonical_id(id_map, str(row["canonical_id"]))
-    if project_id is None or new_cid is None:
+    write = _typed_meta_write_from_bundle_row(row)
+    if project_id is None or new_cid is None or write is None:
         stats["skipped_meta"] += 1
         return
-    session.add(
-        StylebookOrganizationMeta(
-            project_id=project_id,
-            stylebook_organization_canonical_id=new_cid,
-            meta_type=str(row["meta_type"]),
-            data_json=row.get("data_json"),
-            added=bool(row.get("added")),
-            edited=bool(row.get("edited")),
-            deleted=bool(row.get("deleted")),
-        )
+    meta = StylebookOrganizationMeta(
+        project_id=project_id,
+        stylebook_organization_canonical_id=new_cid,
+        added=bool(row.get("added")),
+        edited=bool(row.get("edited")),
     )
+    apply_typed_values_to_row(
+        meta,
+        meta_type=write.meta_type,
+        value_type=write.value_type,
+        value=write.value,
+    )
+    session.add(meta)
     stats["meta"] += 1
 
 

--- a/packages/backfield-entities/src/backfield_entities/public/canonical_metadata.py
+++ b/packages/backfield-entities/src/backfield_entities/public/canonical_metadata.py
@@ -1,0 +1,69 @@
+"""Load and attach typed Stylebook canonical metadata for public entity responses."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel
+from sqlmodel import Session, col, select
+
+from backfield_entities.catalog.canonical_meta import (
+    AttrClause,
+    MetaValueType,
+    apply_attr_clauses_to_filters,
+    meta_row_to_api,
+)
+
+
+class PublicCanonicalMetaOut(BaseModel):
+    meta_type: str
+    value_type: MetaValueType
+    value: str | float | bool
+
+
+def load_meta_by_canonical_ids(
+    session: Session,
+    *,
+    meta_model: type[Any],
+    canonical_fk_attr: str,
+    canonical_ids: list[str],
+) -> dict[str, list[PublicCanonicalMetaOut]]:
+    """Batch-load metadata rows keyed by canonical id string."""
+    if not canonical_ids:
+        return {}
+    fk = getattr(meta_model, canonical_fk_attr)
+    rows = session.exec(
+        select(meta_model)
+        .where(col(fk).in_(canonical_ids))
+        .order_by(col(meta_model.meta_type), col(meta_model.id))
+    ).all()
+    out: dict[str, list[PublicCanonicalMetaOut]] = {cid: [] for cid in canonical_ids}
+    for row in rows:
+        cid = str(getattr(row, canonical_fk_attr))
+        payload = meta_row_to_api(row, include_id=False)
+        out.setdefault(cid, []).append(PublicCanonicalMetaOut(**payload))
+    return out
+
+
+def append_attr_filters(
+    filters: list[Any],
+    *,
+    meta_model: type[Any],
+    canonical_fk_attr: str,
+    canonical_id_column: Any,
+    attr_clauses: tuple[AttrClause, ...],
+) -> None:
+    apply_attr_clauses_to_filters(
+        filters,
+        meta_model=meta_model,
+        canonical_fk_attr=canonical_fk_attr,
+        canonical_id_column=canonical_id_column,
+        clauses=attr_clauses,
+    )
+
+
+__all__ = [
+    "PublicCanonicalMetaOut",
+    "append_attr_filters",
+    "load_meta_by_canonical_ids",
+]

--- a/packages/backfield-entities/src/backfield_entities/public/location_geo_search.py
+++ b/packages/backfield-entities/src/backfield_entities/public/location_geo_search.py
@@ -5,16 +5,18 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import StrEnum
 
-from backfield_db import StylebookLocationCanonical
+from backfield_db import StylebookLocationCanonical, StylebookLocationMeta
 from sqlalchemy import text
 from sqlmodel import Session, col, select
 
+from backfield_entities.catalog.canonical_meta import AttrClause
 from backfield_entities.public.article_geo_search import (
     MILES_TO_METERS,
     _haversine_miles,
     _point_coordinates,
     _sqlite_geometry_matches,
 )
+from backfield_entities.public.canonical_metadata import load_meta_by_canonical_ids
 from backfield_entities.public.locations import (
     PublicLocationOut,
     PublicLocationSearchParams,
@@ -45,6 +47,8 @@ class PublicLocationGeoSearchParams:
     location_type: str | None = None
     natures: tuple[str, ...] = ()
     min_mentions: int = 0
+    attr_clauses: tuple[AttrClause, ...] = ()
+    include_metadata: bool = False
     limit: int = 25
     offset: int = 0
 
@@ -55,6 +59,8 @@ def _keyword_params_from_geo(params: PublicLocationGeoSearchParams) -> PublicLoc
         location_type=params.location_type,
         natures=params.natures,
         min_mentions=params.min_mentions,
+        attr_clauses=params.attr_clauses,
+        include_metadata=params.include_metadata,
         limit=params.limit,
         offset=params.offset,
     )
@@ -242,6 +248,8 @@ def search_public_locations_by_geo(
                 location_type=params.location_type,
                 natures=params.natures,
                 min_mentions=params.min_mentions,
+                attr_clauses=params.attr_clauses,
+                include_metadata=False,
                 limit=10_000,
                 offset=0,
             ),
@@ -272,12 +280,21 @@ def search_public_locations_by_geo(
         canonical_ids=canonical_ids,
     )
     stylebook_slug = stylebook_slugs_by_id(session, {stylebook_id}).get(stylebook_id)
+    meta_by_id = {}
+    if params.include_metadata:
+        meta_by_id = load_meta_by_canonical_ids(
+            session,
+            meta_model=StylebookLocationMeta,
+            canonical_fk_attr="stylebook_location_canonical_id",
+            canonical_ids=canonical_ids,
+        )
     items = [
         _location_to_public_out(
             row,
             mention_count=mention_counts.get(str(row.id), 0),
             story_count=story_counts.get(str(row.id), 0),
             stylebook_slug=stylebook_slug,
+            metadata=meta_by_id.get(str(row.id), []),
         )
         for row in page_rows
     ]

--- a/packages/backfield-entities/src/backfield_entities/public/locations.py
+++ b/packages/backfield-entities/src/backfield_entities/public/locations.py
@@ -10,18 +10,25 @@ from typing import Any
 from backfield_db import (
     StylebookLocationAlias,
     StylebookLocationCanonical,
+    StylebookLocationMeta,
     SubstrateArticle,
     SubstrateLocation,
     SubstrateLocationMention,
     SubstrateLocationMentionOccurrence,
 )
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from sqlalchemy import case, exists, literal, or_
 from sqlalchemy.sql.elements import ColumnElement
 from sqlmodel import Session, col, func, select
 
+from backfield_entities.catalog.canonical_meta import AttrClause
 from backfield_entities.catalog.search import catalog_label_alias_ilike_filter
 from backfield_entities.public.articles import ArticleMetaClause, PublicArticleOut
+from backfield_entities.public.canonical_metadata import (
+    PublicCanonicalMetaOut,
+    append_attr_filters,
+    load_meta_by_canonical_ids,
+)
 from backfield_entities.public.entity_articles import (
     collect_mention_article_pairs,
     paginate_public_articles_from_mention_pairs,
@@ -63,6 +70,7 @@ class PublicLocationOut(BaseModel):
     h3_cell: str | None = None
     h3_resolution: int | None = None
     counts: PublicEntityCountsOut = PublicEntityCountsOut()
+    metadata: list[PublicCanonicalMetaOut] = Field(default_factory=list)
 
 
 class PublicLocationMentionArticleOut(BaseModel):
@@ -89,6 +97,8 @@ class PublicLocationSearchParams:
     location_type: str | None = None
     natures: tuple[str, ...] = ()
     min_mentions: int = 0
+    attr_clauses: tuple[AttrClause, ...] = ()
+    include_metadata: bool = False
     sort: PublicLocationSort = PublicLocationSort.label
     limit: int = 25
     offset: int = 0
@@ -100,6 +110,7 @@ def _location_to_public_out(
     mention_count: int = 0,
     story_count: int = 0,
     stylebook_slug: str | None = None,
+    metadata: list[PublicCanonicalMetaOut] | None = None,
 ) -> PublicLocationOut:
     return PublicLocationOut(
         id=str(canon.id),
@@ -113,6 +124,7 @@ def _location_to_public_out(
         h3_cell=canon.h3_cell,
         h3_resolution=canon.h3_resolution,
         counts=PublicEntityCountsOut(mentions=mention_count, stories=story_count),
+        metadata=list(metadata or []),
     )
 
 
@@ -223,6 +235,13 @@ def location_filters(
             .having(func.count(col(SubstrateLocationMention.id)) >= params.min_mentions)
         )
         filters.append(col(StylebookLocationCanonical.id).in_(min_stmt))
+    append_attr_filters(
+        filters,
+        meta_model=StylebookLocationMeta,
+        canonical_fk_attr="stylebook_location_canonical_id",
+        canonical_id_column=StylebookLocationCanonical.id,
+        attr_clauses=params.attr_clauses,
+    )
     return filters
 
 
@@ -310,12 +329,21 @@ def search_public_locations(
         canonical_ids=canonical_ids,
     )
     stylebook_slug = stylebook_slugs_by_id(session, {stylebook_id}).get(stylebook_id)
+    meta_by_id: dict[str, list[PublicCanonicalMetaOut]] = {}
+    if params.include_metadata:
+        meta_by_id = load_meta_by_canonical_ids(
+            session,
+            meta_model=StylebookLocationMeta,
+            canonical_fk_attr="stylebook_location_canonical_id",
+            canonical_ids=canonical_ids,
+        )
     items = [
         _location_to_public_out(
             row,
             mention_count=mention_counts.get(str(row.id), 0),
             story_count=story_counts.get(str(row.id), 0),
             stylebook_slug=stylebook_slug,
+            metadata=meta_by_id.get(str(row.id), []),
         )
         for row in rows
     ]
@@ -347,11 +375,18 @@ def get_public_location(
         canonical_ids=[str(canon.id)],
     )
     stylebook_slug = stylebook_slugs_by_id(session, {stylebook_id}).get(stylebook_id)
+    meta_by_id = load_meta_by_canonical_ids(
+        session,
+        meta_model=StylebookLocationMeta,
+        canonical_fk_attr="stylebook_location_canonical_id",
+        canonical_ids=[str(canon.id)],
+    )
     return _location_to_public_out(
         canon,
         mention_count=mention_counts.get(str(canon.id), 0),
         story_count=story_counts.get(str(canon.id), 0),
         stylebook_slug=stylebook_slug,
+        metadata=meta_by_id.get(str(canon.id), []),
     )
 
 

--- a/packages/backfield-entities/src/backfield_entities/public/organizations.py
+++ b/packages/backfield-entities/src/backfield_entities/public/organizations.py
@@ -8,17 +8,24 @@ from enum import StrEnum
 
 from backfield_db import (
     StylebookOrganizationCanonical,
+    StylebookOrganizationMeta,
     SubstrateArticle,
     SubstrateOrganization,
     SubstrateOrganizationMention,
     SubstrateOrganizationMentionOccurrence,
 )
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from sqlalchemy import case, exists, literal
 from sqlalchemy.sql.elements import ColumnElement
 from sqlmodel import Session, col, func, select
 
+from backfield_entities.catalog.canonical_meta import AttrClause
 from backfield_entities.public.articles import ArticleMetaClause, PublicArticleOut
+from backfield_entities.public.canonical_metadata import (
+    PublicCanonicalMetaOut,
+    append_attr_filters,
+    load_meta_by_canonical_ids,
+)
 from backfield_entities.public.entity_articles import (
     collect_mention_article_pairs,
     paginate_public_articles_from_mention_pairs,
@@ -59,6 +66,7 @@ class PublicOrganizationOut(BaseModel):
     stylebook_slug: str | None = None
     organization_type: str | None = None
     counts: PublicEntityCountsOut = PublicEntityCountsOut()
+    metadata: list[PublicCanonicalMetaOut] = Field(default_factory=list)
 
 
 class PublicOrganizationMentionArticleOut(BaseModel):
@@ -84,6 +92,8 @@ class PublicOrganizationSearchParams:
     organization_type: str | None = None
     natures: tuple[str, ...] = ()
     min_mentions: int = 0
+    attr_clauses: tuple[AttrClause, ...] = ()
+    include_metadata: bool = False
     sort: PublicOrganizationSort = PublicOrganizationSort.label
     limit: int = 25
     offset: int = 0
@@ -95,6 +105,7 @@ def _organization_to_public_out(
     mention_count: int = 0,
     story_count: int = 0,
     stylebook_slug: str | None = None,
+    metadata: list[PublicCanonicalMetaOut] | None = None,
 ) -> PublicOrganizationOut:
     return PublicOrganizationOut(
         id=str(canon.id),
@@ -103,6 +114,7 @@ def _organization_to_public_out(
         stylebook_slug=stylebook_slug,
         organization_type=canon.organization_type,
         counts=PublicEntityCountsOut(mentions=mention_count, stories=story_count),
+        metadata=list(metadata or []),
     )
 
 
@@ -209,6 +221,13 @@ def _organization_filters(
             .having(func.count(col(SubstrateOrganizationMention.id)) >= params.min_mentions)
         )
         filters.append(col(StylebookOrganizationCanonical.id).in_(min_stmt))
+    append_attr_filters(
+        filters,
+        meta_model=StylebookOrganizationMeta,
+        canonical_fk_attr="stylebook_organization_canonical_id",
+        canonical_id_column=StylebookOrganizationCanonical.id,
+        attr_clauses=params.attr_clauses,
+    )
     return filters
 
 
@@ -296,12 +315,21 @@ def search_public_organizations(
         canonical_ids=canonical_ids,
     )
     stylebook_slug = stylebook_slugs_by_id(session, {stylebook_id}).get(stylebook_id)
+    meta_by_id: dict[str, list[PublicCanonicalMetaOut]] = {}
+    if params.include_metadata:
+        meta_by_id = load_meta_by_canonical_ids(
+            session,
+            meta_model=StylebookOrganizationMeta,
+            canonical_fk_attr="stylebook_organization_canonical_id",
+            canonical_ids=canonical_ids,
+        )
     items = [
         _organization_to_public_out(
             row,
             mention_count=mention_counts.get(str(row.id), 0),
             story_count=story_counts.get(str(row.id), 0),
             stylebook_slug=stylebook_slug,
+            metadata=meta_by_id.get(str(row.id), []),
         )
         for row in rows
     ]
@@ -333,11 +361,18 @@ def get_public_organization(
         canonical_ids=[str(canon.id)],
     )
     stylebook_slug = stylebook_slugs_by_id(session, {stylebook_id}).get(stylebook_id)
+    meta_by_id = load_meta_by_canonical_ids(
+        session,
+        meta_model=StylebookOrganizationMeta,
+        canonical_fk_attr="stylebook_organization_canonical_id",
+        canonical_ids=[str(canon.id)],
+    )
     return _organization_to_public_out(
         canon,
         mention_count=mention_counts.get(str(canon.id), 0),
         story_count=story_counts.get(str(canon.id), 0),
         stylebook_slug=stylebook_slug,
+        metadata=meta_by_id.get(str(canon.id), []),
     )
 
 

--- a/packages/backfield-entities/src/backfield_entities/public/people.py
+++ b/packages/backfield-entities/src/backfield_entities/public/people.py
@@ -8,17 +8,24 @@ from enum import StrEnum
 
 from backfield_db import (
     StylebookPersonCanonical,
+    StylebookPersonMeta,
     SubstrateArticle,
     SubstratePerson,
     SubstratePersonMention,
     SubstratePersonMentionOccurrence,
 )
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from sqlalchemy import case, exists, literal, or_
 from sqlalchemy.sql.elements import ColumnElement
 from sqlmodel import Session, col, func, select
 
+from backfield_entities.catalog.canonical_meta import AttrClause
 from backfield_entities.public.articles import ArticleMetaClause, PublicArticleOut
+from backfield_entities.public.canonical_metadata import (
+    PublicCanonicalMetaOut,
+    append_attr_filters,
+    load_meta_by_canonical_ids,
+)
 from backfield_entities.public.entity_articles import (
     collect_mention_article_pairs,
     paginate_public_articles_from_mention_pairs,
@@ -75,6 +82,7 @@ class PublicPersonOut(BaseModel):
     public_figure: bool = False
     person_type: str | None = None
     counts: PublicEntityCountsOut = PublicEntityCountsOut()
+    metadata: list[PublicCanonicalMetaOut] = Field(default_factory=list)
 
 
 class PublicPersonMentionArticleOut(BaseModel):
@@ -105,6 +113,8 @@ class PublicPersonSearchParams:
     affiliation: str | None = None
     natures: tuple[str, ...] = ()
     min_mentions: int = 0
+    attr_clauses: tuple[AttrClause, ...] = ()
+    include_metadata: bool = False
     sort: PublicPersonSort = PublicPersonSort.sort_key
     limit: int = 25
     offset: int = 0
@@ -116,6 +126,7 @@ def _person_to_public_out(
     mention_count: int = 0,
     story_count: int = 0,
     stylebook_slug: str | None = None,
+    metadata: list[PublicCanonicalMetaOut] | None = None,
 ) -> PublicPersonOut:
     return PublicPersonOut(
         id=str(canon.id),
@@ -127,6 +138,7 @@ def _person_to_public_out(
         public_figure=bool(canon.public_figure),
         person_type=canon.person_type,
         counts=PublicEntityCountsOut(mentions=mention_count, stories=story_count),
+        metadata=list(metadata or []),
     )
 
 
@@ -241,6 +253,13 @@ def _person_filters(
             .having(func.count(col(SubstratePersonMention.id)) >= params.min_mentions)
         )
         filters.append(col(StylebookPersonCanonical.id).in_(min_stmt))
+    append_attr_filters(
+        filters,
+        meta_model=StylebookPersonMeta,
+        canonical_fk_attr="stylebook_person_canonical_id",
+        canonical_id_column=StylebookPersonCanonical.id,
+        attr_clauses=params.attr_clauses,
+    )
     return filters
 
 
@@ -322,12 +341,21 @@ def search_public_people(
         canonical_ids=canonical_ids,
     )
     stylebook_slug = stylebook_slugs_by_id(session, {stylebook_id}).get(stylebook_id)
+    meta_by_id: dict[str, list[PublicCanonicalMetaOut]] = {}
+    if params.include_metadata:
+        meta_by_id = load_meta_by_canonical_ids(
+            session,
+            meta_model=StylebookPersonMeta,
+            canonical_fk_attr="stylebook_person_canonical_id",
+            canonical_ids=canonical_ids,
+        )
     items = [
         _person_to_public_out(
             row,
             mention_count=mention_counts.get(str(row.id), 0),
             story_count=story_counts.get(str(row.id), 0),
             stylebook_slug=stylebook_slug,
+            metadata=meta_by_id.get(str(row.id), []),
         )
         for row in rows
     ]
@@ -355,11 +383,18 @@ def get_public_person(
         canonical_ids=[str(canon.id)],
     )
     stylebook_slug = stylebook_slugs_by_id(session, {stylebook_id}).get(stylebook_id)
+    meta_by_id = load_meta_by_canonical_ids(
+        session,
+        meta_model=StylebookPersonMeta,
+        canonical_fk_attr="stylebook_person_canonical_id",
+        canonical_ids=[str(canon.id)],
+    )
     return _person_to_public_out(
         canon,
         mention_count=mention_counts.get(str(canon.id), 0),
         story_count=story_counts.get(str(canon.id), 0),
         stylebook_slug=stylebook_slug,
+        metadata=meta_by_id.get(str(canon.id), []),
     )
 
 

--- a/tests/backfield_db/test_location_models.py
+++ b/tests/backfield_db/test_location_models.py
@@ -166,10 +166,12 @@ def test_location_models_satisfy_shared_entity_contracts() -> None:
         "project_id",
         "stylebook_location_canonical_id",
         "meta_type",
-        "data_json",
+        "value_type",
+        "value_text",
+        "value_number",
+        "value_boolean",
         "added",
         "edited",
-        "deleted",
         "created_at",
     )
     assert model_has_fields(StylebookLocationMeta, shared_meta)

--- a/tests/backfield_db/test_organization_models.py
+++ b/tests/backfield_db/test_organization_models.py
@@ -178,10 +178,12 @@ def test_organization_models_satisfy_shared_entity_contracts() -> None:
         "project_id",
         "stylebook_organization_canonical_id",
         "meta_type",
-        "data_json",
+        "value_type",
+        "value_text",
+        "value_number",
+        "value_boolean",
         "added",
         "edited",
-        "deleted",
         "created_at",
     )
     assert model_has_fields(StylebookOrganizationMeta, shared_meta)

--- a/tests/backfield_db/test_person_models.py
+++ b/tests/backfield_db/test_person_models.py
@@ -163,10 +163,12 @@ def test_person_models_satisfy_shared_entity_contracts() -> None:
         "project_id",
         "stylebook_person_canonical_id",
         "meta_type",
-        "data_json",
+        "value_type",
+        "value_text",
+        "value_number",
+        "value_boolean",
         "added",
         "edited",
-        "deleted",
         "created_at",
     )
     assert model_has_fields(StylebookPersonMeta, shared_meta)

--- a/tests/entities/test_canonical_meta.py
+++ b/tests/entities/test_canonical_meta.py
@@ -1,0 +1,54 @@
+"""Unit tests for typed canonical metadata helpers."""
+
+from __future__ import annotations
+
+import pytest
+from backfield_entities.catalog.canonical_meta import (
+    AttrFilterError,
+    CanonicalMetaWrite,
+    coerce_import_scalar,
+    normalize_meta_type,
+    parse_attr_clauses,
+    typed_columns_for_value,
+)
+
+
+def test_normalize_meta_type_slug() -> None:
+    assert normalize_meta_type("Party") == "party"
+    assert normalize_meta_type("school-district") == "school_district"
+    with pytest.raises(ValueError):
+        normalize_meta_type("Bad Key!")
+
+
+def test_typed_columns_and_write() -> None:
+    assert typed_columns_for_value("text", "Democratic") == ("Democratic", None, None)
+    write = CanonicalMetaWrite(meta_type="Population", value_type="number", value=12000)
+    assert write.meta_type == "population"
+    assert write.value == 12000
+    with pytest.raises(Exception):
+        CanonicalMetaWrite(meta_type="party", value_type="text", value=" ")
+
+
+def test_parse_attr_clauses_grammar() -> None:
+    clauses = parse_attr_clauses(
+        ["party", "!population", "party:Democratic", "population:lt:50000", "party:ieq:dem"]
+    )
+    assert clauses[0].op == "exists" and clauses[0].meta_type == "party"
+    assert clauses[1].negate and clauses[1].op == "exists"
+    assert clauses[2].op == "eq" and clauses[2].values == ("Democratic",)
+    assert clauses[3].op == "lt"
+    assert clauses[4].op == "ieq"
+    or_clause = parse_attr_clauses(["party:eq:Democratic|Republican"])[0]
+    assert or_clause.values == ("Democratic", "Republican")
+    with pytest.raises(AttrFilterError):
+        parse_attr_clauses(["population:lt:1|2"])
+    with pytest.raises(AttrFilterError):
+        parse_attr_clauses(["note:hello:world:extra"])
+
+
+def test_coerce_import_scalar() -> None:
+    assert coerce_import_scalar(42)[0] == "number"
+    assert coerce_import_scalar(True) == ("boolean", True)
+    assert coerce_import_scalar("hello") == ("text", "hello")
+    with pytest.raises(ValueError):
+        coerce_import_scalar({"nested": True})

--- a/tests/entities/test_full_bundle_roundtrip.py
+++ b/tests/entities/test_full_bundle_roundtrip.py
@@ -205,7 +205,8 @@ def test_export_project_slice_lookup_stays_in_source_organization(tmp_path: Path
                 project_id=int(source_project.id),  # type: ignore[arg-type]
                 stylebook_location_canonical_id=canonical_id,
                 meta_type="review",
-                data_json={},
+                value_type="text",
+                value_text="pending",
             )
         )
         session.commit()
@@ -449,7 +450,8 @@ def test_export_import_roundtrip_includes_aliases_meta_connections(tmp_path: Pat
                 project_id=project_id,
                 stylebook_location_canonical_id=loc_id,
                 meta_type="note",
-                data_json={"body": "Landmark building"},
+                value_type="text",
+                value_text="Landmark building",
                 added=True,
             )
         )
@@ -518,7 +520,8 @@ def test_export_import_roundtrip_includes_aliases_meta_connections(tmp_path: Pat
             )
         ).all()
         assert len(meta_rows) == 1
-        assert meta_rows[0].data_json == {"body": "Landmark building"}
+        assert meta_rows[0].value_type == "text"
+        assert meta_rows[0].value_text == "Landmark building"
 
         connections = session.exec(
             select(StylebookConnection).where(

--- a/tests/stylebook_api/test_person_api.py
+++ b/tests/stylebook_api/test_person_api.py
@@ -637,7 +637,8 @@ def test_canonical_person_mentions_and_stylebook_meta(
                 project_id=int(proj.id),
                 stylebook_person_canonical_id=cid,
                 meta_type="note",
-                data_json={"source": "test"},
+                value_type="text",
+                value_text="test",
             )
         )
         s.commit()

--- a/tests/stylebook_api/test_stylebook_api.py
+++ b/tests/stylebook_api/test_stylebook_api.py
@@ -733,7 +733,7 @@ def test_stylebook_scoped_import_persists_canonical_metadata(
                         "properties": {
                             "name": "Import metadata test",
                             "type": "place",
-                            "details": {"agency": "parks", "priority": 2},
+                            "agency": "parks",
                         },
                     }
                 ],
@@ -743,7 +743,7 @@ def test_stylebook_scoped_import_persists_canonical_metadata(
                 "location_type_property": "type",
             },
             "meta_property_mappings": [
-                {"property_key": "details", "meta_type": "import_details"}
+                {"property_key": "agency", "meta_type": "import_agency"}
             ],
         },
     )
@@ -761,10 +761,9 @@ def test_stylebook_scoped_import_persists_canonical_metadata(
         ).all()
 
     assert len(metadata_rows) == 1
-    assert metadata_rows[0].meta_type == "import_details"
-    assert metadata_rows[0].data_json == {
-        "details": {"agency": "parks", "priority": 2}
-    }
+    assert metadata_rows[0].meta_type == "import_agency"
+    assert metadata_rows[0].value_type == "text"
+    assert metadata_rows[0].value_text == "parks"
     assert metadata_rows[0].added is True
 
 
@@ -1021,7 +1020,8 @@ def test_import_geojson_with_meta_property_mappings(
         ).all()
         assert len(metas) == 1
         assert metas[0].meta_type == "import_ref"
-        assert metas[0].data_json == {"ref": 99}
+        assert metas[0].value_type == "number"
+        assert metas[0].value_number == 99
 
 
 def test_import_geojson_meta_rejects_unknown_property_key(client: TestClient) -> None:
@@ -1103,7 +1103,8 @@ def test_import_geojson_meta_skips_empty_property_silently(
         assert len(metas) == 1
         assert metas[0].stylebook_location_canonical_id in cids
         assert metas[0].meta_type == "note"
-        assert metas[0].data_json == {"notes": "saved"}
+        assert metas[0].value_type == "text"
+        assert metas[0].value_text == "saved"
 
 
 def test_create_location_creates_standalone_canonical_and_alias_no_substrate(
@@ -3393,23 +3394,25 @@ def test_stylebook_canonical_location_meta_crud(
 
     r1 = editor_client.post(
         f"/v1/stylebooks/default/canonical-locations/{cid}/meta",
-        json={"meta_type": "tag", "data": {"shared": True}},
+        json={"meta_type": "tag", "value_type": "boolean", "value": True},
     )
     assert r1.status_code == 200
     mid = int(r1.json()["id"])
+    assert r1.json()["value_type"] == "boolean"
+    assert r1.json()["value"] is True
 
     r2 = editor_client.get(f"/v1/stylebooks/default/canonical-locations/{cid}/meta")
     assert r2.status_code == 200
     assert r2.json()["count"] == 1
-    assert r2.json()["meta"][0]["data"] == {"shared": True}
+    assert r2.json()["meta"][0]["value"] is True
 
     r3 = editor_client.patch(
         f"/v1/stylebooks/default/canonical-locations/{cid}/meta/{mid}",
-        json={"data": {"shared": "everywhere"}, "meta_type": "note"},
+        json={"value_type": "text", "value": "everywhere", "meta_type": "note"},
     )
     assert r3.status_code == 200
     assert r3.json()["meta_type"] == "note"
-    assert r3.json()["data"] == {"shared": "everywhere"}
+    assert r3.json()["value"] == "everywhere"
 
     r4 = editor_client.delete(f"/v1/stylebooks/default/canonical-locations/{cid}/meta/{mid}")
     assert r4.status_code == 200


### PR DESCRIPTION
## Summary

- Replace freeform Stylebook canonical meta (`data_json`) with typed scalar attributes (`text` | `number` | `boolean`) and unique `(canonical_id, meta_type)` rows.
- Expose attributes on the public API: detail always returns `metadata`; list/search/geo-search require `include=metadata`; filter with repeatable `attr=` clauses.
- Update Stylebook CRUD/UI, GeoJSON import coercion, bundle schema v5, Playground help for `attr`, and entity `include=metadata` options.

## Project scope check

- [x] This change targets local development / source inspection (production self-hosting is unsupported in this repo)
- [x] Docs under `docs/` updated if behavior, architecture, or operations changed
- [x] First-admin provisioning still uses `backfield init` / `backfield seed` only (no HTTP/env bootstrap paths)

## Test plan

- [x] `make lint`
- [x] `make test`
- [x] `make ui-typecheck ui-test` (if UI/TypeScript changed) — Playground presentation tests covered; Stylebook UI MetaTab changed (run if not already)
- [ ] `make smoke-fast` (if live-stack behavior changed)
- [ ] `make smoke` (if golden-path / provider-dependent runtime changed; configure **Settings → AI models**)

## Notes for reviewers

- Migration `076_typed_canonical_meta` truncates existing meta rows (no legacy JSON migration path).
- Nested / non-scalar import values are rejected; GeoJSON scalar mappings still work.
- List/search responses include an empty `metadata: []` unless `include=metadata` is set.


Made with [Cursor](https://cursor.com)