### PR TITLE
Add attached images to the Playground include picker

### DIFF
--- a/.cursor/rules/frontend-standards.mdc
+++ b/.cursor/rules/frontend-standards.mdc
@@ -3,6 +3,7 @@ description: Frontend conventions for Agate UI, Stylebook UI, and shared TS/Reac
 globs:
   - apps/agate-ui/**/*.{ts,tsx}
   - apps/stylebook-ui/**/*.{ts,tsx}
+  - apps/api-playground/**/*.{ts,tsx}
   - packages/backfield-ui/**/*.{ts,tsx}
   - packages/backfield-agate/src/**/*.tsx
 alwaysApply: false
@@ -16,3 +17,5 @@ alwaysApply: false
 - Reuse shared API helpers, UI primitives, and existing patterns before adding a new abstraction.
 - Keep browser storage keys and custom event names consistent with existing prefixes and docs.
 - Do not hand-edit generated node registry output unless the generation flow itself is changing.
+- Public `/public/v1` changes must update API Playground presentation in `apps/api-playground`
+  (include pickers, helpers, discovery dropdowns) in addition to OpenAPI export.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,9 @@ canonical agent/engineering checklist.
 - Keep changes surgical. Every changed line should trace back to the task.
 - Prefer existing commands, docs, and package boundaries over inventing new workflows.
 - Update the matching source-of-truth doc when behavior, architecture, or operations change.
+- Public `/public/v1` contract changes must also update the API Playground presentation in
+  `apps/api-playground` (include pickers, helpers, discovery dropdowns, and request-body
+  controls). Regenerating OpenAPI is not enough when those UI tokens are hardcoded.
 - Keep work reviewable: one task per branch, one coherent diff, no unrelated cleanup.
 - In user-facing UI copy and frontend docs, prefer **product language** (e.g. “locations”, “candidates”, “canonicals”) over internal database terms like **“substrate”**.
 - **Frontend copy** (`apps/agate-ui`, `apps/stylebook-ui`, shared UI in `packages/backfield-ui`, node panels synced into apps): write for a **non-technical end user** and **avoid technical or code-related language** in any string shown in the product (see [`docs/development/frontend/conventions.md`](docs/development/frontend/conventions.md) → **User-facing copy**).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,8 @@ See [Testing](docs/development/testing.md) for layout and the fork-safe CI contr
 - Link the related issue when one exists.
 - Describe intent, risk, and how you validated the change.
 - Keep commits reviewable; force-pushes are fine on your feature branch before merge.
+- Public `/public/v1` changes should update the API Playground (`apps/api-playground`)
+  as well as the OpenAPI export; see [AGENTS.md](AGENTS.md).
 
 Maintainers may ask for smaller PRs, extra tests, or doc updates before merge.
 

--- a/apps/api-playground/README.md
+++ b/apps/api-playground/README.md
@@ -58,6 +58,17 @@ The semantic-search and geo-cell batch request bodies use the same structured fi
 validated against their OpenAPI constraints before the request is sent. The public trigger-run
 operation remains in the API contract but is intentionally omitted from the Playground interface.
 
+## Keeping pace with the public API
+
+The Playground is schema-first for endpoint discovery, but several request controls are
+hardcoded so they can use product labels and helpers. Public API changes that add or rename
+query parameters, request-body fields, `include` tokens, filters, or project-scoped discovery
+values must update those controls in the same change—typically
+[`src/lib/presentation.ts`](src/lib/presentation.ts) (`includeOptions`, `helperTextForField`,
+facet/metadata loaders) plus tests in `src/lib/presentation.test.ts`. Regenerating
+[`docs/api/public.openapi.json`](../../docs/api/public.openapi.json) is required and not
+sufficient by itself.
+
 ## Security boundary
 
 - Opening the Playground requires a signed-in Backfield session, matching Agate and Stylebook.

--- a/apps/api-playground/src/lib/presentation.test.ts
+++ b/apps/api-playground/src/lib/presentation.test.ts
@@ -160,6 +160,63 @@ describe("endpoint presentation contract", () => {
       { value: "metadata", label: "Stylebook attributes" },
     ])
     expect(peopleInclude.helperText).toMatch(/include metadata/i)
+
+    const articleSearchInclude = presentationForField(
+      articleSearch!,
+      "include",
+      { type: "array", items: { type: "string" } },
+      "Include extras",
+      blockedContext,
+      "query",
+    )
+    expect(articleSearchInclude.options).toEqual([
+      { value: "counts", label: "Mention counts" },
+      { value: "images", label: "Attached images" },
+    ])
+    expect(articleSearchInclude.helperText).toMatch(/images includes up to 10/)
+
+    const semanticInclude = presentationForField(
+      semanticSearch!,
+      "include",
+      { type: "array", items: { type: "string" } },
+      "Include extras",
+      blockedContext,
+      "body",
+    )
+    expect(semanticInclude.options).toEqual(articleSearchInclude.options)
+
+    const articleDetail = operations.find(
+      (operation) => operation.displayPath === "/articles/{article_id}",
+    )
+    expect(articleDetail).toBeDefined()
+    const detailInclude = presentationForField(
+      articleDetail!,
+      "include",
+      { type: "array", items: { type: "string" } },
+      "Include extras",
+      blockedContext,
+      "query",
+    )
+    expect(detailInclude.options).toEqual([
+      { value: "counts", label: "Mention counts" },
+      { value: "text", label: "Full article text" },
+    ])
+    expect(detailInclude.helperText).toMatch(/already includes up to 10 images/)
+
+    const personArticles = operations.find(
+      (operation) => operation.displayPath === "/people/{person_id}/articles",
+    )
+    expect(personArticles).toBeDefined()
+    expect(
+      presentationForField(
+        personArticles!,
+        "include",
+        { type: "array", items: { type: "string" } },
+        "Include extras",
+        blockedContext,
+        "query",
+      ).options,
+    ).toEqual(articleSearchInclude.options)
   })
 
   it("presents every request-body property through the shared field model", () => {

--- a/apps/api-playground/src/lib/presentation.ts
+++ b/apps/api-playground/src/lib/presentation.ts
@@ -146,15 +146,32 @@ function isEntityCatalogPath(displayPath: string): boolean {
   )
 }
 
+function isArticleDetailPath(displayPath: string): boolean {
+  return /^\/articles\/\{article_id\}$/.test(displayPath)
+}
+
+function isArticleCollectionPath(displayPath: string): boolean {
+  return (
+    displayPath === "/articles/search" ||
+    displayPath === "/articles/semantic-search" ||
+    displayPath === "/articles/geo-search" ||
+    /^\/(people|organizations|locations)\/\{[^}]+}\/articles$/.test(displayPath)
+  )
+}
+
+/** Keep tokens in sync with public `include=` allow-lists when those routes change. */
 function includeOptions(operation: PlaygroundOperation): SelectOption[] {
   if (isEntityCatalogPath(operation.displayPath)) {
     return [{ value: "metadata", label: "Stylebook attributes" }]
   }
-  const detailPath = /^\/articles\/\{article_id\}$/.test(operation.displayPath)
-  return [
-    { value: "counts", label: "Mention counts" },
-    ...(detailPath ? [{ value: "text", label: "Full article text" }] : []),
-  ]
+  const options: SelectOption[] = [{ value: "counts", label: "Mention counts" }]
+  if (isArticleCollectionPath(operation.displayPath)) {
+    options.push({ value: "images", label: "Attached images" })
+  }
+  if (isArticleDetailPath(operation.displayPath)) {
+    options.push({ value: "text", label: "Full article text" })
+  }
+  return options
 }
 
 function helperTextForField(
@@ -189,9 +206,10 @@ function helperTextForField(
         "Get-by-id responses always include metadata."
       )
     }
-    return /^\/articles\/\{article_id\}$/.test(operation.displayPath)
-      ? "counts adds mention totals; text includes the article body."
-      : "counts adds mention totals for each article."
+    if (isArticleDetailPath(operation.displayPath)) {
+      return "counts adds mention totals; text includes the article body. Detail already includes up to 10 images."
+    }
+    return "counts adds mention totals; images includes up to 10 attached images."
   }
   return undefined
 }

--- a/docs/api/public.md
+++ b/docs/api/public.md
@@ -236,6 +236,13 @@ A filtered public-only OpenAPI document is committed at
 uv run python scripts/export_public_openapi.py
 ```
 
+When a public route gains or changes query/body fields, `include` tokens, filters, or
+discovery values, update the Playground in `apps/api-playground` in the same change
+(especially `src/lib/presentation.ts` include pickers and helper text). The Playground
+loads OpenAPI for the catalog, but several controls are hardcoded and will not pick up
+new tokens from the spec alone. See the
+[`apps/api-playground` guide](../../apps/api-playground/README.md).
+
 Core API serves this public-only contract without authentication at
 `/public/v1/openapi.json`. The document contains only public paths and schemas
 reachable from them, declares project API key Bearer authentication, and lists

--- a/docs/development/frontend/conventions.md
+++ b/docs/development/frontend/conventions.md
@@ -105,6 +105,9 @@ embed absolute API hosts.
 - Apply the user-facing copy rules to every new or changed string.
 - Use `useAppMessage` for notices, errors, and confirmations.
 - Update the appropriate typed API module when a contract changes.
+- Public `/public/v1` contract changes: update the API Playground presentation in
+  `apps/api-playground` (include pickers, helpers, discovery controls) as well as
+  OpenAPI export. See [`../../apps/api-playground/README.md`](../../apps/api-playground/README.md).
 - Preserve URL-backed filters and deep-link state when changing navigation.
 - Reuse shared shells and split components that have become hard to scan.
 - For node metadata or panel changes, follow

--- a/docs/development/frontend/conventions.md
+++ b/docs/development/frontend/conventions.md
@@ -107,7 +107,7 @@ embed absolute API hosts.
 - Update the appropriate typed API module when a contract changes.
 - Public `/public/v1` contract changes: update the API Playground presentation in
   `apps/api-playground` (include pickers, helpers, discovery controls) as well as
-  OpenAPI export. See [`../../apps/api-playground/README.md`](../../apps/api-playground/README.md).
+  OpenAPI export. See [`../../../apps/api-playground/README.md`](../../../apps/api-playground/README.md).
 - Preserve URL-backed filters and deep-link state when changing navigation.
 - Reuse shared shells and split components that have become hard to scan.
 - For node metadata or panel changes, follow


### PR DESCRIPTION
## Summary

- Article list/search (keyword, semantic, geo) and person/org/location article lists now offer **Attached images** on the Playground `include` control, matching `include=images`.
- Helper text documents the 10-image cap; article detail still only offers counts and full text because images are already inlined.
- Documents that public API contract changes must update Playground presentation (`include` pickers, helpers, discovery controls), not only the OpenAPI export.

## Project scope check

- [x] This change targets local development / source inspection (production self-hosting is unsupported in this repo)
- [x] Docs under `docs/` updated if behavior, architecture, or operations changed
- [x] First-admin provisioning still uses `backfield init` / `backfield seed` only (no HTTP/env bootstrap paths)

## Test plan

- [ ] `make lint`
- [ ] `make test`
- [x] `make api-playground-test` (Playground TypeScript; `make ui-typecheck ui-test` not run for Agate/Stylebook)
- [ ] `make smoke-fast` (if live-stack behavior changed)
- [ ] `make smoke` (if golden-path / provider-dependent runtime changed; configure **Settings → AI models**)

## Notes for reviewers

- Depends on `include=images` from #153 (already on `main`).
- Regenerating OpenAPI alone does not add Playground checkbox tokens; they live in `apps/api-playground/src/lib/presentation.ts`.


Made with [Cursor](https://cursor.com)