### PR TITLE
Add Playground API key vault and original-vs-updated flow rerun

### DIFF
--- a/apps/agate-api/src/api/routers/runs.py
+++ b/apps/agate-api/src/api/routers/runs.py
@@ -73,7 +73,7 @@ from backfield_events import (
 from backfield_observability.celery_publish import register_publish_timestamp_hook
 from backfield_observability.lifecycle import api_identity, emit_item_terminal, emit_run_terminal
 from celery import Celery
-from fastapi import APIRouter, Depends, Header, HTTPException, status
+from fastapi import APIRouter, Body, Depends, Header, HTTPException, status
 from pydantic import BaseModel, Field
 from sqlalchemy import case, delete, desc, func, or_, update
 from sqlmodel import Session, asc, col, select
@@ -341,6 +341,12 @@ class ProcessedItemOverlayPatchIn(BaseModel):
     overlay: dict[str, Any]
 
 
+class UseCurrentFlowBody(BaseModel):
+    """Optional body for rerun and replay: execute the current saved flow."""
+
+    use_current_flow: bool = False
+
+
 class RerunItemResponse(BaseModel):
     """Response when re-queuing a single batch processed item."""
 
@@ -436,6 +442,41 @@ def _run_graph_spec_snapshot_json(run: AgateRun) -> str | None:
     if isinstance(snap, str) and snap.strip():
         return snap
     return None
+
+
+def _use_current_flow(body: UseCurrentFlowBody | None) -> bool:
+    return bool(body and body.use_current_flow)
+
+
+def _live_graph_spec_json(session: Session, graph_id: str) -> str:
+    graph = session.get(AgateGraph, graph_id)
+    if graph is None:
+        raise HTTPException(status_code=404, detail="Graph not found")
+    return graph.spec_json
+
+
+def _send_execute_processed_item(item_id: int, spec_json: str | None = None) -> None:
+    kwargs: dict[str, Any] = {}
+    if spec_json:
+        kwargs["spec_json"] = spec_json
+    celery_app.send_task(
+        "worker.tasks.execute_processed_item",
+        args=[item_id],
+        kwargs=kwargs,
+        queue=_celery_queue(),
+    )
+
+
+def _send_execute_agate_run(run_id: str, spec_json: str | None = None) -> None:
+    kwargs: dict[str, Any] = {}
+    if spec_json:
+        kwargs["spec_json"] = spec_json
+    celery_app.send_task(
+        "worker.tasks.execute_agate_run",
+        args=[run_id],
+        kwargs=kwargs,
+        queue=_celery_queue(),
+    )
 
 
 def _s3_batch_summary_from_run(run: AgateRun) -> S3BatchSummaryOut | None:
@@ -1165,6 +1206,7 @@ def replay_run(
     run_id: str,
     session: Session = Depends(get_session),
     auth: dict[str, Any] = Depends(get_auth),
+    body: UseCurrentFlowBody | None = Body(default=None),
 ):
     """Create a new run that replays the source run's pinned flow settings and item inputs."""
     source = session.get(AgateRun, run_id)
@@ -1177,7 +1219,11 @@ def replay_run(
     if graph is None:
         raise HTTPException(status_code=404, detail="Graph not found")
 
-    snapshot_json = _resolved_run_snapshot_json(session, source)
+    snapshot_json = (
+        graph.spec_json
+        if _use_current_flow(body)
+        else _resolved_run_snapshot_json(session, source)
+    )
     replayable = _replayable_processed_items(session, source.id)
 
     new_run = AgateRun(
@@ -2404,6 +2450,7 @@ def rerun_run_processed_item(
     item_id: int,
     session: Session = Depends(get_session),
     auth: dict[str, Any] = Depends(get_auth),
+    body: UseCurrentFlowBody | None = Body(default=None),
 ) -> RerunItemResponse:
     """Re-queue processing for one item or a whole-graph run.
 
@@ -2418,6 +2465,10 @@ def rerun_run_processed_item(
     if pid:
         require_project_access(session, auth, pid)
 
+    spec_override: str | None = None
+    if _use_current_flow(body):
+        spec_override = _live_graph_spec_json(session, r.graph_id)
+
     if _is_synthetic_whole_graph_item_view(session, run_id, item_id):
         snapshot = _run_graph_spec_snapshot_json(r)
         if r.status in ("succeeded", "failed", "timed_out"):
@@ -2425,18 +2476,15 @@ def rerun_run_processed_item(
             r.execution_attempt = int(r.execution_attempt or 1) + 1
         r.status = "pending"
         r.error_message = None
-        r.result_json = (
-            merge_run_result_payload(None, graph_spec_json=snapshot) if snapshot else None
-        )
+        if spec_override is None:
+            r.result_json = (
+                merge_run_result_payload(None, graph_spec_json=snapshot) if snapshot else None
+            )
         r.updated_at = datetime.now(UTC)
         session.add(r)
         session.commit()
         session.refresh(r)
-        celery_app.send_task(
-            "worker.tasks.execute_agate_run",
-            args=[r.id],
-            queue=_celery_queue(),
-        )
+        _send_execute_agate_run(r.id, spec_json=spec_override)
         return RerunItemResponse(
             item_id=1,
             run_id=r.id,
@@ -2472,11 +2520,7 @@ def rerun_run_processed_item(
     session.commit()
     session.refresh(item)
 
-    celery_app.send_task(
-        "worker.tasks.execute_processed_item",
-        args=[item.id],
-        queue=_celery_queue(),
-    )
+    _send_execute_processed_item(int(item.id), spec_json=spec_override)
 
     iid = item.id
     if iid is None:

--- a/apps/agate-ui/src/components/AppMessageProvider.tsx
+++ b/apps/agate-ui/src/components/AppMessageProvider.tsx
@@ -39,6 +39,17 @@ export type ShowAppConfirmOptions = {
   destructive?: boolean
 }
 
+export type ConfirmChoice = "primary" | "secondary" | false
+
+export type ShowAppConfirmChoiceOptions = {
+  title?: string
+  primaryLabel: string
+  secondaryLabel: string
+  cancelLabel?: string
+  primaryDestructive?: boolean
+  secondaryDestructive?: boolean
+}
+
 type AppDialogState =
   | { kind: "closed" }
   | {
@@ -57,11 +68,26 @@ type AppDialogState =
       destructive: boolean
       resolve: (value: boolean) => void
     }
+  | {
+      kind: "confirm_choice"
+      title: string
+      description: string
+      primaryLabel: string
+      secondaryLabel: string
+      cancelLabel: string
+      primaryDestructive: boolean
+      secondaryDestructive: boolean
+      resolve: (value: ConfirmChoice) => void
+    }
 
 type AppMessageContextValue = {
   showMessage: (description: string, options?: ShowAppMessageOptions) => MessageDialogHandle
   showError: (description: string, options?: { title?: string }) => void
   showConfirm: (description: string, options?: ShowAppConfirmOptions) => Promise<boolean>
+  showConfirmChoice: (
+    description: string,
+    options: ShowAppConfirmChoiceOptions,
+  ) => Promise<ConfirmChoice>
 }
 
 const AppMessageContext = createContext<AppMessageContextValue | null>(null)
@@ -87,6 +113,9 @@ export function AppMessageProvider({ children }: { children: ReactNode }) {
     }
     setState((prev) => {
       if (prev.kind === "confirm") {
+        prev.resolve(false)
+      }
+      if (prev.kind === "confirm_choice") {
         prev.resolve(false)
       }
       return { kind: "closed" }
@@ -139,13 +168,33 @@ export function AppMessageProvider({ children }: { children: ReactNode }) {
     })
   }, [])
 
+  const showConfirmChoice = useCallback(
+    (description: string, options: ShowAppConfirmChoiceOptions): Promise<ConfirmChoice> => {
+      return new Promise((resolve) => {
+        setState({
+          kind: "confirm_choice",
+          title: options.title ?? "Confirm",
+          description,
+          primaryLabel: options.primaryLabel,
+          secondaryLabel: options.secondaryLabel,
+          cancelLabel: options.cancelLabel ?? "Cancel",
+          primaryDestructive: options.primaryDestructive ?? false,
+          secondaryDestructive: options.secondaryDestructive ?? false,
+          resolve,
+        })
+      })
+    },
+    [],
+  )
+
   const value = useMemo(
     () => ({
       showMessage,
       showError,
       showConfirm,
+      showConfirmChoice,
     }),
-    [showConfirm, showError, showMessage],
+    [showConfirm, showConfirmChoice, showError, showMessage],
   )
 
   const open = state.kind !== "closed"
@@ -165,7 +214,7 @@ export function AppMessageProvider({ children }: { children: ReactNode }) {
         }}
       >
         <DialogContent
-          className="sm:max-w-md"
+          className={state.kind === "confirm_choice" ? "sm:max-w-lg" : "sm:max-w-md"}
           hideCloseButton={state.kind === "message" && state.pending}
           onPointerDownOutside={(e) => e.preventDefault()}
           onEscapeKeyDown={(e) => {
@@ -237,6 +286,45 @@ export function AppMessageProvider({ children }: { children: ReactNode }) {
                   }}
                 >
                   {state.confirmLabel}
+                </Button>
+              </DialogFooter>
+            </>
+          ) : null}
+          {state.kind === "confirm_choice" ? (
+            <>
+              <DialogHeader>
+                <DialogTitle>{state.title}</DialogTitle>
+                <DialogDescription className="text-left whitespace-pre-wrap break-words">
+                  {state.description}
+                </DialogDescription>
+              </DialogHeader>
+              <DialogFooter className="gap-2 sm:flex-wrap">
+                <Button type="button" variant="outline" onClick={close}>
+                  {state.cancelLabel}
+                </Button>
+                <Button
+                  type="button"
+                  variant={state.primaryDestructive ? "destructive" : "default"}
+                  onClick={() => {
+                    suppressConfirmDismissRef.current = true
+                    const r = state.resolve
+                    setState({ kind: "closed" })
+                    r("primary")
+                  }}
+                >
+                  {state.primaryLabel}
+                </Button>
+                <Button
+                  type="button"
+                  variant={state.secondaryDestructive ? "destructive" : "secondary"}
+                  onClick={() => {
+                    suppressConfirmDismissRef.current = true
+                    const r = state.resolve
+                    setState({ kind: "closed" })
+                    r("secondary")
+                  }}
+                >
+                  {state.secondaryLabel}
                 </Button>
               </DialogFooter>
             </>

--- a/apps/agate-ui/src/lib/api.test.ts
+++ b/apps/agate-ui/src/lib/api.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { createProject } from './api'
+import { createProject, replayRun, rerunProcessedItem } from './api'
 
 function stubFetch() {
   const fetchMock = vi.fn(
@@ -46,5 +46,17 @@ describe('createProject', () => {
     await createProject({ name: 'Investigations', workspace_id: 3, stylebook_id: null })
 
     expect(sentBody(fetchMock)).not.toHaveProperty('stylebook_id')
+  })
+})
+
+describe('rerun and replay current flow', () => {
+  it('omits use_current_flow unless the caller chose the updated flow', async () => {
+    const fetchMock = stubFetch()
+    await rerunProcessedItem('run-1', 9)
+    expect(sentBody(fetchMock)).toEqual({})
+
+    const replayMock = stubFetch()
+    await replayRun('run-1', { useCurrentFlow: true })
+    expect(sentBody(replayMock)).toEqual({ use_current_flow: true })
   })
 })

--- a/apps/agate-ui/src/lib/api.ts
+++ b/apps/agate-ui/src/lib/api.ts
@@ -806,9 +806,15 @@ export async function createRun(graphId: string | number, data: RunCreate = {}):
   return normalizeRun(raw)
 }
 
-export async function replayRun(runId: string): Promise<Run> {
+export async function replayRun(
+  runId: string,
+  options: { useCurrentFlow?: boolean } = {},
+): Promise<Run> {
   const raw = (await fetchAPI(`/runs/${runId}/replay`, {
     method: 'POST',
+    body: JSON.stringify(
+      options.useCurrentFlow ? { use_current_flow: true } : {},
+    ),
   })) as RawRun
   return normalizeRun(raw)
 }
@@ -1139,10 +1145,14 @@ export interface RerunItemResponse {
 
 export async function rerunProcessedItem(
   runId: string | number,
-  itemId: number
+  itemId: number,
+  options: { useCurrentFlow?: boolean } = {},
 ): Promise<RerunItemResponse> {
   return fetchAPI(`/runs/${runId}/items/${itemId}/rerun`, {
     method: 'POST',
+    body: JSON.stringify(
+      options.useCurrentFlow ? { use_current_flow: true } : {},
+    ),
   }) as Promise<RerunItemResponse>
 }
 

--- a/apps/agate-ui/src/lib/rerunWarning.test.ts
+++ b/apps/agate-ui/src/lib/rerunWarning.test.ts
@@ -1,12 +1,16 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  RERUN_ORIGINAL_FLOW_LABEL,
   RERUN_WARNING_TITLE,
   RUN_AGAIN_WARNING_TITLE,
+  RUN_UPDATED_FLOW_LABEL,
+  promptFlowRerun,
   reconciliationPolicyFromGraph,
   runAgainWarningBody,
   rerunWarningBody,
   rerunWarningTitle,
+  shouldOfferUpdatedFlow,
 } from './rerunWarning'
 
 describe('rerunWarning', () => {
@@ -30,6 +34,60 @@ describe('rerunWarning', () => {
     expect(rerunWarningBody(3, { flowName: 'Places', policy: 'replace' })).toBe(
       'This will replay using the flow settings from when this run started (“Places”) with Replace. Run review edits on these 3 items will be cleared. It will replace existing saved data from the flow’s categories with this run’s results.',
     )
+  })
+
+  it('mentions the current saved flow when both actions are offered', () => {
+    expect(
+      rerunWarningBody(1, {
+        flowName: 'Places',
+        policy: 'smart_merge',
+        offerUpdatedFlow: true,
+      }),
+    ).toContain('Run updated flow uses the current saved flow.')
+    expect(
+      runAgainWarningBody({
+        flowName: 'Starter',
+        policy: 'smart_merge',
+        offerUpdatedFlow: true,
+      }),
+    ).toContain('Run updated flow uses the current saved flow.')
+  })
+
+  it('offers the updated-flow action only when the saved flow changed', () => {
+    expect(shouldOfferUpdatedFlow(true)).toBe(true)
+    expect(shouldOfferUpdatedFlow(false)).toBe(false)
+    expect(shouldOfferUpdatedFlow(null)).toBe(false)
+  })
+
+  it('prompts original vs updated flow only when the saved flow changed', async () => {
+    const showConfirm = async () => true
+    const showConfirmChoice = async () => 'secondary' as const
+    await expect(
+      promptFlowRerun({
+        flowChanged: false,
+        title: RERUN_WARNING_TITLE,
+        unchangedConfirmLabel: 'Rerun',
+        description: 'body',
+        originalPolicy: 'smart_merge',
+        updatedPolicy: 'replace',
+        showConfirm,
+        showConfirmChoice,
+      }),
+    ).resolves.toBe('original')
+    await expect(
+      promptFlowRerun({
+        flowChanged: true,
+        title: RERUN_WARNING_TITLE,
+        unchangedConfirmLabel: 'Rerun',
+        description: 'body',
+        originalPolicy: 'smart_merge',
+        updatedPolicy: 'replace',
+        showConfirm,
+        showConfirmChoice,
+      }),
+    ).resolves.toBe('updated')
+    expect(RERUN_ORIGINAL_FLOW_LABEL).toBe('Rerun original flow')
+    expect(RUN_UPDATED_FLOW_LABEL).toBe('Run updated flow')
   })
 
   it('reads the Backfield Output policy from graph params', () => {

--- a/apps/agate-ui/src/lib/rerunWarning.ts
+++ b/apps/agate-ui/src/lib/rerunWarning.ts
@@ -1,14 +1,26 @@
-/** Confirmation copy for re-runs that replay a run's pinned flow settings. */
+import type {
+  ConfirmChoice,
+  ShowAppConfirmChoiceOptions,
+  ShowAppConfirmOptions,
+} from '@/components/AppMessageProvider'
 
 export const RERUN_WARNING_TITLE = 'Rerun item?'
 
 export const RUN_AGAIN_WARNING_TITLE = 'Replay run?'
 
+export const RERUN_ORIGINAL_FLOW_LABEL = 'Rerun original flow'
+
+export const RUN_UPDATED_FLOW_LABEL = 'Run updated flow'
+
 export type ReconciliationPolicy = 'add_only' | 'smart_merge' | 'replace'
+
+export type FlowRerunDecision = 'original' | 'updated' | false
 
 type FlowWarningOptions = {
   flowName?: string | null
   policy?: ReconciliationPolicy | string | null
+  /** When true, mention that Run updated flow uses the current saved flow. */
+  offerUpdatedFlow?: boolean
 }
 
 const policyLabel = (policy: ReconciliationPolicy): string => {
@@ -33,6 +45,12 @@ export const reconciliationPolicyFromGraph = (graph: {
   return normalizeReconciliationPolicy(node?.params?.reconciliation_policy as string | undefined)
 }
 
+export function shouldOfferUpdatedFlow(
+  flowChanged: boolean | null | undefined,
+): boolean {
+  return flowChanged === true
+}
+
 const flowSentence = ({ flowName, policy }: FlowWarningOptions): string => {
   const quoted = flowName?.trim() ? `“${flowName.trim()}”` : 'this flow'
   const normalized = normalizeReconciliationPolicy(policy)
@@ -53,12 +71,16 @@ const policySentence = (policy: ReconciliationPolicy): string => {
   return 'It will update saved data from the flow while preserving changes made by editors.'
 }
 
+const updatedFlowSentence = 'Run updated flow uses the current saved flow.'
+
 export const RUN_AGAIN_WARNING_BODY =
   flowSentence({ policy: 'smart_merge' }) + ' ' + policySentence('smart_merge')
 
 export const runAgainWarningBody = (options: FlowWarningOptions = {}): string => {
   const policy = normalizeReconciliationPolicy(options.policy)
-  return `${flowSentence({ ...options, policy })} ${policySentence(policy)}`
+  const body = `${flowSentence({ ...options, policy })} ${policySentence(policy)}`
+  if (!options.offerUpdatedFlow) return body
+  return `${body} ${updatedFlowSentence}`
 }
 
 export const rerunWarningTitle = (itemCount = 1): string =>
@@ -71,5 +93,40 @@ export const rerunWarningBody = (
   const itemPhrase =
     itemCount === 1 ? 'this item' : `these ${itemCount} items`
   const policy = normalizeReconciliationPolicy(options.policy)
-  return `${flowSentence({ ...options, policy })} Run review edits on ${itemPhrase} will be cleared. ${policySentence(policy)}`
+  const body = `${flowSentence({ ...options, policy })} Run review edits on ${itemPhrase} will be cleared. ${policySentence(policy)}`
+  if (!options.offerUpdatedFlow) return body
+  return `${body} ${updatedFlowSentence}`
+}
+
+export async function promptFlowRerun(args: {
+  flowChanged: boolean | null | undefined
+  title: string
+  unchangedConfirmLabel: string
+  description: string
+  originalPolicy: ReconciliationPolicy
+  updatedPolicy: ReconciliationPolicy
+  showConfirm: (description: string, options?: ShowAppConfirmOptions) => Promise<boolean>
+  showConfirmChoice: (
+    description: string,
+    options: ShowAppConfirmChoiceOptions,
+  ) => Promise<ConfirmChoice>
+}): Promise<FlowRerunDecision> {
+  if (!shouldOfferUpdatedFlow(args.flowChanged)) {
+    const ok = await args.showConfirm(args.description, {
+      title: args.title,
+      confirmLabel: args.unchangedConfirmLabel,
+      destructive: args.originalPolicy === 'replace',
+    })
+    return ok ? 'original' : false
+  }
+  const choice = await args.showConfirmChoice(args.description, {
+    title: args.title,
+    primaryLabel: RERUN_ORIGINAL_FLOW_LABEL,
+    secondaryLabel: RUN_UPDATED_FLOW_LABEL,
+    primaryDestructive: args.originalPolicy === 'replace',
+    secondaryDestructive: args.updatedPolicy === 'replace',
+  })
+  if (choice === 'primary') return 'original'
+  if (choice === 'secondary') return 'updated'
+  return false
 }

--- a/apps/agate-ui/src/pages/ProcessedItemDetail.tsx
+++ b/apps/agate-ui/src/pages/ProcessedItemDetail.tsx
@@ -28,10 +28,13 @@ import {
 } from '@/lib/review/content/detailTab'
 import {
   RERUN_WARNING_TITLE,
+  promptFlowRerun,
   reconciliationPolicyFromGraph,
   rerunWarningBody,
+  shouldOfferUpdatedFlow,
 } from '@/lib/rerunWarning'
 import {
+  flowChangedSinceRun,
   graphSpecSnapshotJsonFromRun,
   resolveRunGraphSpecForDisplay,
 } from '@/lib/runGraphSpec'
@@ -63,7 +66,7 @@ const PROCESSED_ITEM_TAB_LABELS: Record<ProcessedItemDetailTab, string> = {
 }
 
 export default function ProcessedItemDetail() {
-  const { showError, showConfirm, showMessage } = useAppMessage()
+  const { showError, showConfirm, showConfirmChoice, showMessage } = useAppMessage()
   const { runId, itemId } = useParams<{ runId: string; itemId: string }>()
   const navigate = useNavigate()
   const location = useLocation()
@@ -648,18 +651,38 @@ export default function ProcessedItemDetail() {
                   snapshotJson,
                   graph?.spec,
                 )
-                const policy = reconciliationPolicyFromGraph({ spec: runTimeSpec ?? undefined })
-                const ok = await showConfirm(rerunWarningBody(1, { flowName: graph?.name, policy }), {
-                  title: RERUN_WARNING_TITLE,
-                  confirmLabel: 'Rerun',
-                  destructive: policy === 'replace',
+                const originalPolicy = reconciliationPolicyFromGraph({
+                  spec: runTimeSpec ?? undefined,
                 })
-                if (!ok) return
+                const updatedPolicy = reconciliationPolicyFromGraph(graph)
+                const flowChanged = flowChangedSinceRun(
+                  snapshotJson,
+                  graph?.spec ? JSON.stringify(graph.spec) : null,
+                  run?.flow_changed_since_run,
+                )
+                const offerUpdatedFlow = shouldOfferUpdatedFlow(flowChanged)
+                const decision = await promptFlowRerun({
+                  flowChanged,
+                  title: RERUN_WARNING_TITLE,
+                  unchangedConfirmLabel: 'Rerun',
+                  description: rerunWarningBody(1, {
+                    flowName: graph?.name,
+                    policy: originalPolicy,
+                    offerUpdatedFlow,
+                  }),
+                  originalPolicy,
+                  updatedPolicy,
+                  showConfirm,
+                  showConfirmChoice,
+                })
+                if (!decision) return
                 rerunSawInFlightRef.current = false
                 setRerunRequested(true)
                 try {
                   setRerunning(true)
-                  const rerunRes = await rerunProcessedItem(runId, parseInt(itemId, 10))
+                  const rerunRes = await rerunProcessedItem(runId, parseInt(itemId, 10), {
+                    useCurrentFlow: decision === 'updated',
+                  })
                   if (rerunRes.status === 'pending' || rerunRes.status === 'running') {
                     rerunSawInFlightRef.current = true
                     setItem((prev) =>

--- a/apps/agate-ui/src/pages/RunDetail.tsx
+++ b/apps/agate-ui/src/pages/RunDetail.tsx
@@ -27,10 +27,12 @@ import { formatCurrencySummary } from '@/lib/formatRunEstimatedCost'
 import { formatDurationMs } from '@/lib/formatDuration'
 import {
   RUN_AGAIN_WARNING_TITLE,
+  promptFlowRerun,
   reconciliationPolicyFromGraph,
   runAgainWarningBody,
   rerunWarningBody,
   rerunWarningTitle,
+  shouldOfferUpdatedFlow,
 } from '@/lib/rerunWarning'
 import { isBatchFileSource, processedItemSourceLabel } from '@/lib/review/content/sourceDisplay'
 import {
@@ -53,7 +55,7 @@ import {
 } from '@/lib/processedItemTableSort'
 
 export default function RunDetail() {
-  const { showConfirm, showError } = useAppMessage()
+  const { showConfirm, showConfirmChoice, showError } = useAppMessage()
   const { runId } = useParams<{ runId: string }>()
   const navigate = useNavigate()
   const [run, setRun] = useState<Run | null>(null)
@@ -220,17 +222,33 @@ export default function RunDetail() {
 
     const snapshotJson = graphSpecSnapshotJsonFromRun(run)
     const { spec: runTimeSpec } = resolveRunGraphSpecForDisplay(snapshotJson, graph?.spec)
-    const policy = reconciliationPolicyFromGraph({ spec: runTimeSpec ?? undefined })
-    const ok = await showConfirm(runAgainWarningBody({ flowName: graph.name, policy }), {
+    const originalPolicy = reconciliationPolicyFromGraph({ spec: runTimeSpec ?? undefined })
+    const updatedPolicy = reconciliationPolicyFromGraph(graph)
+    const flowChanged = flowChangedSinceRun(
+      snapshotJson,
+      graph.spec ? JSON.stringify(graph.spec) : null,
+      run.flow_changed_since_run,
+    )
+    const offerUpdatedFlow = shouldOfferUpdatedFlow(flowChanged)
+    const decision = await promptFlowRerun({
+      flowChanged,
       title: RUN_AGAIN_WARNING_TITLE,
-      confirmLabel: 'Replay run',
-      destructive: policy === 'replace',
+      unchangedConfirmLabel: 'Replay run',
+      description: runAgainWarningBody({
+        flowName: graph.name,
+        policy: originalPolicy,
+        offerUpdatedFlow,
+      }),
+      originalPolicy,
+      updatedPolicy,
+      showConfirm,
+      showConfirmChoice,
     })
-    if (!ok) return
+    if (!decision) return
 
     try {
       setRunningAgain(true)
-      const newRun = await replayRun(runId)
+      const newRun = await replayRun(runId, { useCurrentFlow: decision === 'updated' })
       navigate(`/runs/${newRun.id}`)
     } catch (error) {
       console.error('Failed to replay run:', error)
@@ -313,13 +331,29 @@ export default function RunDetail() {
     const count = selectedItems.size
     const snapshotJson = run ? graphSpecSnapshotJsonFromRun(run) : null
     const { spec: runTimeSpec } = resolveRunGraphSpecForDisplay(snapshotJson, graph?.spec)
-    const policy = reconciliationPolicyFromGraph({ spec: runTimeSpec ?? undefined })
-    const ok = await showConfirm(rerunWarningBody(count, { flowName: graph?.name, policy }), {
+    const originalPolicy = reconciliationPolicyFromGraph({ spec: runTimeSpec ?? undefined })
+    const updatedPolicy = reconciliationPolicyFromGraph(graph)
+    const flowChanged = flowChangedSinceRun(
+      snapshotJson,
+      graph?.spec ? JSON.stringify(graph.spec) : null,
+      run?.flow_changed_since_run,
+    )
+    const offerUpdatedFlow = shouldOfferUpdatedFlow(flowChanged)
+    const decision = await promptFlowRerun({
+      flowChanged,
       title: rerunWarningTitle(count),
-      confirmLabel: count === 1 ? 'Rerun' : `Rerun ${count} items`,
-      destructive: policy === 'replace',
+      unchangedConfirmLabel: count === 1 ? 'Rerun' : `Rerun ${count} items`,
+      description: rerunWarningBody(count, {
+        flowName: graph?.name,
+        policy: originalPolicy,
+        offerUpdatedFlow,
+      }),
+      originalPolicy,
+      updatedPolicy,
+      showConfirm,
+      showConfirmChoice,
     })
-    if (!ok) return
+    if (!decision) return
 
     const itemIds = Array.from(selectedItems)
     setRerunningItems(new Set(itemIds))
@@ -327,7 +361,9 @@ export default function RunDetail() {
     try {
       // Rerun all selected items in parallel
       await Promise.all(
-        itemIds.map(itemId => rerunProcessedItem(runId, itemId))
+        itemIds.map(itemId =>
+          rerunProcessedItem(runId, itemId, { useCurrentFlow: decision === 'updated' }),
+        ),
       )
       
       // Clear selection and refresh data

--- a/apps/api-playground/README.md
+++ b/apps/api-playground/README.md
@@ -66,17 +66,24 @@ operation remains in the API contract but is intentionally omitted from the Play
 - The public OpenAPI schema still loads without a project API key so every endpoint can be
   browsed once signed in. A project API key is required only to execute requests and load
   project-scoped field choices.
-- The project API key is held in React state and this tab's `sessionStorage`, so it survives a
-  reload but is discarded when the tab closes. It is never put in local storage, cookies, URL
+- Project API keys are pasted into this tab and held in React state plus `sessionStorage` (the
+  active secret and a tab-scoped vault of secrets this tab has already applied). They survive a
+  reload and are discarded when the tab closes. They are never put in local storage, cookies, URL
   state, analytics, request history, or third-party scripts. Public API requests omit browser
   credentials.
+- The remembered-key dropdown is that vault, labeled from session `GET /v1/projects/{id}/api-keys`
+  metadata (`label`, `key_prefix`, project name) when a pasted secret's prefix matches. Core does
+  not return `raw_key` on list, so Settings keys this tab has never pasted cannot be selected or
+  executed.
 - When a tab-scoped key is present after a reload, the Playground automatically reloads the public
   schema and restores the selected endpoint, endpoint filter, and expanded endpoint groups. Endpoint
   groups start collapsed, and searching temporarily reveals matching endpoints. Once loaded, the
-  connection form collapses to a compact schema status and reload/clear controls.
+  connection form collapses to a compact schema status, remembered-key selector, and reload/clear
+  controls.
 - The organization slug comes only from the Playground hostname. No organization selector, project
   slug, API key, request values, or response data is put in the URL.
-- Closing the tab clears the key. **Clear key** removes it immediately.
+- Closing the tab clears remembered secrets. **Clear key** unsets the active secret (the vault
+  remains so you can pick it again). Logout clears the vault.
 - Generated curl uses `$BACKFIELD_PROJECT_API_KEY` instead of printing the entered key.
 - The production build injects a restrictive Content Security Policy. `index.html` also sets
   `Referrer-Policy: no-referrer` through a meta policy, which works on any static host.

--- a/apps/api-playground/src/App.test.tsx
+++ b/apps/api-playground/src/App.test.tsx
@@ -90,7 +90,21 @@ function sessionResponse(input: RequestInfo | URL): Response | undefined {
       headers: { "Content-Type": "application/json" },
     })
   }
+  if (/\/v1\/projects\/\d+\/api-keys$/.test(url)) {
+    return new Response(JSON.stringify([]), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    })
+  }
   return undefined
+}
+
+const KEY_ONE = `bfk_${"a".repeat(40)}`
+const KEY_TWO = `bfk_${"b".repeat(40)}`
+
+function readVault(): string[] {
+  const raw = sessionStorage.getItem("backfield-playground-project-api-keys")
+  return raw ? (JSON.parse(raw) as string[]) : []
 }
 
 describe("API key handling", () => {
@@ -260,6 +274,7 @@ describe("API key handling", () => {
         sessionStorage.getItem("backfield-playground-project-api-key"),
       ).toBe("top-secret-key"),
     )
+    expect(readVault()).toEqual(["top-secret-key"])
 
     // A fresh mount models a reload in the same browser tab.
     firstRender.unmount()
@@ -271,6 +286,7 @@ describe("API key handling", () => {
     expect(screen.getByRole("heading", { name: "API schema loaded" })).toBeInTheDocument()
     expect(screen.getByRole("button", { name: "Reload schema" })).toBeInTheDocument()
     expect(screen.getByRole("button", { name: "Clear key" })).toBeInTheDocument()
+    expect(screen.getByLabelText("Remembered keys")).toBeInTheDocument()
     expect(screen.queryByLabelText(/Project API key/)).not.toBeInTheDocument()
     fireEvent.change(screen.getByLabelText(/project_slug/), {
       target: { value: "daily-news" },
@@ -315,6 +331,9 @@ describe("API key handling", () => {
         sessionStorage.getItem("backfield-playground-project-api-key"),
       ).toBeNull(),
     )
+    expect(readVault()).toEqual(["top-secret-key"])
+    expect(screen.getByLabelText("Remembered keys")).toBeInTheDocument()
+    expect(screen.getByLabelText("Paste another key")).toBeInTheDocument()
   })
 
   it("clears the project API key from storage and UI on logout", async () => {
@@ -351,11 +370,114 @@ describe("API key handling", () => {
 
     await waitFor(() => expect(assign).toHaveBeenCalled())
     expect(sessionStorage.getItem("backfield-playground-project-api-key")).toBeNull()
+    expect(sessionStorage.getItem("backfield-playground-project-api-keys")).toBeNull()
     expect(screen.queryByDisplayValue("logout-secret-key")).not.toBeInTheDocument()
+  })
+
+  it("lets the tab pick among remembered keys without listing unused Settings keys", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockImplementation((input, init) => {
+      const url = String(input)
+      if (url.endsWith("/v1/projects/2/api-keys")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify([
+              {
+                key_prefix: KEY_ONE.slice(0, 22),
+                label: "Local testing",
+                revoked_at: null,
+              },
+              {
+                key_prefix: KEY_TWO.slice(0, 22),
+                label: "Never pasted",
+                revoked_at: null,
+              },
+            ]),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        )
+      }
+      const session = sessionResponse(input)
+      if (session) return Promise.resolve(session)
+      if (url.endsWith("/openapi.json")) {
+        return Promise.resolve(
+          new Response(JSON.stringify(schema), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        )
+      }
+      if (url.endsWith("/articles/facets")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({ authors: [], external_sources: [] }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        )
+      }
+      if (init?.method === "GET" && url.includes("/articles/search")) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ items: [] }), {
+            status: 200,
+            headers: {
+              "Content-Type": "application/json",
+              "X-Request-ID": "request-456",
+            },
+          }),
+        )
+      }
+      return Promise.reject(new Error(`Unexpected request: ${url}`))
+    })
+    vi.stubGlobal("fetch", fetchMock)
+
+    render(<App />)
+    fireEvent.change(await screen.findByLabelText(/Project API key/), {
+      target: { value: KEY_ONE },
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Use API key" }))
+
+    await waitFor(() =>
+      expect(screen.getByLabelText("Remembered keys")).toHaveTextContent(
+        "Daily News — Local testing",
+      ),
+    )
+    expect(screen.getByLabelText("Remembered keys")).not.toHaveTextContent("Never pasted")
+    expect(document.body.textContent).not.toContain(KEY_ONE)
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear key" }))
+    fireEvent.change(await screen.findByLabelText("Paste another key"), {
+      target: { value: KEY_TWO },
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Use API key" }))
+
+    const switchedSelect = await screen.findByLabelText("Remembered keys")
+    await waitFor(() => expect(switchedSelect.querySelectorAll("option")).toHaveLength(2))
+    expect(readVault()).toEqual([KEY_ONE, KEY_TWO])
+    fireEvent.change(switchedSelect, { target: { value: KEY_ONE.slice(0, 22) } })
+    fireEvent.change(screen.getByLabelText(/project_slug/), {
+      target: { value: "daily-news" },
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Execute request" }))
+    expect(await screen.findByText("request-456")).toBeInTheDocument()
+
+    const apiRequest = fetchMock.mock.calls.find(
+      ([input, init]) =>
+        String(input).includes("/articles/search") &&
+        new Headers(init?.headers).has("Authorization"),
+    )
+    expect(new Headers(apiRequest?.[1]?.headers).get("Authorization")).toBe(
+      `Bearer ${KEY_ONE}`,
+    )
+    expect(document.body.textContent).not.toContain(KEY_ONE)
+    expect(document.body.textContent).not.toContain(KEY_TWO)
+    expect(window.localStorage.getItem("backfield-playground-project-api-keys")).toBeNull()
   })
 })
 
 describe("tenant session host", () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+  })
+
   afterEach(() => {
     cleanup()
     vi.restoreAllMocks()
@@ -427,7 +549,13 @@ describe("tenant session host", () => {
 
     const requested = fetchMock.mock.calls.map(([input]) => String(input))
     expect(requested).toContain("https://agate.canary.stg.backfield.news/v1/auth/me")
+    expect(requested).toContain(
+      "https://agate.canary.stg.backfield.news/v1/projects/2/api-keys",
+    )
     expect(requested).toContain("https://api.canary.stg.backfield.news/public/v1/openapi.json")
     expect(requested).not.toContain("https://api.canary.stg.backfield.news/v1/auth/me")
+    expect(requested).not.toContain(
+      "https://api.canary.stg.backfield.news/v1/projects/2/api-keys",
+    )
   })
 })

--- a/apps/api-playground/src/App.tsx
+++ b/apps/api-playground/src/App.tsx
@@ -19,6 +19,18 @@ import {
   parsePlaygroundHost,
 } from "./lib/origin"
 import {
+  API_KEY_ACTIVE_SESSION_STORAGE,
+  displayLabelForSecret,
+  fetchAccessibleProjectApiKeyMetadata,
+  forgetAllProjectApiKeys,
+  projectApiKeyPrefix,
+  readRememberedApiKeys,
+  rememberApiKey,
+  secretForPrefix,
+  writeRememberedApiKeys,
+  type ProjectApiKeyMetadata,
+} from "./lib/projectApiKeys"
+import {
   fetchPlatformContext,
   logoutSession,
   SessionAuthRequiredError,
@@ -31,7 +43,6 @@ interface OperationGroup {
   operations: PlaygroundOperation[]
 }
 
-const API_KEY_SESSION_STORAGE = "backfield-playground-project-api-key"
 const SELECTED_OPERATION_SESSION_STORAGE = "backfield-playground-selected-operation"
 const ENDPOINT_FILTER_SESSION_STORAGE = "backfield-playground-endpoint-filter"
 const EXPANDED_GROUPS_SESSION_STORAGE = "backfield-playground-expanded-groups"
@@ -76,6 +87,42 @@ function isPlaygroundHomePath(pathname: string): boolean {
   return normalized === "/"
 }
 
+function RememberedKeySelect({
+  id,
+  secrets,
+  activeSecret,
+  metadata,
+  onSelect,
+}: {
+  id: string
+  secrets: string[]
+  activeSecret: string
+  metadata: ProjectApiKeyMetadata[]
+  onSelect: (secret: string) => void
+}) {
+  return (
+    <select
+      id={id}
+      aria-label="Remembered keys"
+      value={activeSecret ? projectApiKeyPrefix(activeSecret) : ""}
+      onChange={(event) => {
+        const next = secretForPrefix(secrets, event.target.value)
+        if (next) onSelect(next)
+      }}
+    >
+      {!activeSecret && <option value="">Select a remembered key</option>}
+      {secrets.map((secret) => {
+        const prefix = projectApiKeyPrefix(secret)
+        return (
+          <option key={prefix} value={prefix}>
+            {displayLabelForSecret(secret, metadata)}
+          </option>
+        )
+      })}
+    </select>
+  )
+}
+
 export default function App() {
   if (!isPlaygroundHomePath(window.location.pathname)) {
     return <NotFound />
@@ -106,8 +153,12 @@ function PlaygroundHome() {
   // Local Compose exposes Core session routes on :8004. Cloud keeps /v1 session
   // and admin routes on the Agate UI host; api.* only serves /public/v1.
   const sessionOrigin = localAvailable ? apiOrigin : agateOrigin
-  const [apiKey, setApiKey] = useState(() => readSessionValue(API_KEY_SESSION_STORAGE))
-  const [apiKeyDraft, setApiKeyDraft] = useState(apiKey)
+  const [rememberedKeys, setRememberedKeys] = useState(readRememberedApiKeys)
+  const [apiKey, setApiKey] = useState(() =>
+    readSessionValue(API_KEY_ACTIVE_SESSION_STORAGE),
+  )
+  const [apiKeyDraft, setApiKeyDraft] = useState("")
+  const [keyMetadata, setKeyMetadata] = useState<ProjectApiKeyMetadata[]>([])
   const [document, setDocument] = useState<OpenApiDocument>()
   const [platformContext, setPlatformContext] = useState<PlatformContext>()
   const [sessionError, setSessionError] = useState("")
@@ -133,14 +184,35 @@ function PlaygroundHome() {
   useEffect(() => {
     try {
       if (apiKey) {
-        sessionStorage.setItem(API_KEY_SESSION_STORAGE, apiKey)
+        sessionStorage.setItem(API_KEY_ACTIVE_SESSION_STORAGE, apiKey)
       } else {
-        sessionStorage.removeItem(API_KEY_SESSION_STORAGE)
+        sessionStorage.removeItem(API_KEY_ACTIVE_SESSION_STORAGE)
       }
     } catch {
       // Storage may be unavailable; the key remains usable in memory for this page.
     }
   }, [apiKey])
+
+  useEffect(() => {
+    writeRememberedApiKeys(rememberedKeys)
+  }, [rememberedKeys])
+
+  useEffect(() => {
+    if (!sessionOrigin || !platformContext) {
+      setKeyMetadata([])
+      return
+    }
+    const projects = platformContext.workspaces.flatMap((workspace) => workspace.projects)
+    let cancelled = false
+    void fetchAccessibleProjectApiKeyMetadata(sessionOrigin, projects)
+      .then((rows) => {
+        if (!cancelled) setKeyMetadata(rows)
+      })
+      .catch(() => undefined)
+    return () => {
+      cancelled = true
+    }
+  }, [platformContext, sessionOrigin])
 
   useEffect(() => {
     try {
@@ -296,7 +368,7 @@ function PlaygroundHome() {
   }
 
   async function logout() {
-    clearApiKey()
+    forgetAllKeys()
     if (sessionOrigin) {
       await logoutSession(sessionOrigin)
     }
@@ -314,7 +386,7 @@ function PlaygroundHome() {
       throw new Error("Could not switch organizations.")
     }
     await switchOrganization(sessionOrigin, nextOrganizationId)
-    clearApiKey()
+    forgetAllKeys()
     if (localAvailable) {
       window.location.reload()
       return
@@ -322,14 +394,29 @@ function PlaygroundHome() {
     window.location.assign(`${derivePlaygroundOrigin(selected.slug, parentDomain)}/`)
   }
 
+  function applyApiKey(secret: string) {
+    const trimmed = secret.trim()
+    if (!trimmed) return
+    setRememberedKeys((current) => rememberApiKey(trimmed, current))
+    setApiKey(trimmed)
+    setApiKeyDraft("")
+  }
+
   function clearApiKey() {
     setApiKey("")
     setApiKeyDraft("")
     try {
-      sessionStorage.removeItem(API_KEY_SESSION_STORAGE)
+      sessionStorage.removeItem(API_KEY_ACTIVE_SESSION_STORAGE)
     } catch {
       // Storage may be unavailable; in-memory state is still cleared above.
     }
+  }
+
+  function forgetAllKeys() {
+    setRememberedKeys([])
+    setApiKey("")
+    setApiKeyDraft("")
+    forgetAllProjectApiKeys()
   }
 
   return (
@@ -405,6 +492,15 @@ function PlaygroundHome() {
                 </div>
               </div>
               <div className="connection-compact-actions">
+                {rememberedKeys.length > 0 && (
+                  <RememberedKeySelect
+                    id="remembered-api-key-compact"
+                    secrets={rememberedKeys}
+                    activeSecret={apiKey}
+                    metadata={keyMetadata}
+                    onSelect={setApiKey}
+                  />
+                )}
                 <button
                   className="secondary-button"
                   type="button"
@@ -439,9 +535,25 @@ function PlaygroundHome() {
                 </div>
               </div>
               <div className="connection-grid connection-grid-key-only">
+                {rememberedKeys.length > 0 && (
+                  <div className="field">
+                    <label htmlFor="remembered-api-key">
+                      <span className="field-name">Remembered keys</span>
+                    </label>
+                    <RememberedKeySelect
+                      id="remembered-api-key"
+                      secrets={rememberedKeys}
+                      activeSecret={apiKey}
+                      metadata={keyMetadata}
+                      onSelect={setApiKey}
+                    />
+                  </div>
+                )}
                 <div className="field">
                   <label htmlFor="project-api-key">
-                    <span className="field-name">Project API key</span>
+                    <span className="field-name">
+                      {rememberedKeys.length > 0 ? "Paste another key" : "Project API key"}
+                    </span>
                   </label>
                   <div className="secret-row">
                     <input
@@ -467,7 +579,7 @@ function PlaygroundHome() {
                   className="connect-button"
                   type="button"
                   disabled={!apiKeyDraft.trim()}
-                  onClick={() => setApiKey(apiKeyDraft.trim())}
+                  onClick={() => applyApiKey(apiKeyDraft)}
                 >
                   Use API key
                 </button>

--- a/apps/api-playground/src/lib/projectApiKeys.test.ts
+++ b/apps/api-playground/src/lib/projectApiKeys.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  API_KEY_ACTIVE_SESSION_STORAGE,
+  API_KEY_VAULT_SESSION_STORAGE,
+  displayLabelForSecret,
+  fetchAccessibleProjectApiKeyMetadata,
+  forgetAllProjectApiKeys,
+  projectApiKeyPrefix,
+  readRememberedApiKeys,
+  rememberApiKey,
+  writeRememberedApiKeys,
+} from "./projectApiKeys"
+
+const KEY_ONE = `bfk_${"a".repeat(40)}`
+const KEY_TWO = `bfk_${"b".repeat(40)}`
+
+describe("project API key vault", () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it("migrates a legacy single-key sessionStorage value into the vault", () => {
+    sessionStorage.setItem(API_KEY_ACTIVE_SESSION_STORAGE, KEY_ONE)
+    expect(readRememberedApiKeys()).toEqual([KEY_ONE])
+  })
+
+  it("reads the vault when both storage keys exist", () => {
+    sessionStorage.setItem(API_KEY_ACTIVE_SESSION_STORAGE, KEY_TWO)
+    sessionStorage.setItem(API_KEY_VAULT_SESSION_STORAGE, JSON.stringify([KEY_ONE, KEY_TWO]))
+    expect(readRememberedApiKeys()).toEqual([KEY_ONE, KEY_TWO])
+  })
+
+  it("appends unique secrets and persists JSON without writing localStorage", () => {
+    const localStorageWrite = vi.spyOn(window.localStorage, "setItem")
+    const next = rememberApiKey(KEY_TWO, rememberApiKey(KEY_ONE, []))
+    expect(next).toEqual([KEY_ONE, KEY_TWO])
+    expect(rememberApiKey(KEY_ONE, next)).toEqual([KEY_ONE, KEY_TWO])
+    writeRememberedApiKeys(next)
+    expect(sessionStorage.getItem(API_KEY_VAULT_SESSION_STORAGE)).toBe(
+      JSON.stringify([KEY_ONE, KEY_TWO]),
+    )
+    expect(localStorageWrite).not.toHaveBeenCalled()
+  })
+
+  it("clears the vault and active key together", () => {
+    sessionStorage.setItem(API_KEY_ACTIVE_SESSION_STORAGE, KEY_ONE)
+    writeRememberedApiKeys([KEY_ONE, KEY_TWO])
+    forgetAllProjectApiKeys()
+    expect(sessionStorage.getItem(API_KEY_ACTIVE_SESSION_STORAGE)).toBeNull()
+    expect(sessionStorage.getItem(API_KEY_VAULT_SESSION_STORAGE)).toBeNull()
+    expect(readRememberedApiKeys()).toEqual([])
+  })
+
+  it("labels remembered secrets from prefix metadata without exposing the secret", () => {
+    const prefix = projectApiKeyPrefix(KEY_ONE)
+    const label = displayLabelForSecret(KEY_ONE, [
+      {
+        prefix,
+        label: "Local testing",
+        projectId: 2,
+        projectName: "Daily News",
+        projectSlug: "daily-news",
+      },
+    ])
+    expect(label).toContain("Daily News")
+    expect(label).toContain("Local testing")
+    expect(label).not.toContain(KEY_ONE)
+    expect(displayLabelForSecret(KEY_TWO, [])).not.toContain(KEY_TWO)
+  })
+
+  it("fetches list metadata per accessible project and skips failures", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockImplementation(async (input) => {
+      const url = String(input)
+      if (url.endsWith("/v1/projects/2/api-keys")) {
+        return new Response(
+          JSON.stringify([
+            {
+              key_prefix: projectApiKeyPrefix(KEY_ONE),
+              label: "Local testing",
+              revoked_at: null,
+            },
+            {
+              key_prefix: "bfk_revokedprefixxxxxxx",
+              label: "Old key",
+              revoked_at: "2026-01-01T00:00:00Z",
+            },
+          ]),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        )
+      }
+      if (url.endsWith("/v1/projects/3/api-keys")) {
+        return new Response(JSON.stringify({ detail: "Forbidden" }), { status: 403 })
+      }
+      throw new Error(`Unexpected request: ${url}`)
+    })
+    vi.stubGlobal("fetch", fetchMock)
+
+    await expect(
+      fetchAccessibleProjectApiKeyMetadata("http://localhost:8004", [
+        { id: 2, name: "Daily News", slug: "daily-news" },
+        { id: 3, name: "Hidden", slug: "hidden" },
+      ]),
+    ).resolves.toEqual([
+      {
+        prefix: projectApiKeyPrefix(KEY_ONE),
+        label: "Local testing",
+        projectId: 2,
+        projectName: "Daily News",
+        projectSlug: "daily-news",
+      },
+    ])
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:8004/v1/projects/2/api-keys",
+      expect.objectContaining({ credentials: "include" }),
+    )
+  })
+})

--- a/apps/api-playground/src/lib/projectApiKeys.ts
+++ b/apps/api-playground/src/lib/projectApiKeys.ts
@@ -1,0 +1,135 @@
+import {
+  fetchProjectApiKeys,
+  type PlatformProject,
+} from "./session"
+
+/** Currently selected secret. Migrated into the vault on first read after this ships. */
+export const API_KEY_ACTIVE_SESSION_STORAGE = "backfield-playground-project-api-key"
+export const API_KEY_VAULT_SESSION_STORAGE = "backfield-playground-project-api-keys"
+
+/** Core stores `key_prefix = raw_key[:22]` and never returns the secret on list. */
+export const PROJECT_API_KEY_PREFIX_LENGTH = 22
+
+const DISPLAY_PREFIX_LENGTH = 10
+
+export interface ProjectApiKeyMetadata {
+  prefix: string
+  label: string | null
+  projectId: number
+  projectName: string
+  projectSlug: string
+}
+
+export function projectApiKeyPrefix(secret: string): string {
+  return secret.trim().slice(0, PROJECT_API_KEY_PREFIX_LENGTH)
+}
+
+function uniqueNonEmptySecrets(secrets: string[]): string[] {
+  const seen = new Set<string>()
+  const unique: string[] = []
+  for (const secret of secrets) {
+    const trimmed = secret.trim()
+    if (!trimmed || seen.has(trimmed)) continue
+    seen.add(trimmed)
+    unique.push(trimmed)
+  }
+  return unique
+}
+
+export function readRememberedApiKeys(): string[] {
+  try {
+    const raw = sessionStorage.getItem(API_KEY_VAULT_SESSION_STORAGE)
+    if (raw) {
+      const parsed: unknown = JSON.parse(raw)
+      if (Array.isArray(parsed)) {
+        return uniqueNonEmptySecrets(
+          parsed.filter((item): item is string => typeof item === "string"),
+        )
+      }
+    }
+    const legacy = sessionStorage.getItem(API_KEY_ACTIVE_SESSION_STORAGE)?.trim()
+    return legacy ? [legacy] : []
+  } catch {
+    return []
+  }
+}
+
+export function writeRememberedApiKeys(secrets: string[]): void {
+  try {
+    const unique = uniqueNonEmptySecrets(secrets)
+    if (!unique.length) {
+      sessionStorage.removeItem(API_KEY_VAULT_SESSION_STORAGE)
+      return
+    }
+    sessionStorage.setItem(API_KEY_VAULT_SESSION_STORAGE, JSON.stringify(unique))
+  } catch {
+    // Storage may be unavailable; the vault remains in memory for this page.
+  }
+}
+
+export function rememberApiKey(secret: string, current: string[]): string[] {
+  return uniqueNonEmptySecrets([...current, secret])
+}
+
+export function forgetAllProjectApiKeys(): void {
+  try {
+    sessionStorage.removeItem(API_KEY_VAULT_SESSION_STORAGE)
+    sessionStorage.removeItem(API_KEY_ACTIVE_SESSION_STORAGE)
+  } catch {
+    // In-memory state is still cleared by callers.
+  }
+}
+
+function displayPrefix(prefix: string): string {
+  if (prefix.length <= DISPLAY_PREFIX_LENGTH) return `${prefix}…`
+  return `${prefix.slice(0, DISPLAY_PREFIX_LENGTH)}…`
+}
+
+export function displayLabelForSecret(
+  secret: string,
+  metadata: ProjectApiKeyMetadata[],
+): string {
+  const prefix = projectApiKeyPrefix(secret)
+  const shortPrefix = displayPrefix(prefix)
+  const match = metadata.find((row) => row.prefix === prefix)
+  if (!match) return shortPrefix
+  const name = match.label?.trim()
+  if (name) return `${match.projectName} — ${name} (${shortPrefix})`
+  return `${match.projectName} (${shortPrefix})`
+}
+
+export function secretForPrefix(
+  secrets: string[],
+  prefix: string,
+): string | undefined {
+  return secrets.find((secret) => projectApiKeyPrefix(secret) === prefix)
+}
+
+export async function fetchAccessibleProjectApiKeyMetadata(
+  sessionOrigin: string,
+  projects: PlatformProject[],
+): Promise<ProjectApiKeyMetadata[]> {
+  const lists = await Promise.all(
+    projects.map(async (project) => {
+      try {
+        const rows = await fetchProjectApiKeys(sessionOrigin, project.id)
+        const labeled: ProjectApiKeyMetadata[] = []
+        for (const row of rows) {
+          const prefix = row.key_prefix?.trim()
+          if (!prefix || row.revoked_at) continue
+          labeled.push({
+            prefix,
+            label: row.label?.trim() || null,
+            projectId: project.id,
+            projectName: project.name,
+            projectSlug: project.slug,
+          })
+        }
+        return labeled
+      } catch {
+        return []
+      }
+    }),
+  )
+  return lists.flat()
+}

--- a/apps/api-playground/src/lib/session.test.ts
+++ b/apps/api-playground/src/lib/session.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 
 import {
   fetchPlatformContext,
+  fetchProjectApiKeys,
   logoutSession,
   SessionAuthRequiredError,
   switchOrganization,
@@ -108,6 +109,33 @@ describe("Playground session", () => {
     expect(fetchMock).toHaveBeenCalledWith(
       "https://agate.newsroom.backfield.news/v1/organizations/7/settings",
       expect.objectContaining({ credentials: "include" }),
+    )
+  })
+
+  it("lists project API key metadata with session credentials and ignores failed lists", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockImplementation(async (input) => {
+      if (String(input).endsWith("/v1/projects/2/api-keys")) {
+        return new Response(
+          JSON.stringify([{ key_prefix: "bfk_testprefixxxxxxxx", label: "Local testing" }]),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        )
+      }
+      return new Response(JSON.stringify({ detail: "Forbidden" }), { status: 403 })
+    })
+    vi.stubGlobal("fetch", fetchMock)
+
+    await expect(
+      fetchProjectApiKeys("https://agate.newsroom.backfield.news", 2),
+    ).resolves.toEqual([{ key_prefix: "bfk_testprefixxxxxxxx", label: "Local testing" }])
+    await expect(
+      fetchProjectApiKeys("https://agate.newsroom.backfield.news", 9),
+    ).resolves.toEqual([])
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://agate.newsroom.backfield.news/v1/projects/2/api-keys",
+      expect.objectContaining({
+        credentials: "include",
+        referrerPolicy: "no-referrer",
+      }),
     )
   })
 

--- a/apps/api-playground/src/lib/session.ts
+++ b/apps/api-playground/src/lib/session.ts
@@ -87,6 +87,29 @@ async function sessionJson<T>(origin: string, path: string): Promise<T> {
   return (await response.json()) as T
 }
 
+export interface SessionProjectApiKey {
+  key_prefix?: string
+  label?: string | null
+  revoked_at?: string | null
+}
+
+/** Session-scoped project key metadata only — Core never returns `raw_key` on list. */
+export async function fetchProjectApiKeys(
+  origin: string,
+  projectId: number,
+): Promise<SessionProjectApiKey[]> {
+  const response = await fetch(`${origin}/v1/projects/${projectId}/api-keys`, {
+    credentials: "include",
+    headers: { Accept: "application/json" },
+    referrerPolicy: "no-referrer",
+  })
+  if (!response.ok) {
+    return []
+  }
+  const payload: unknown = await response.json()
+  return Array.isArray(payload) ? (payload as SessionProjectApiKey[]) : []
+}
+
 export async function logoutSession(coreOrigin: string): Promise<void> {
   try {
     await fetch(`${coreOrigin}/v1/auth/logout`, {

--- a/apps/api-playground/src/styles.css
+++ b/apps/api-playground/src/styles.css
@@ -239,6 +239,15 @@ pre,
   gap: 8px;
 }
 
+.connection-compact-actions select {
+  width: auto;
+  min-width: 12rem;
+  max-width: 18rem;
+  min-height: 34px;
+  padding: 6px 10px;
+  font-size: 0.8125rem;
+}
+
 .connection-compact-actions .secondary-button {
   min-height: 34px;
   padding: 6px 10px;

--- a/apps/worker/src/worker/tasks.py
+++ b/apps/worker/src/worker/tasks.py
@@ -724,7 +724,7 @@ def _finalize_s3_parent_run(session: Session, run_id: str) -> None:
 
 
 @celery_app.task(name="worker.tasks.execute_agate_run")
-def execute_agate_run(run_id: str) -> None:
+def execute_agate_run(run_id: str, spec_json: str | None = None) -> None:
     engine = get_engine()
     with Session(engine) as session:
         run = session.get(AgateRun, run_id)
@@ -779,6 +779,7 @@ def execute_agate_run(run_id: str) -> None:
                 resolve_run_graph_spec_json(
                     run_result_json=run.result_json,
                     graph_spec_json=graph.spec_json,
+                    override_spec_json=spec_json,
                 )
             )
             overlay = merge_project_and_org_llm_api_keys(session, graph.project_id)
@@ -1243,9 +1244,11 @@ def execute_run_replay_setup(source_run_id: str, new_run_id: str) -> None:
         s3_batch = source_payload.get("s3_batch")
         if isinstance(s3_batch, dict):
             merge_updates["s3_batch"] = s3_batch
-        snap = source_payload.get(GRAPH_SPEC_JSON_KEY)
-        if isinstance(snap, str) and snap.strip():
-            merge_updates[GRAPH_SPEC_JSON_KEY] = snap
+        existing_pin = parse_run_result_payload(new_run.result_json).get(GRAPH_SPEC_JSON_KEY)
+        if not (isinstance(existing_pin, str) and existing_pin.strip()):
+            snap = source_payload.get(GRAPH_SPEC_JSON_KEY)
+            if isinstance(snap, str) and snap.strip():
+                merge_updates[GRAPH_SPEC_JSON_KEY] = snap
 
         new_run.status = "running"
         new_run.updated_at = datetime.now(UTC)
@@ -1298,15 +1301,15 @@ def execute_run_replay_setup(source_run_id: str, new_run_id: str) -> None:
     acks_late=True,
     reject_on_worker_lost=True,
 )
-def execute_processed_item(item_id: int) -> None:
+def execute_processed_item(item_id: int, spec_json: str | None = None) -> None:
     token = _current_processed_item_id.set(int(item_id))
     try:
-        _execute_processed_item_impl(item_id)
+        _execute_processed_item_impl(item_id, spec_json=spec_json)
     finally:
         _current_processed_item_id.reset(token)
 
 
-def _execute_processed_item_impl(item_id: int) -> None:
+def _execute_processed_item_impl(item_id: int, spec_json: str | None = None) -> None:
     engine = get_engine()
     claimed_at: datetime
     with Session(engine) as session:
@@ -1394,6 +1397,7 @@ def _execute_processed_item_impl(item_id: int) -> None:
                 resolve_run_graph_spec_json(
                     run_result_json=run.result_json,
                     graph_spec_json=graph.spec_json,
+                    override_spec_json=spec_json,
                 )
             )
 

--- a/docs/api/agate.md
+++ b/docs/api/agate.md
@@ -81,6 +81,9 @@ Deleting a flow removes its run-control records and detaches durable article row
   items, preserves completed items, and returns the same compact status shape used for polling.
   Repeating cancellation returns that terminal status without changing the run again.
 - Replay creates a new run from an existing run contract; item rerun requeues an existing processed item and clears its review state.
+- `POST /runs/{run_id}/replay` and `POST /runs/{run_id}/items/{item_id}/rerun` accept optional
+  JSON `{ "use_current_flow": true }` to execute the current saved flow. Omit the flag (the default)
+  to keep the run’s pinned spec. In-place item rerun does not replace that pin.
 
 For active runs, poll `GET /runs/{run_id}/status` and page summaries through `GET /runs/{run_id}/items`. Full `GET /runs/{run_id}` remains supported for callers that need the complete run response.
 
@@ -93,7 +96,8 @@ Important item routes are:
 - `GET /runs/{run_id}/items/{item_id}` for input, immutable execution output, review state, enriched review lanes, article context, indexing state, connection state, and item cost;
 - `PATCH /runs/{run_id}/items/{item_id}` to replace the review overlay with optimistic concurrency;
 - article metadata create, update, and delete routes below the item;
-- `POST …/rerun` to requeue the item and clear overlay and reviewed output;
+- `POST …/rerun` to requeue the item and clear overlay and reviewed output (optional
+  `{ "use_current_flow": true }` runs the current saved flow without replacing the run pin);
 - `POST …/s3-sync` to overwrite the item's recorded S3 Output object with reviewed output when present.
 
 Synthetic `items/1` views support whole-flow runs that have no stored processed-item row. They are readable, but mutations that require an `agate_processed_item` row reject them.

--- a/docs/api/processed-item-review.md
+++ b/docs/api/processed-item-review.md
@@ -32,6 +32,8 @@ Synthetic `items/1` views are available for whole-flow runs without a stored pro
 - Invalid supported geometry returns `400`.
 - The API never mutates `result_json` when applying review edits.
 - Item rerun clears the overlay, reviewed output, and version before requeueing execution.
+  Optional `{ "use_current_flow": true }` executes the current saved flow for that item
+  without replacing the run’s pinned spec.
 
 Clients must merge their local edits into the latest complete overlay before sending the replacement payload.
 

--- a/docs/architecture/runtime.md
+++ b/docs/architecture/runtime.md
@@ -37,7 +37,8 @@ TextInput and JSONInput runs create one `agate_processed_item` and enqueue
    revisions so unchanged objects can be claimed again.
 
 Run replay clones replayable processed-item inputs and executes them against the graph snapshot
-carried by the replay run; it does not consult the S3 ingestion ledger.
+carried by the replay run (the source pin, or the current saved flow when `use_current_flow` is
+true); it does not consult the S3 ingestion ledger.
 
 ## Item execution
 

--- a/docs/development/frontend/agate.md
+++ b/docs/development/frontend/agate.md
@@ -39,9 +39,11 @@ Node panels and synced node UI are documented in
 
 - Text and JSON bookend input on the run page is saved to the graph spec before a
   run starts.
-- Rerun actions confirm that the current saved flow will run, identify the
-  Backfield Output reconciliation policy, and explain that run-local review edits
-  for affected items will be cleared.
+- Rerun and replay confirm the flow settings from when the run started. When the saved
+  flow has changed, the dialog also offers **Run updated flow**, which reprocesses the
+  same items with the current saved flow and still clears run-local review edits. **Rerun
+  original flow** remains the default. Each action names the matching Backfield Output
+  reconciliation policy.
 - Backfield Output presents **Add Only**, **Smart Merge**, and **Replace**. Runtime
   inference owns domain reconciliation details; the panel does not expose
   implementation-level ownership overrides.

--- a/docs/development/frontend/conventions.md
+++ b/docs/development/frontend/conventions.md
@@ -39,6 +39,7 @@ Do not use browser `alert()` or `confirm()`. Each app mounts
 - `showMessage(description, options)` for a notice.
 - `showError(description, options)` for a failure.
 - `await showConfirm(description, options)` for a two-action confirmation.
+- `await showConfirmChoice(description, options)` for Cancel plus two confirm actions.
 
 The shared dialog treatment keeps copy, destructive styling, keyboard behavior, and
 accessibility consistent.

--- a/packages/backfield-agate/src/agate_runtime/run_graph_spec.py
+++ b/packages/backfield-agate/src/agate_runtime/run_graph_spec.py
@@ -25,8 +25,15 @@ def merge_run_result_payload(existing: str | None, **updates: Any) -> str:
     return json.dumps(data)
 
 
-def resolve_run_graph_spec_json(*, run_result_json: str | None, graph_spec_json: str) -> str:
-    """Use the spec snapshot stored on the run when present."""
+def resolve_run_graph_spec_json(
+    *,
+    run_result_json: str | None,
+    graph_spec_json: str,
+    override_spec_json: str | None = None,
+) -> str:
+    """Use an explicit override, else the spec snapshot stored on the run, else the live graph."""
+    if isinstance(override_spec_json, str) and override_spec_json.strip():
+        return override_spec_json
     snap = parse_run_result_payload(run_result_json).get(GRAPH_SPEC_JSON_KEY)
     if isinstance(snap, str) and snap.strip():
         return snap

--- a/packages/backfield-agate/tests/test_run_graph_spec.py
+++ b/packages/backfield-agate/tests/test_run_graph_spec.py
@@ -32,3 +32,14 @@ def test_resolve_run_graph_spec_json_falls_back_to_live_graph() -> None:
     live = '{"name":"live"}'
     resolved = resolve_run_graph_spec_json(run_result_json=None, graph_spec_json=live)
     assert resolved == live
+
+
+def test_resolve_run_graph_spec_json_prefers_override_over_snapshot() -> None:
+    live = '{"name":"live"}'
+    snap = json.dumps({GRAPH_SPEC_JSON_KEY: '{"name":"snap"}'})
+    resolved = resolve_run_graph_spec_json(
+        run_result_json=snap,
+        graph_spec_json=live,
+        override_spec_json='{"name":"override"}',
+    )
+    assert resolved == '{"name":"override"}'

--- a/tests/agate_api/test_agate_api.py
+++ b/tests/agate_api/test_agate_api.py
@@ -646,6 +646,15 @@ def test_replay_run_uses_source_snapshot_not_live_graph(monkeypatch, client: Tes
     assert sent.get("name") == "worker.tasks.execute_run_replay_setup"
     assert sent.get("args") == [source["id"], new_run["id"]]
 
+    replay_updated = client.post(
+        f"/runs/{source['id']}/replay",
+        json={"use_current_flow": True},
+    )
+    assert replay_updated.status_code == 200
+    updated_run = replay_updated.json()
+    assert "Chicago" in (updated_run.get("graph_spec_snapshot_json") or "")
+    assert "Austin" not in (updated_run.get("graph_spec_snapshot_json") or "")
+
 
 def test_graph_description_round_trip(client: TestClient):
     project_response = _post_project(client, name="Desc Project", slug="desc-proj")
@@ -1230,6 +1239,104 @@ def test_rerun_processed_item_resets_row_and_enqueues_task(monkeypatch, tmp_path
         assert captured["name"] == "worker.tasks.execute_processed_item"
         assert captured["args"] == [iid]
         assert captured["queue"] == "agate"
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_rerun_processed_item_use_current_flow_passes_live_spec_without_replacing_pin(
+    monkeypatch, tmp_path
+):
+    database_path = tmp_path / "agate-rerun-current.db"
+    engine = create_engine(
+        f"sqlite:///{database_path}",
+        connect_args={"check_same_thread": False},
+    )
+    SQLModel.metadata.create_all(engine)
+
+    with Session(engine) as s:
+        s.add(BackfieldOrganization(name="Backfield", slug="default"))
+        s.commit()
+
+    def get_test_session() -> Generator[Session, None, None]:
+        with Session(engine) as session:
+            yield session
+
+    captured: dict[str, object] = {}
+
+    def capture_send_task(name: str, args: list[int] | None = None, **kwargs: object) -> None:
+        captured["name"] = name
+        captured["args"] = args
+        captured["queue"] = kwargs.get("queue")
+        captured["task_kwargs"] = kwargs.get("kwargs") or {}
+
+    app.dependency_overrides[get_session] = get_test_session
+    monkeypatch.setattr(runs.celery_app, "send_task", capture_send_task)
+
+    original_spec = _minimal_text_input_spec(name="orig", text="Austin, TX")
+    live_spec = _minimal_text_input_spec(name="live", text="Chicago, IL")
+    try:
+        tc = TestClient(
+            app,
+            headers={"Authorization": "Bearer backfield-dev"},
+        )
+        project = _post_project(tc, name="Rerun Current", slug="rerun-current").json()
+        graph = tc.post(
+            "/graphs",
+            json={
+                "name": "Current",
+                "project_id": project["id"],
+                "spec": original_spec,
+            },
+        ).json()
+        with Session(engine) as s:
+            row = _insert_pending_run(s, graph["id"])
+            rid = row.id
+            row.status = "succeeded"
+            row.result_json = json.dumps({"graph_spec_json": json.dumps(original_spec)})
+            s.add(row)
+            item = AgateProcessedItem(
+                run_id=rid,
+                source_file="a.json",
+                input_json='{"text":"hello"}',
+                status="succeeded",
+            )
+            s.add(item)
+            s.commit()
+            s.refresh(item)
+            iid = item.id
+        assert iid is not None
+
+        update = tc.put(
+            f"/graphs/{graph['id']}",
+            json={
+                "name": "Current",
+                "project_id": project["id"],
+                "spec": live_spec,
+            },
+        )
+        assert update.status_code == 200
+
+        default = tc.post(f"/runs/{rid}/items/{iid}/rerun")
+        assert default.status_code == 200
+        assert captured.get("task_kwargs") == {}
+
+        current = tc.post(
+            f"/runs/{rid}/items/{iid}/rerun",
+            json={"use_current_flow": True},
+        )
+        assert current.status_code == 200
+        task_kwargs = captured.get("task_kwargs") or {}
+        assert isinstance(task_kwargs, dict)
+        spec_json = task_kwargs.get("spec_json")
+        assert isinstance(spec_json, str)
+        assert "Chicago" in spec_json
+        assert "Austin" not in spec_json
+
+        with Session(engine) as s:
+            run_row = s.get(AgateRun, rid)
+            assert run_row is not None
+            assert "Austin" in (run_row.result_json or "")
+            assert "Chicago" not in (run_row.result_json or "")
     finally:
         app.dependency_overrides.clear()
 

--- a/tests/worker/test_single_item_worker.py
+++ b/tests/worker/test_single_item_worker.py
@@ -121,6 +121,41 @@ def test_execute_processed_item_text_input_shim(single_engine, monkeypatch):
         assert len(wrap["items"]) == 1
 
 
+def test_execute_processed_item_spec_json_override_wins_over_run_snapshot(
+    single_engine, monkeypatch
+):
+    engine, item_id, run_id = single_engine
+    monkeypatch.setattr(
+        worker_tasks,
+        "merge_project_and_org_llm_api_keys",
+        lambda *_a, **_k: {},
+    )
+    bad_snapshot = json.dumps(
+        {
+            "name": "broken",
+            "nodes": [{"id": "x", "type": "NotARealNode", "params": {}}],
+            "edges": [],
+        }
+    )
+    with Session(engine) as s:
+        run = s.get(AgateRun, run_id)
+        assert run is not None
+        run.result_json = json.dumps({"graph_spec_json": bad_snapshot})
+        s.add(run)
+        s.commit()
+
+    worker_tasks.execute_processed_item(item_id, spec_json=_text_flow_spec())
+
+    with Session(engine) as s:
+        item = s.get(AgateProcessedItem, item_id)
+        assert item is not None
+        assert item.status == "succeeded"
+        run = s.get(AgateRun, run_id)
+        assert run is not None
+        wrap = json.loads(run.result_json or "{}")
+        assert json.loads(wrap["graph_spec_json"])["name"] == "broken"
+
+
 def test_worker_cannot_store_output_after_cancellation(single_engine):
     engine, item_id, run_id = single_engine
     claimed_at = datetime.now(UTC)


### PR DESCRIPTION
## Summary

- Remember pasted Playground API keys in a tab-scoped vault so developers can switch among them without Core storing secrets.
- When a run’s saved flow has changed, Rerun/Replay can reprocess the same items through the current saved flow in place. The default remains the flow pinned when the run started, and in-place updated reruns do not overwrite that snapshot.

## Project scope check

- [x] This change targets local development / source inspection (production self-hosting is unsupported in this repo)
- [x] Docs under `docs/` updated if behavior, architecture, or operations changed
- [x] First-admin provisioning still uses `backfield init` / `backfield seed` only (no HTTP/env bootstrap paths)

## Test plan

- [x] `make lint`
- [x] `make test`
- [ ] `make ui-typecheck ui-test` (if UI/TypeScript changed)
- [ ] `make smoke-fast` (if live-stack behavior changed)
- [ ] `make smoke` (if golden-path / provider-dependent runtime changed; configure **Settings → AI models**)

## Notes for reviewers

Two independent changes on this branch. Playground keys stay in browser session storage only. For rerun: `use_current_flow` captures live `spec_json` at request time and passes it to the worker; mixed items on one run are expected until each row is rerun. Two confirm actions appear only when `flow_changed_since_run` is true.


Made with [Cursor](https://cursor.com)