### PR TITLE
Apply catalog geography to linked saved places

### DIFF
--- a/apps/stylebook-api/src/stylebook_api/entities/location/locations.py
+++ b/apps/stylebook-api/src/stylebook_api/entities/location/locations.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 from uuid import UUID
 
@@ -24,7 +24,7 @@ from backfield_entities.entities.linking.substrate_actions import (
     unlink_substrate_from_canonical,
 )
 from backfield_entities.entities.location.types import PLACE_EXTRACT_LOCATION_TYPES
-from backfield_entities.geo.h3_index import apply_h3_fields
+from backfield_entities.geo.geometry_bind import assign_geojson_geometry
 from backfield_entities.ingest.semantic_indexing.reindex import (
     location_patch_affects_semantic_index,
 )
@@ -653,12 +653,8 @@ def patch_location_geometry(
     loc = session.get(SubstrateLocation, location_id)
     if loc is None or int(loc.project_id) != int(proj.id):
         raise HTTPException(status_code=404, detail="Location not found")
-    loc.geometry_json = body.geometry_json
-    loc.geometry_type = body.geometry_json.get("type") if body.geometry_json else None
-    loc.geometry = None
-    h3_cell, h3_resolution = apply_h3_fields(geometry_json=body.geometry_json)
-    loc.h3_cell = h3_cell
-    loc.h3_resolution = h3_resolution
+    assign_geojson_geometry(session, loc, body.geometry_json)
+    loc.updated_at = datetime.now(UTC)
     session.add(loc)
     session.commit()
     session.refresh(loc)

--- a/apps/stylebook-api/src/stylebook_api/routers/stylebook_canonicals.py
+++ b/apps/stylebook-api/src/stylebook_api/routers/stylebook_canonicals.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from typing import Any, Literal
 
 from backfield_db import (
@@ -19,7 +20,12 @@ from backfield_entities.activity import (
     log_stylebook_activity_safe,
 )
 from backfield_entities.catalog.search import catalog_label_alias_ilike_filter
+from backfield_entities.entities.location.geometry_apply import (
+    apply_canonical_geometry_to_substrates,
+    suggest_substrate_for_geometry_apply,
+)
 from backfield_entities.entities.location.persist import create_standalone_canonical
+from backfield_entities.geo.geometry_bind import assign_geojson_geometry
 from backfield_events import record_canonical_updated
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
@@ -116,6 +122,21 @@ class PatchCanonicalGeometryBody(BaseModel):
     geometry_json: dict[str, Any] | None = None
 
 
+class ApplyCanonicalGeometryBody(BaseModel):
+    substrate_location_ids: list[int] = Field(min_length=1)
+
+
+class ApplyCanonicalGeometrySkipped(BaseModel):
+    id: int
+    reason: str
+
+
+class ApplyCanonicalGeometryResponse(BaseModel):
+    updated_ids: list[int]
+    skipped: list[ApplyCanonicalGeometrySkipped] = Field(default_factory=list)
+    cache_rows_purged: int = 0
+
+
 def _canonical_filters(
     *, stylebook_id: int, q: str | None, type_filter: str | None
 ) -> list[ColumnElement[bool]]:
@@ -187,6 +208,8 @@ class LinkedSubstrateItem(BaseModel):
     location_type: str
     canonical_link_status: str
     formatted_address: str | None = None
+    geometry_type: str | None = None
+    suggested_for_geometry: bool = False
     project_id: int
     project_slug: str
     project_name: str
@@ -587,7 +610,20 @@ def patch_canonical_location_geometry(
     canon = session.get(StylebookLocationCanonical, canonical_id)
     if canon is None or int(canon.stylebook_id) != int(sb.id):
         raise HTTPException(status_code=404, detail="Canonical location not found")
-    canon.geometry_json = body.geometry_json
+    assign_geojson_geometry(session, canon, body.geometry_json)
+    canon.updated_at = datetime.now(UTC)
+    log_stylebook_activity_safe(
+        session,
+        stylebook_id=int(sb.id),
+        actor_type="user",
+        actor_user_id=_created_by_user_id(auth),
+        source="manual_ui",
+        event_type=EVENT_CANONICAL_UPDATED,
+        entity_type="location",
+        entity_id=str(canon.id),
+        entity_label=str(canon.label),
+        payload_json={"geometry_updated": True},
+    )
     record_canonical_updated(
         session,
         stylebook_id=int(sb.id),
@@ -598,6 +634,77 @@ def patch_canonical_location_geometry(
     session.add(canon)
     session.commit()
     return {"message": "ok", "id": str(canon.id)}
+
+
+@router.post(
+    "/{stylebook_slug}/canonical-locations/{canonical_id}/geometry/apply-to-substrates",
+    response_model=ApplyCanonicalGeometryResponse,
+)
+def apply_canonical_location_geometry_to_substrates(
+    stylebook_slug: str,
+    canonical_id: str,
+    body: ApplyCanonicalGeometryBody,
+    project: str | None = Query(
+        None,
+        description=(
+            "Optional project slug to limit visible saved places "
+            "(default: all visible projects)."
+        ),
+    ),
+    session: Session = Depends(get_session),
+    auth: dict[str, Any] = Depends(get_auth),
+) -> ApplyCanonicalGeometryResponse:
+    require_stylebook_edit_access(session, auth=auth, stylebook_slug=stylebook_slug)
+    sb = require_stylebook_by_slug_in_auth_org(session, auth=auth, stylebook_slug=stylebook_slug)
+    if sb.id is None:
+        raise HTTPException(status_code=404, detail="Stylebook not found")
+    canon = session.get(StylebookLocationCanonical, canonical_id)
+    if canon is None or int(canon.stylebook_id) != int(sb.id):
+        raise HTTPException(status_code=404, detail="Canonical location not found")
+    project_ids = optional_project_filter_to_ids(
+        session,
+        auth=auth,
+        project_slug=project,
+        organization_id=int(sb.organization_id),
+    )
+    result = apply_canonical_geometry_to_substrates(
+        session,
+        canon=canon,
+        substrate_ids=body.substrate_location_ids,
+        visible_project_ids=project_ids,
+    )
+    log_stylebook_activity_safe(
+        session,
+        stylebook_id=int(sb.id),
+        actor_type="user",
+        actor_user_id=_created_by_user_id(auth),
+        source="manual_ui",
+        event_type=EVENT_CANONICAL_UPDATED,
+        entity_type="location",
+        entity_id=str(canon.id),
+        entity_label=str(canon.label),
+        payload_json={
+            "applied_geometry_to_saved_places": True,
+            "updated_ids": list(result.updated_ids),
+            "skipped": [{"id": item.id, "reason": item.reason} for item in result.skipped],
+            "cache_rows_purged": result.cache_rows_purged,
+        },
+    )
+    record_canonical_updated(
+        session,
+        stylebook_id=int(sb.id),
+        entity_type="location",
+        canonical_id=str(canon.id),
+        label=str(canon.label),
+    )
+    session.commit()
+    return ApplyCanonicalGeometryResponse(
+        updated_ids=list(result.updated_ids),
+        skipped=[
+            ApplyCanonicalGeometrySkipped(id=item.id, reason=item.reason) for item in result.skipped
+        ],
+        cache_rows_purged=result.cache_rows_purged,
+    )
 
 
 @router.delete("/{stylebook_slug}/canonical-locations/{canonical_id}")
@@ -709,6 +816,11 @@ def list_canonical_linked_substrates(
                 location_type=str(loc.location_type or ""),
                 canonical_link_status=str(loc.canonical_link_status or ""),
                 formatted_address=(loc.formatted_address or "").strip() or None,
+                geometry_type=(str(loc.geometry_type) if loc.geometry_type else None),
+                suggested_for_geometry=suggest_substrate_for_geometry_apply(
+                    substrate_location_type=loc.location_type,
+                    canonical_location_type=canon.location_type,
+                ),
                 project_id=int(project_row.id),  # type: ignore[arg-type]
                 project_slug=str(project_row.slug),
                 project_name=str(project_row.name),

--- a/apps/stylebook-ui/src/components/LocationGeographySection.tsx
+++ b/apps/stylebook-ui/src/components/LocationGeographySection.tsx
@@ -1,12 +1,28 @@
 import { useCallback, useEffect, useMemo, useState } from "react"
 import { useAppMessage } from "@/components/AppMessageProvider"
 import SimpleGeoJsonGeometry from "@/components/SimpleGeoJsonGeometry"
-import { updateCanonicalLocationGeometry } from "@/lib/stylebook-api/locations"
+import {
+  applyCanonicalGeometryToSavedPlaces,
+  listCanonicalLinkedSubstrates,
+  updateCanonicalLocationGeometry,
+  type LinkedSubstrateItem,
+} from "@/lib/stylebook-api/locations"
+import { defaultSelectedSavedPlaceIds } from "@/lib/applyCatalogGeography"
+import { placeExtractTypeLabel } from "@/lib/place-extract-type-label"
 import { cn } from "@/lib/utils"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Alert, AlertDescription } from "@/components/ui/alert"
+import { Checkbox } from "@/components/ui/checkbox"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
 import { GeometryEditLeafletMap } from "@backfield/ui/GeometryEditLeafletMap"
 import { useOrgMapDefaultViewport } from "@/lib/useOrgMapDefaultViewport"
 import {
@@ -121,6 +137,7 @@ export interface LocationGeographySectionProps {
   stylebookSlug: string
   geometry: Record<string, unknown> | null
   canEdit: boolean
+  projectFilterSlug?: string
   onGeometrySaved: () => void | Promise<void>
 }
 
@@ -129,9 +146,10 @@ export default function LocationGeographySection({
   stylebookSlug,
   geometry,
   canEdit,
+  projectFilterSlug,
   onGeometrySaved,
 }: LocationGeographySectionProps) {
-  const { showError, showConfirm } = useAppMessage()
+  const { showError, showConfirm, showMessage } = useAppMessage()
   const orgMapDefault = useOrgMapDefaultViewport()
   const [geometryEditing, setGeometryEditing] = useState(false)
   const [geometryDraft, setGeometryDraft] = useState<Record<string, unknown> | null>(geometry)
@@ -141,12 +159,45 @@ export default function LocationGeographySection({
     southWest: { lat: number; lng: number }
     northEast: { lat: number; lng: number }
   } | null>(null)
+  const [applyOpen, setApplyOpen] = useState(false)
+  const [applyLoading, setApplyLoading] = useState(false)
+  const [applySaving, setApplySaving] = useState(false)
+  const [linkedPlaces, setLinkedPlaces] = useState<LinkedSubstrateItem[]>([])
+  const [selectedPlaceIds, setSelectedPlaceIds] = useState<number[]>([])
 
   useEffect(() => {
     if (!geometryEditing) {
       setGeometryDraft(geometry)
     }
   }, [geometry, geometryEditing])
+
+  const openApplyDialog = useCallback(
+    async ({ quietIfEmpty }: { quietIfEmpty: boolean }) => {
+      setApplyLoading(true)
+      try {
+        const response = await listCanonicalLinkedSubstrates(
+          canonicalId,
+          stylebookSlug,
+          projectFilterSlug,
+        )
+        const places = response.substrates
+        if (places.length === 0) {
+          if (!quietIfEmpty) {
+            showMessage("This location has no linked saved places.")
+          }
+          return
+        }
+        setLinkedPlaces(places)
+        setSelectedPlaceIds(defaultSelectedSavedPlaceIds(places))
+        setApplyOpen(true)
+      } catch (e) {
+        showError(e instanceof Error ? e.message : "Could not load linked saved places.")
+      } finally {
+        setApplyLoading(false)
+      }
+    },
+    [canonicalId, projectFilterSlug, showError, showMessage, stylebookSlug],
+  )
 
   const saveGeometry = async () => {
     setGeometrySaving(true)
@@ -156,6 +207,7 @@ export default function LocationGeographySection({
       setGeometryAddMode(null)
       setRectanglePreview(null)
       await onGeometrySaved()
+      await openApplyDialog({ quietIfEmpty: true })
     } catch (e) {
       console.error(e)
       const msg =
@@ -164,6 +216,40 @@ export default function LocationGeographySection({
     } finally {
       setGeometrySaving(false)
     }
+  }
+
+  const applySelectedGeography = async () => {
+    if (selectedPlaceIds.length === 0) return
+    setApplySaving(true)
+    try {
+      const result = await applyCanonicalGeometryToSavedPlaces(
+        canonicalId,
+        stylebookSlug,
+        selectedPlaceIds,
+        projectFilterSlug,
+      )
+      setApplyOpen(false)
+      const count = result.updated_ids.length
+      showMessage(
+        count === 1
+          ? "Updated geography on 1 saved place."
+          : `Updated geography on ${count} saved places.`,
+      )
+      await onGeometrySaved()
+    } catch (e) {
+      showError(e instanceof Error ? e.message : "Could not apply catalog geography.")
+    } finally {
+      setApplySaving(false)
+    }
+  }
+
+  const togglePlace = (placeId: number, checked: boolean) => {
+    setSelectedPlaceIds((prev) => {
+      if (checked) {
+        return prev.includes(placeId) ? prev : [...prev, placeId]
+      }
+      return prev.filter((id) => id !== placeId)
+    })
   }
 
   const geometrySource = geometryEditing ? geometryDraft : geometry
@@ -237,6 +323,7 @@ export default function LocationGeographySection({
   }, [geometry])
 
   return (
+    <>
     <Card
       className={cn(
         "relative z-0 isolate",
@@ -263,7 +350,7 @@ export default function LocationGeographySection({
               : "View canonical geometry."}
           </CardDescription>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center justify-end gap-2">
           {geometryEditing ? (
             <>
               <Button variant="outline" onClick={cancelGeometryEdit} disabled={geometrySaving}>
@@ -274,18 +361,27 @@ export default function LocationGeographySection({
               </Button>
             </>
           ) : (
-            <Button
-              variant="outline"
-              onClick={() => {
-                setGeometryDraft(geometry)
-                setGeometryAddMode(null)
-                setRectanglePreview(null)
-                setGeometryEditing(true)
-              }}
-              disabled={!canEdit}
-            >
-              Edit geography
-            </Button>
+            <>
+              <Button
+                variant="outline"
+                onClick={() => void openApplyDialog({ quietIfEmpty: false })}
+                disabled={!canEdit || applyLoading || geometrySaving}
+              >
+                {applyLoading ? "Loading…" : "Apply to linked saved places"}
+              </Button>
+              <Button
+                variant="outline"
+                onClick={() => {
+                  setGeometryDraft(geometry)
+                  setGeometryAddMode(null)
+                  setRectanglePreview(null)
+                  setGeometryEditing(true)
+                }}
+                disabled={!canEdit}
+              >
+                Edit geography
+              </Button>
+            </>
           )}
         </div>
       </CardHeader>
@@ -388,5 +484,52 @@ export default function LocationGeographySection({
         ) : null}
       </CardContent>
     </Card>
+    <Dialog open={applyOpen} onOpenChange={(open) => !applySaving && setApplyOpen(open)}>
+      <DialogContent className="max-w-lg max-h-[85vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Apply catalog geography?</DialogTitle>
+          <DialogDescription>
+            Search uses each saved place’s geography. Applying this catalog shape updates the
+            selected saved places so they match this location.
+          </DialogDescription>
+        </DialogHeader>
+        <ul className="space-y-2">
+          {linkedPlaces.map((place) => {
+            const checked = selectedPlaceIds.includes(place.id)
+            return (
+              <li key={place.id} className="flex items-start gap-3 rounded-md border p-3">
+                <Checkbox
+                  checked={checked}
+                  onCheckedChange={(next) => togglePlace(place.id, next)}
+                  disabled={applySaving}
+                  aria-label={`Select ${place.name}`}
+                />
+                <div className="min-w-0">
+                  <p className="text-sm font-medium leading-5">{place.name}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {place.project_name}
+                    {place.location_type
+                      ? ` · ${placeExtractTypeLabel(place.location_type)}`
+                      : ""}
+                  </p>
+                </div>
+              </li>
+            )
+          })}
+        </ul>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => setApplyOpen(false)} disabled={applySaving}>
+            Cancel
+          </Button>
+          <Button
+            onClick={() => void applySelectedGeography()}
+            disabled={applySaving || selectedPlaceIds.length === 0}
+          >
+            {applySaving ? "Applying…" : "Apply geography"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+    </>
   )
 }

--- a/apps/stylebook-ui/src/lib/api.ts
+++ b/apps/stylebook-ui/src/lib/api.ts
@@ -35,6 +35,7 @@ export {
   patchCanonicalLocation,
   unlinkSubstrateFromCanonical,
   updateCanonicalLocationGeometry,
+  applyCanonicalGeometryToSavedPlaces,
   updateLocation,
   updateLocationGeometry,
 } from "@/lib/stylebook-api/locations"

--- a/apps/stylebook-ui/src/lib/applyCatalogGeography.test.ts
+++ b/apps/stylebook-ui/src/lib/applyCatalogGeography.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest"
+
+import { defaultSelectedSavedPlaceIds } from "./applyCatalogGeography"
+
+describe("defaultSelectedSavedPlaceIds", () => {
+  it("selects only saved places suggested for catalog geography", () => {
+    expect(
+      defaultSelectedSavedPlaceIds([
+        { id: 1, suggested_for_geometry: true },
+        { id: 2, suggested_for_geometry: false },
+        { id: 3 },
+        { id: 4, suggested_for_geometry: true },
+      ]),
+    ).toEqual([1, 4])
+  })
+})

--- a/apps/stylebook-ui/src/lib/applyCatalogGeography.ts
+++ b/apps/stylebook-ui/src/lib/applyCatalogGeography.ts
@@ -1,0 +1,5 @@
+export function defaultSelectedSavedPlaceIds(
+  items: Array<{ id: number; suggested_for_geometry?: boolean }>,
+): number[] {
+  return items.filter((item) => item.suggested_for_geometry === true).map((item) => item.id)
+}

--- a/apps/stylebook-ui/src/lib/stylebook-api/locations.ts
+++ b/apps/stylebook-ui/src/lib/stylebook-api/locations.ts
@@ -142,6 +142,8 @@ export interface LinkedSubstrateItem {
   location_type: string
   canonical_link_status: string
   formatted_address?: string | null
+  geometry_type?: string | null
+  suggested_for_geometry?: boolean
   project_id: number
   project_slug: string
   project_name: string
@@ -277,6 +279,29 @@ export async function updateCanonicalLocationGeometry(
       canonicalId,
     )}/geometry`,
     { method: "PATCH", body: JSON.stringify({ geometry_json: geometryJson }) },
+  )
+}
+
+export interface ApplyCanonicalGeometryResult {
+  updated_ids: number[]
+  skipped: Array<{ id: number; reason: string }>
+  cache_rows_purged: number
+}
+
+export async function applyCanonicalGeometryToSavedPlaces(
+  canonicalId: string,
+  stylebookSlug: string,
+  savedPlaceIds: number[],
+  projectFilterSlug?: string,
+): Promise<ApplyCanonicalGeometryResult> {
+  const params = new URLSearchParams()
+  if (projectFilterSlug) params.set("project", projectFilterSlug)
+  const query = params.toString()
+  return stylebookJsonFetch<ApplyCanonicalGeometryResult>(
+    `/v1/stylebooks/${encodeURIComponent(stylebookSlug)}/canonical-locations/${encodeURIComponent(
+      canonicalId,
+    )}/geometry/apply-to-substrates${query ? `?${query}` : ""}`,
+    { method: "POST", body: JSON.stringify({ substrate_location_ids: savedPlaceIds }) },
   )
 }
 

--- a/apps/stylebook-ui/src/pages/LocationDetail.tsx
+++ b/apps/stylebook-ui/src/pages/LocationDetail.tsx
@@ -524,7 +524,8 @@ export default function LocationDetail() {
             stylebookSlug={stylebookSlug}
             geometry={geometry}
             canEdit={canEdit}
-            onGeometrySaved={() => void loadCanonical(canonical.id, stylebookSlug, true)}
+            projectFilterSlug={evidenceProjectSlug || undefined}
+            onGeometrySaved={() => void refreshCanonicalPage(true)}
           />
         ) : null
       }

--- a/apps/worker/src/worker/substrate/entities/location/upsert.py
+++ b/apps/worker/src/worker/substrate/entities/location/upsert.py
@@ -9,6 +9,11 @@ from dataclasses import dataclass
 from typing import Any
 
 from backfield_db import SubstrateLocation, SubstrateLocationCache
+from backfield_entities.entities.location.geometry_apply import (
+    clear_geometry_editorial_override,
+    substrate_has_editorial_geometry_override,
+)
+from backfield_entities.geo.geometry_bind import geometry_bind_value
 from backfield_entities.geo.h3_index import derive_h3_index
 from backfield_entities.ingest.geocode_cache.fingerprint import (
     substrate_location_cache_query_fingerprint,
@@ -79,113 +84,6 @@ def _place_extract_persist_fields_from_entry(entry: dict[str, Any]) -> dict[str,
         out["address_place_kind"] = kind.strip().lower()
     return out
 
-
-def _coord_pair_wkt(pair: Any) -> str | None:
-    if not isinstance(pair, (list, tuple)) or len(pair) < 2:
-        return None
-    lon, lat = float(pair[0]), float(pair[1])
-    return f"{lon} {lat}"
-
-
-def _ring_coords_wkt(ring: Any) -> str | None:
-    if not isinstance(ring, list) or not ring:
-        return None
-    pts: list[str] = []
-    for pair in ring:
-        wkt_pair = _coord_pair_wkt(pair)
-        if not wkt_pair:
-            return None
-        pts.append(wkt_pair)
-    if len(pts) < 3:
-        return None
-    if pts[0] != pts[-1]:
-        pts.append(pts[0])
-    return ", ".join(pts)
-
-
-def _geojson_to_wkt(geometry_json: dict[str, Any]) -> str | None:
-    gtype = str(geometry_json.get("type") or "").title()
-    coords = geometry_json.get("coordinates")
-
-    try:
-        if gtype == "Point":
-            pair = _coord_pair_wkt(coords)
-            if not pair:
-                return None
-            return f"POINT ({pair})"
-
-        if gtype == "MultiPoint":
-            if not isinstance(coords, list) or not coords:
-                return None
-            parts: list[str] = []
-            for pair in coords:
-                wkt_pair = _coord_pair_wkt(pair)
-                if not wkt_pair:
-                    return None
-                parts.append(f"({wkt_pair})")
-            return "MULTIPOINT (" + ", ".join(parts) + ")"
-
-        if gtype == "LineString":
-            if not isinstance(coords, list) or len(coords) < 2:
-                return None
-            pts: list[str] = []
-            for pair in coords:
-                wkt_pair = _coord_pair_wkt(pair)
-                if not wkt_pair:
-                    return None
-                pts.append(wkt_pair)
-            return "LINESTRING (" + ", ".join(pts) + ")"
-
-        if gtype == "Polygon":
-            if not isinstance(coords, list) or not coords:
-                return None
-            rings_wkt: list[str] = []
-            for ring in coords:
-                ring_wkt = _ring_coords_wkt(ring)
-                if not ring_wkt:
-                    return None
-                rings_wkt.append(f"({ring_wkt})")
-            return "POLYGON (" + ", ".join(rings_wkt) + ")"
-
-        if gtype == "MultiPolygon":
-            if not isinstance(coords, list) or not coords:
-                return None
-            polys: list[str] = []
-            for poly in coords:
-                if not isinstance(poly, list) or not poly:
-                    return None
-                rings_wkt = []
-                for ring in poly:
-                    ring_wkt = _ring_coords_wkt(ring)
-                    if not ring_wkt:
-                        return None
-                    rings_wkt.append(f"({ring_wkt})")
-                polys.append("(" + ", ".join(rings_wkt) + ")")
-            return "MULTIPOLYGON (" + ", ".join(polys) + ")"
-    except Exception:
-        return None
-
-    return None
-
-
-def _geometry_bind_value(session: Session, geometry_json: dict[str, Any]) -> object | None:
-    """Return a dialect-appropriate bind value for `SubstrateLocation.geometry`.
-
-    SQLite tests store `geometry` as plain text and cannot bind GeoAlchemy elements.
-    Postgres uses true PostGIS geometry via GeoAlchemy's `WKTElement`.
-    """
-
-    wkt = _geojson_to_wkt(geometry_json)
-    if not wkt:
-        return None
-
-    dialect_name = session.get_bind().dialect.name
-    if dialect_name == "postgresql":
-        from geoalchemy2.elements import WKTElement
-
-        return WKTElement(wkt, srid=4326)
-
-    return wkt
 
 def _upsert_location_cache(
     session: Session,
@@ -533,7 +431,7 @@ def _geometry_parts_from_entry(
     elif isinstance(entry.get("geometry"), dict):
         geometry_json = dict(entry["geometry"])
 
-    bind_value = _geometry_bind_value(session, geometry_json) if geometry_json else None
+    bind_value = geometry_bind_value(session, geometry_json) if geometry_json else None
     geometry_type = geometry_json.get("type") if geometry_json else None
     geometry_type_str = str(geometry_type) if geometry_type else None
     return geometry_json, bind_value, geometry_type_str
@@ -661,6 +559,9 @@ def _apply_substrate_location_merge(
     loc.source_kind = "agate_geocode"
     prev_details = loc.source_details_json if isinstance(loc.source_details_json, dict) else {}
     loc.source_details_json = {**prev_details, **details}
+    keep_editorial_geometry = (
+        not clear_geocode_identity and substrate_has_editorial_geometry_override(loc)
+    )
     if clear_geocode_identity:
         loc.external_source = None
         loc.external_id = None
@@ -671,15 +572,17 @@ def _apply_substrate_location_merge(
         loc.geometry_json = None
         loc.h3_cell = None
         loc.h3_resolution = None
+        clear_geometry_editorial_override(loc)
     else:
         loc.external_source = external_source or loc.external_source
         loc.external_id = external_id or loc.external_id
         loc.geocode_type = geocode_type or loc.geocode_type
         loc.formatted_address = formatted_address or loc.formatted_address
-        loc.geometry = geometry_value or loc.geometry
-        loc.geometry_type = geometry_type_str or loc.geometry_type
-        loc.geometry_json = geometry_json or loc.geometry_json
-    if geometry_json is not None and not clear_geocode_identity:
+        if not keep_editorial_geometry:
+            loc.geometry = geometry_value or loc.geometry
+            loc.geometry_type = geometry_type_str or loc.geometry_type
+            loc.geometry_json = geometry_json or loc.geometry_json
+    if geometry_json is not None and not clear_geocode_identity and not keep_editorial_geometry:
         loc.h3_cell = h3_cell
         loc.h3_resolution = h3_resolution
     # Latest ingest wins when the payload carries an audit dict (Advanced path).

--- a/docs/api/stylebook.md
+++ b/docs/api/stylebook.md
@@ -39,7 +39,7 @@ Stylebook-scoped families under `/v1/stylebooks/{stylebook_slug}` provide list/s
 
 Canonical identifiers are UUID strings. Catalog responses expose immutable slugs for stable links. Project filters narrow mention and evidence counts without changing catalog ownership.
 
-Location geometry uses GeoJSON `Point`, `Polygon`, or `MultiPolygon` with longitude-latitude coordinate order.
+Location geometry uses GeoJSON `Point`, `Polygon`, or `MultiPolygon` with longitude-latitude coordinate order. Canonical and saved-place geometry PATCH routes write GeoJSON together with PostGIS `geometry`, `geometry_type`, and H3. Editors can copy a canonical location’s current geography onto selected linked saved places with `POST /v1/stylebooks/{stylebook_slug}/canonical-locations/{id}/geometry/apply-to-substrates`. That write marks those saved places so later ingest does not replace the editorial shape, and it deletes matching project geocode-cache rows.
 
 Canonical metadata is Stylebook-wide editorial data: one typed scalar attribute per
 `meta_type` slug on a canonical (`text`, `number`, or `boolean`). Rows retain a project

--- a/docs/development/entities/overview.md
+++ b/docs/development/entities/overview.md
@@ -131,6 +131,12 @@ reflected in API query parameters and UI filters:
 - editing a story row from Agate review affects that story's substrate evidence and
   does not silently rewrite the canonical.
 
+Location catalog geography can be copied onto selected linked saved places from Stylebook.
+That override stays on the saved-place row (including PostGIS and H3) so article geo-search
+follows the catalog shape. The next ingest of the same geocode finds the existing row by
+identity fingerprint and keeps the editorial geometry unless an authoritative geocode
+rejection clears it.
+
 Occurrence offsets are written only for a normalization-equivalent article slice.
 When whitespace or encoding artifacts cannot be mapped back exactly, the evidence
 text remains but its offsets are null.

--- a/docs/development/frontend/stylebook.md
+++ b/docs/development/frontend/stylebook.md
@@ -145,7 +145,7 @@ behavior. Type-specific filters live in the list configuration.
 Each canonical detail page uses this section order:
 
 1. Details
-2. Geography for locations only
+2. Geography for locations only (including applying catalog geography to linked saved places)
 3. Mentions grouped by linked substrate row
 4. Metadata
 5. Connections

--- a/packages/backfield-entities/src/backfield_entities/entities/location/__init__.py
+++ b/packages/backfield-entities/src/backfield_entities/entities/location/__init__.py
@@ -1,5 +1,9 @@
 """Location canonical persist, policy, and PlaceExtract type helpers."""
 
+from backfield_entities.entities.location.geometry_apply import (
+    apply_canonical_geometry_to_substrates,
+    suggest_substrate_for_geometry_apply,
+)
 from backfield_entities.entities.location.persist import (
     apply_canonical_persist_plan,
     apply_canonical_persist_plan_review_only,
@@ -21,6 +25,7 @@ from backfield_entities.entities.location.policy import (
 )
 
 __all__ = [
+    "apply_canonical_geometry_to_substrates",
     "apply_canonical_persist_plan",
     "apply_canonical_persist_plan_review_only",
     "assert_canonical_link_invariant",
@@ -36,4 +41,5 @@ __all__ = [
     "rank_scored_canonical_recall_matches",
     "refresh_aliases_for_linked_location",
     "substrate_may_materialize_canonical_after_recall",
+    "suggest_substrate_for_geometry_apply",
 ]

--- a/packages/backfield-entities/src/backfield_entities/entities/location/geometry_apply.py
+++ b/packages/backfield-entities/src/backfield_entities/entities/location/geometry_apply.py
@@ -1,0 +1,174 @@
+"""Apply Stylebook catalog geometry onto linked saved-place (substrate) rows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from backfield_db import (
+    StylebookLocationAlias,
+    StylebookLocationCanonical,
+    SubstrateLocation,
+    SubstrateLocationCache,
+)
+from sqlalchemy import delete
+from sqlmodel import Session, col, select
+
+from backfield_entities.canonical.link_matrix import types_are_comparable
+from backfield_entities.entities.location.types import is_address_like_location_type
+from backfield_entities.geo.geometry_bind import assign_geojson_geometry
+from backfield_entities.ingest.geocode_cache.fingerprint import normalize_substrate_cache_query
+
+GEOMETRY_EDITORIAL_OVERRIDE_KEY = "geometry_editorial_override"
+
+SKIP_NOT_FOUND = "not_found"
+SKIP_NOT_VISIBLE = "not_visible"
+SKIP_NOT_LINKED = "not_linked"
+
+
+@dataclass(frozen=True)
+class GeometryApplySkip:
+    id: int
+    reason: str
+
+
+@dataclass(frozen=True)
+class GeometryApplyResult:
+    updated_ids: tuple[int, ...]
+    skipped: tuple[GeometryApplySkip, ...]
+    cache_rows_purged: int
+
+
+def suggest_substrate_for_geometry_apply(
+    *,
+    substrate_location_type: str | None,
+    canonical_location_type: str | None,
+) -> bool:
+    """True when a linked saved place should be pre-checked for catalog geography apply."""
+    if is_address_like_location_type(substrate_location_type):
+        return False
+    return types_are_comparable(substrate_location_type, canonical_location_type)
+
+
+def substrate_has_editorial_geometry_override(location: SubstrateLocation) -> bool:
+    """True when an editor applied catalog geography onto this saved place."""
+    details = location.source_details_json if isinstance(location.source_details_json, dict) else {}
+    return details.get(GEOMETRY_EDITORIAL_OVERRIDE_KEY) is True
+
+
+def mark_geometry_editorial_override(location: SubstrateLocation) -> None:
+    details = (
+        dict(location.source_details_json)
+        if isinstance(location.source_details_json, dict)
+        else {}
+    )
+    details[GEOMETRY_EDITORIAL_OVERRIDE_KEY] = True
+    location.source_details_json = details
+
+
+def clear_geometry_editorial_override(location: SubstrateLocation) -> None:
+    details = (
+        location.source_details_json
+        if isinstance(location.source_details_json, dict)
+        else None
+    )
+    if not isinstance(details, dict) or GEOMETRY_EDITORIAL_OVERRIDE_KEY not in details:
+        return
+    updated = dict(details)
+    updated.pop(GEOMETRY_EDITORIAL_OVERRIDE_KEY, None)
+    location.source_details_json = updated or None
+
+
+def apply_canonical_geometry_to_substrates(
+    session: Session,
+    *,
+    canon: StylebookLocationCanonical,
+    substrate_ids: list[int],
+    visible_project_ids: list[int],
+) -> GeometryApplyResult:
+    """Copy catalog geometry onto selected linked saved places and purge matching cache rows."""
+    requested = list(dict.fromkeys(int(sid) for sid in substrate_ids))
+    visible = {int(pid) for pid in visible_project_ids}
+    canonical_id = str(canon.id)
+    now = datetime.now(UTC)
+
+    skipped: list[GeometryApplySkip] = []
+    updated: list[SubstrateLocation] = []
+
+    for sid in requested:
+        loc = session.get(SubstrateLocation, sid)
+        if loc is None or loc.id is None:
+            skipped.append(GeometryApplySkip(id=sid, reason=SKIP_NOT_FOUND))
+            continue
+        if int(loc.project_id) not in visible:
+            skipped.append(GeometryApplySkip(id=sid, reason=SKIP_NOT_VISIBLE))
+            continue
+        if str(loc.stylebook_location_canonical_id or "") != canonical_id:
+            skipped.append(GeometryApplySkip(id=sid, reason=SKIP_NOT_LINKED))
+            continue
+        gj = dict(canon.geometry_json) if isinstance(canon.geometry_json, dict) else None
+        assign_geojson_geometry(session, loc, gj)
+        mark_geometry_editorial_override(loc)
+        loc.updated_at = now
+        session.add(loc)
+        updated.append(loc)
+
+    cache_rows_purged = 0
+    if updated:
+        cache_rows_purged = _purge_matching_location_cache_rows(
+            session,
+            canon=canon,
+            updated=updated,
+        )
+
+    return GeometryApplyResult(
+        updated_ids=tuple(int(loc.id) for loc in updated if loc.id is not None),
+        skipped=tuple(skipped),
+        cache_rows_purged=cache_rows_purged,
+    )
+
+
+def _purge_matching_location_cache_rows(
+    session: Session,
+    *,
+    canon: StylebookLocationCanonical,
+    updated: list[SubstrateLocation],
+) -> int:
+    project_ids = sorted({int(loc.project_id) for loc in updated})
+    keys: set[str] = set()
+    label_key = normalize_substrate_cache_query(str(canon.label or ""))
+    if label_key:
+        keys.add(label_key)
+    alias_rows = session.exec(
+        select(StylebookLocationAlias.normalized_alias).where(
+            StylebookLocationAlias.location_canonical_id == str(canon.id),
+            StylebookLocationAlias.suppressed.is_(False),
+        )
+    ).all()
+    for alias in alias_rows:
+        key = str(alias or "").strip()
+        if key:
+            keys.add(key)
+    for loc in updated:
+        for raw in (loc.name, loc.normalized_name):
+            key = normalize_substrate_cache_query(str(raw or ""))
+            if key:
+                keys.add(key)
+    if not project_ids or not keys:
+        return 0
+    cache_ids = [
+        int(row)
+        for row in session.exec(
+            select(SubstrateLocationCache.id).where(
+                col(SubstrateLocationCache.project_id).in_(project_ids),
+                col(SubstrateLocationCache.normalized_query).in_(sorted(keys)),
+            )
+        ).all()
+        if row is not None
+    ]
+    if not cache_ids:
+        return 0
+    session.exec(
+        delete(SubstrateLocationCache).where(col(SubstrateLocationCache.id).in_(cache_ids))
+    )
+    return len(cache_ids)

--- a/packages/backfield-entities/src/backfield_entities/geo/geometry_bind.py
+++ b/packages/backfield-entities/src/backfield_entities/geo/geometry_bind.py
@@ -1,0 +1,148 @@
+"""Convert GeoJSON to a dialect-appropriate bind value for location PostGIS columns."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+from backfield_entities.geo.h3_index import apply_h3_fields
+from sqlmodel import Session
+
+
+class HasLocationGeometry(Protocol):
+    geometry: object | None
+    geometry_json: dict | None
+    geometry_type: str | None
+    h3_cell: str | None
+    h3_resolution: int | None
+
+
+def _coord_pair_wkt(pair: Any) -> str | None:
+    if not isinstance(pair, (list, tuple)) or len(pair) < 2:
+        return None
+    lon, lat = float(pair[0]), float(pair[1])
+    return f"{lon} {lat}"
+
+
+def _ring_coords_wkt(ring: Any) -> str | None:
+    if not isinstance(ring, list) or not ring:
+        return None
+    pts: list[str] = []
+    for pair in ring:
+        wkt_pair = _coord_pair_wkt(pair)
+        if not wkt_pair:
+            return None
+        pts.append(wkt_pair)
+    if len(pts) < 3:
+        return None
+    if pts[0] != pts[-1]:
+        pts.append(pts[0])
+    return ", ".join(pts)
+
+
+def geojson_to_wkt(geometry_json: dict[str, Any]) -> str | None:
+    """Return WKT for a GeoJSON geometry, or ``None`` when the shape is invalid."""
+    gtype = str(geometry_json.get("type") or "").title()
+    coords = geometry_json.get("coordinates")
+
+    try:
+        if gtype == "Point":
+            pair = _coord_pair_wkt(coords)
+            if not pair:
+                return None
+            return f"POINT ({pair})"
+
+        if gtype == "MultiPoint":
+            if not isinstance(coords, list) or not coords:
+                return None
+            parts: list[str] = []
+            for pair in coords:
+                wkt_pair = _coord_pair_wkt(pair)
+                if not wkt_pair:
+                    return None
+                parts.append(f"({wkt_pair})")
+            return "MULTIPOINT (" + ", ".join(parts) + ")"
+
+        if gtype == "LineString":
+            if not isinstance(coords, list) or len(coords) < 2:
+                return None
+            pts: list[str] = []
+            for pair in coords:
+                wkt_pair = _coord_pair_wkt(pair)
+                if not wkt_pair:
+                    return None
+                pts.append(wkt_pair)
+            return "LINESTRING (" + ", ".join(pts) + ")"
+
+        if gtype == "Polygon":
+            if not isinstance(coords, list) or not coords:
+                return None
+            rings_wkt: list[str] = []
+            for ring in coords:
+                ring_wkt = _ring_coords_wkt(ring)
+                if not ring_wkt:
+                    return None
+                rings_wkt.append(f"({ring_wkt})")
+            return "POLYGON (" + ", ".join(rings_wkt) + ")"
+
+        if gtype == "MultiPolygon":
+            if not isinstance(coords, list) or not coords:
+                return None
+            polys: list[str] = []
+            for poly in coords:
+                if not isinstance(poly, list) or not poly:
+                    return None
+                rings_wkt = []
+                for ring in poly:
+                    ring_wkt = _ring_coords_wkt(ring)
+                    if not ring_wkt:
+                        return None
+                    rings_wkt.append(f"({ring_wkt})")
+                polys.append("(" + ", ".join(rings_wkt) + ")")
+            return "MULTIPOLYGON (" + ", ".join(polys) + ")"
+    except Exception:
+        return None
+
+    return None
+
+
+def geometry_bind_value(session: Session, geometry_json: dict[str, Any]) -> object | None:
+    """Return a dialect-appropriate bind value for a location ``geometry`` column.
+
+    SQLite tests store ``geometry`` as plain text and cannot bind GeoAlchemy elements.
+    Postgres uses true PostGIS geometry via GeoAlchemy's ``WKTElement``.
+    """
+    wkt = geojson_to_wkt(geometry_json)
+    if not wkt:
+        return None
+
+    dialect_name = session.get_bind().dialect.name
+    if dialect_name == "postgresql":
+        from geoalchemy2.elements import WKTElement
+
+        return WKTElement(wkt, srid=4326)
+
+    return wkt
+
+
+def assign_geojson_geometry(
+    session: Session,
+    row: HasLocationGeometry,
+    geometry_json: dict[str, Any] | None,
+) -> None:
+    """Write GeoJSON, PostGIS, type, and H3 onto a canonical or saved-place row."""
+    if geometry_json is None:
+        row.geometry_json = None
+        row.geometry = None
+        row.geometry_type = None
+        row.h3_cell = None
+        row.h3_resolution = None
+        return
+
+    copied = dict(geometry_json)
+    row.geometry_json = copied
+    gt = copied.get("type")
+    row.geometry_type = str(gt) if gt else None
+    row.geometry = geometry_bind_value(session, copied)
+    cell, resolution = apply_h3_fields(geometry_json=copied)
+    row.h3_cell = cell
+    row.h3_resolution = resolution

--- a/tests/entities/test_location_geometry_apply.py
+++ b/tests/entities/test_location_geometry_apply.py
@@ -1,0 +1,47 @@
+"""Unit tests for catalog-geography apply helpers."""
+
+from __future__ import annotations
+
+from backfield_entities.entities.location.geometry_apply import (
+    suggest_substrate_for_geometry_apply,
+)
+
+
+def test_suggest_same_neighborhood_types() -> None:
+    assert (
+        suggest_substrate_for_geometry_apply(
+            substrate_location_type="neighborhood",
+            canonical_location_type="neighborhood",
+        )
+        is True
+    )
+
+
+def test_suggest_comparable_admin_types() -> None:
+    assert (
+        suggest_substrate_for_geometry_apply(
+            substrate_location_type="community_area",
+            canonical_location_type="neighborhood",
+        )
+        is True
+    )
+
+
+def test_skip_address_like_even_if_types_otherwise_open() -> None:
+    assert (
+        suggest_substrate_for_geometry_apply(
+            substrate_location_type="address",
+            canonical_location_type="neighborhood",
+        )
+        is False
+    )
+
+
+def test_skip_place_linked_to_neighborhood() -> None:
+    assert (
+        suggest_substrate_for_geometry_apply(
+            substrate_location_type="place",
+            canonical_location_type="neighborhood",
+        )
+        is False
+    )

--- a/tests/stylebook_api/test_stylebook_api.py
+++ b/tests/stylebook_api/test_stylebook_api.py
@@ -22,6 +22,7 @@ from backfield_db import (
     StylebookPersonCanonical,
     SubstrateArticle,
     SubstrateLocation,
+    SubstrateLocationCache,
     SubstrateLocationMention,
     SubstrateLocationMentionOccurrence,
     SubstrateOrganization,
@@ -35,6 +36,7 @@ from backfield_entities.canonical.link import (
     CANONICAL_LINK_UNLINKED,
     CANONICAL_LINK_WAIVED,
 )
+from backfield_entities.entities.location.geometry_apply import GEOMETRY_EDITORIAL_OVERRIDE_KEY
 from backfield_entities.entities.location.persist import materialize_new_canonical_and_link
 from fastapi.testclient import TestClient
 from sqlalchemy import event
@@ -2245,6 +2247,239 @@ def test_patch_saved_place_geometry_clear_with_null(
         assert row is not None
         assert row.geometry_json is None
         assert row.geometry_type is None
+        assert row.geometry is None
+
+
+def test_patch_saved_place_geometry_writes_bind_value(
+    client: TestClient, stylebook_test_engine: Engine
+) -> None:
+    engine = stylebook_test_engine
+    gj: dict = {"type": "Point", "coordinates": [-87.6298, 41.8781]}
+    with Session(engine) as s:
+        proj = s.exec(select(BackfieldProject).where(BackfieldProject.slug == "demo-proj")).one()
+        loc = SubstrateLocation(
+            project_id=int(proj.id),
+            name="WriteGeom",
+            normalized_name="writegeom",
+            location_type="place",
+            identity_fingerprint="fp-write-geom-1",
+        )
+        s.add(loc)
+        s.commit()
+        s.refresh(loc)
+        sid = int(loc.id)  # type: ignore[arg-type]
+
+    r = client.patch(
+        f"/v1/locations/{sid}/geometry?project_slug=demo-proj",
+        headers=_service_headers(),
+        json={"geometry_json": gj},
+    )
+    assert r.status_code == 200
+    with Session(engine) as s:
+        row = s.get(SubstrateLocation, sid)
+        assert row is not None
+        assert row.geometry_json == gj
+        assert row.geometry_type == "Point"
+        assert row.geometry is not None
+        assert str(row.geometry).startswith("POINT")
+        assert row.h3_cell
+
+
+def test_patch_canonical_geometry_writes_postgis_and_h3(
+    client: TestClient, stylebook_test_engine: Engine
+) -> None:
+    engine = stylebook_test_engine
+    gj: dict = {
+        "type": "Polygon",
+        "coordinates": [
+            [[-87.8, 41.7], [-87.6, 41.7], [-87.6, 41.9], [-87.8, 41.9], [-87.8, 41.7]]
+        ],
+    }
+    with Session(engine) as s:
+        proj = s.exec(select(BackfieldProject).where(BackfieldProject.slug == "demo-proj")).one()
+        ws = s.get(BackfieldWorkspace, int(proj.workspace_id))  # type: ignore[arg-type]
+        canon = StylebookLocationCanonical(
+            stylebook_id=int(ws.stylebook_id),
+            label="Northalsted",
+            slug="northalsted-geom-patch",
+            location_type="neighborhood",
+            primary_substrate_location_id=None,
+            status="active",
+        )
+        s.add(canon)
+        user = BackfieldUser(email="geom-patch-admin@example.com", password_hash="x")
+        s.add(user)
+        s.commit()
+        s.refresh(canon)
+        s.refresh(user)
+        cid = str(canon.id)
+        admin_id = int(user.id)  # type: ignore[arg-type]
+
+    def _admin_auth() -> dict[str, Any]:
+        with Session(engine) as s:
+            u = s.get(BackfieldUser, admin_id)
+            assert u is not None
+            return _session_auth_for_user(u, org_id=1, org_role="org_admin")
+
+    app.dependency_overrides[get_auth_dep] = _admin_auth
+    try:
+        r = client.patch(
+            f"/v1/stylebooks/default/canonical-locations/{cid}/geometry",
+            json={"geometry_json": gj},
+        )
+        assert r.status_code == 200
+    finally:
+        app.dependency_overrides.pop(get_auth_dep, None)
+    with Session(engine) as s:
+        row = s.get(StylebookLocationCanonical, cid)
+        assert row is not None
+        assert row.geometry_json == gj
+        assert row.geometry_type == "Polygon"
+        assert row.geometry is not None
+        assert str(row.geometry).startswith("POLYGON")
+        assert row.h3_cell
+
+
+def test_apply_canonical_geometry_to_linked_saved_places(
+    client: TestClient, stylebook_test_engine: Engine
+) -> None:
+    engine = stylebook_test_engine
+    catalog_gj: dict = {
+        "type": "Polygon",
+        "coordinates": [
+            [[-87.7, 41.9], [-87.6, 41.9], [-87.6, 42.0], [-87.7, 42.0], [-87.7, 41.9]]
+        ],
+    }
+    stale_gj: dict = {"type": "Point", "coordinates": [-87.6, 41.8]}
+    with Session(engine) as s:
+        proj = s.exec(select(BackfieldProject).where(BackfieldProject.slug == "demo-proj")).one()
+        pid = int(proj.id)
+        ws = s.get(BackfieldWorkspace, int(proj.workspace_id))  # type: ignore[arg-type]
+        sb_id = int(ws.stylebook_id)
+        canon = StylebookLocationCanonical(
+            stylebook_id=sb_id,
+            label="Northalsted",
+            slug="northalsted-apply",
+            location_type="neighborhood",
+            geometry_json=catalog_gj,
+            geometry_type="Polygon",
+            primary_substrate_location_id=None,
+            status="active",
+        )
+        other = StylebookLocationCanonical(
+            stylebook_id=sb_id,
+            label="Other Place",
+            slug="other-place-apply",
+            location_type="neighborhood",
+            primary_substrate_location_id=None,
+            status="active",
+        )
+        s.add(canon)
+        s.add(other)
+        s.commit()
+        s.refresh(canon)
+        s.refresh(other)
+        cid = str(canon.id)
+        loc = SubstrateLocation(
+            project_id=pid,
+            name="Northalsted",
+            normalized_name="northalsted",
+            location_type="neighborhood",
+            identity_fingerprint="fp-northalsted-stale",
+            stylebook_location_canonical_id=cid,
+            canonical_link_status=CANONICAL_LINK_LINKED,
+            geometry_json=stale_gj,
+            geometry_type="Point",
+        )
+        other_loc = SubstrateLocation(
+            project_id=pid,
+            name="Elsewhere",
+            normalized_name="elsewhere",
+            location_type="neighborhood",
+            identity_fingerprint="fp-elsewhere-apply",
+            stylebook_location_canonical_id=str(other.id),
+            canonical_link_status=CANONICAL_LINK_LINKED,
+            geometry_json=stale_gj,
+            geometry_type="Point",
+        )
+        s.add(loc)
+        s.add(other_loc)
+        s.add(
+            SubstrateLocationCache(
+                project_id=pid,
+                query_text="Northalsted",
+                normalized_query="northalsted",
+                query_fingerprint="fp-cache-northalsted",
+                location_name="Northalsted",
+                location_type="neighborhood",
+                geometry_json=stale_gj,
+                geometry_type="Point",
+                response_payload_json={},
+            )
+        )
+        user = BackfieldUser(email="geom-apply-admin@example.com", password_hash="x")
+        s.add(user)
+        s.commit()
+        s.refresh(loc)
+        s.refresh(other_loc)
+        s.refresh(user)
+        sid = int(loc.id)  # type: ignore[arg-type]
+        other_sid = int(other_loc.id)  # type: ignore[arg-type]
+        fingerprint_before = str(loc.identity_fingerprint)
+        admin_id = int(user.id)  # type: ignore[arg-type]
+
+    def _admin_auth() -> dict[str, Any]:
+        with Session(engine) as s:
+            u = s.get(BackfieldUser, admin_id)
+            assert u is not None
+            return _session_auth_for_user(u, org_id=1, org_role="org_admin")
+
+    app.dependency_overrides[get_auth_dep] = _admin_auth
+    try:
+        listed = client.get(
+            f"/v1/stylebooks/default/canonical-locations/{cid}/linked-substrates",
+        )
+        assert listed.status_code == 200
+        items = listed.json()["substrates"]
+        assert len(items) == 1
+        assert items[0]["id"] == sid
+        assert items[0]["suggested_for_geometry"] is True
+        assert items[0]["geometry_type"] == "Point"
+
+        r = client.post(
+            f"/v1/stylebooks/default/canonical-locations/{cid}/geometry/apply-to-substrates",
+            json={"substrate_location_ids": [sid, other_sid, 999999]},
+        )
+        assert r.status_code == 200
+    finally:
+        app.dependency_overrides.pop(get_auth_dep, None)
+    body = r.json()
+    assert body["updated_ids"] == [sid]
+    reasons = {item["id"]: item["reason"] for item in body["skipped"]}
+    assert reasons[other_sid] == "not_linked"
+    assert reasons[999999] == "not_found"
+    assert body["cache_rows_purged"] == 1
+
+    with Session(engine) as s:
+        row = s.get(SubstrateLocation, sid)
+        assert row is not None
+        assert row.geometry_json == catalog_gj
+        assert row.geometry_type == "Polygon"
+        assert row.geometry is not None
+        assert str(row.geometry).startswith("POLYGON")
+        assert row.identity_fingerprint == fingerprint_before
+        details = row.source_details_json if isinstance(row.source_details_json, dict) else {}
+        assert details.get(GEOMETRY_EDITORIAL_OVERRIDE_KEY) is True
+        leftover = s.exec(
+            select(SubstrateLocationCache).where(
+                SubstrateLocationCache.project_id == int(row.project_id),
+                SubstrateLocationCache.normalized_query == "northalsted",
+            )
+        ).all()
+        assert leftover == []
+        other_row = s.get(SubstrateLocation, other_sid)
+        assert other_row is not None
+        assert other_row.geometry_json == stale_gj
 
 
 def test_accept_candidate_create_new_location_type_override(

--- a/tests/test_geocoding_bbox_polygon.py
+++ b/tests/test_geocoding_bbox_polygon.py
@@ -6,7 +6,7 @@ from agate_utils.geocoding.geocoding_types import (
     GeometryPolygon,
     bbox_west_south_east_north_to_polygon_coordinates,
 )
-from worker.substrate.entities.location.upsert import _geojson_to_wkt
+from backfield_entities.geo.geometry_bind import geojson_to_wkt
 
 
 def test_bbox_to_polygon_is_closed_ring_of_lon_lat_pairs() -> None:
@@ -28,7 +28,7 @@ def test_geometry_polygon_accepts_normalized_bbox_coordinates() -> None:
 
 def test_geojson_to_wkt_accepts_polygon_from_bbox_helper() -> None:
     coords = bbox_west_south_east_north_to_polygon_coordinates([-87.8, 41.7, -87.6, 41.9])
-    wkt = _geojson_to_wkt({"type": "Polygon", "coordinates": coords})
+    wkt = geojson_to_wkt({"type": "Polygon", "coordinates": coords})
     assert wkt is not None
     assert wkt.startswith("POLYGON ((")
     assert wkt.endswith("))")

--- a/tests/worker/test_geocode_router_audit.py
+++ b/tests/worker/test_geocode_router_audit.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+from backfield_entities.entities.location.geometry_apply import (
+    GEOMETRY_EDITORIAL_OVERRIDE_KEY,
+    mark_geometry_editorial_override,
+)
 from worker.substrate.entities.location.upsert import (
     _apply_substrate_location_merge,
     _router_audit_from_place_entry,
@@ -45,3 +49,78 @@ def test_merge_preserves_audit_when_incoming_none() -> None:
 
     _apply_substrate_location_merge(loc, **common, geocode_router_audit_json={"latest": True})
     assert loc.geocode_router_audit_json == {"latest": True}
+
+
+def _merge_kwargs(**overrides: object) -> dict:
+    values: dict = {
+        "display_name": "Northalsted",
+        "normalized": "northalsted",
+        "location_type_str": "neighborhood",
+        "status": "resolved",
+        "external_source": "pelias",
+        "external_id": "gid-1",
+        "fingerprint": "fp-northalsted-stale",
+        "geocode_type": "pelias",
+        "formatted_address": None,
+        "details": {"run_id": "run-2"},
+        "geometry_value": "POINT (-87.6 41.8)",
+        "geometry_type_str": "Point",
+        "geometry_json": {"type": "Point", "coordinates": [-87.6, 41.8]},
+        "h3_cell": "newcell",
+        "h3_resolution": 11,
+        "geocode_router_audit_json": None,
+    }
+    values.update(overrides)
+    return values
+
+
+def test_merge_keeps_editorially_overridden_geometry() -> None:
+    from backfield_db import SubstrateLocation
+
+    catalog = {
+        "type": "Polygon",
+        "coordinates": [
+            [[-87.7, 41.9], [-87.6, 41.9], [-87.6, 42.0], [-87.7, 42.0], [-87.7, 41.9]]
+        ],
+    }
+    loc = SubstrateLocation(
+        project_id=1,
+        name="Northalsted",
+        normalized_name="northalsted",
+        identity_fingerprint="fp-northalsted-stale",
+        geometry_json=catalog,
+        geometry_type="Polygon",
+        geometry="POLYGON ((-87.7 41.9, -87.6 41.9, -87.6 42.0, -87.7 42.0, -87.7 41.9))",
+        h3_cell="oldcell",
+        h3_resolution=7,
+        source_details_json={"run_id": "run-1"},
+    )
+    mark_geometry_editorial_override(loc)
+    _apply_substrate_location_merge(loc, **_merge_kwargs())
+    assert loc.geometry_json == catalog
+    assert loc.geometry_type == "Polygon"
+    assert loc.h3_cell == "oldcell"
+    assert loc.identity_fingerprint == "fp-northalsted-stale"
+    details = loc.source_details_json if isinstance(loc.source_details_json, dict) else {}
+    assert details.get(GEOMETRY_EDITORIAL_OVERRIDE_KEY) is True
+    assert details.get("run_id") == "run-2"
+
+
+def test_merge_clears_editorial_override_on_authoritative_rejection() -> None:
+    from backfield_db import SubstrateLocation
+
+    loc = SubstrateLocation(
+        project_id=1,
+        name="Northalsted",
+        normalized_name="northalsted",
+        identity_fingerprint="fp-northalsted-stale",
+        geometry_json={"type": "Point", "coordinates": [-87.6, 41.8]},
+        geometry_type="Point",
+        source_details_json={GEOMETRY_EDITORIAL_OVERRIDE_KEY: True},
+    )
+    _apply_substrate_location_merge(loc, **_merge_kwargs(), clear_geocode_identity=True)
+    assert loc.geometry_json is None
+    assert loc.geometry is None
+    details = loc.source_details_json if isinstance(loc.source_details_json, dict) else {}
+    assert GEOMETRY_EDITORIAL_OVERRIDE_KEY not in details
+


### PR DESCRIPTION
## Summary

- Editors can apply a corrected Stylebook location’s geography onto selected linked saved places, so article geo-search follows the catalog shape instead of a stale geocode polygon.
- Geometry PATCH now writes GeoJSON, PostGIS, type, and H3 on both catalog and saved-place rows. Applied rows keep an editorial override so later ingest does not clobber them, and matching geocode-cache rows are purged.

## Project scope check

- [x] This change targets local development / source inspection (production self-hosting is unsupported in this repo)
- [x] Docs under `docs/` updated if behavior, architecture, or operations changed
- [x] First-admin provisioning still uses `backfield init` / `backfield seed` only (no HTTP/env bootstrap paths)

## Test plan

- [x] `make lint`
- [x] `make test`
- [ ] `make ui-typecheck ui-test` (if UI/TypeScript changed)
- [ ] `make smoke-fast` (if live-stack behavior changed)
- [ ] `make smoke` (if golden-path / provider-dependent runtime changed; configure **Settings → AI models**)

## Notes for reviewers

No query-time geometry precedence; search still reads saved-place PostGIS. The identity fingerprint is left unchanged so the next identical geocode finds the same row; the merge guard protects the editorial shape. Suggested dialog pre-checks are type-comparable, non-address saved places—editors can still include or exclude rows. Retroactive fixes use the standalone “Apply to linked saved places” action on already-corrected catalog entries.


Made with [Cursor](https://cursor.com)