### PR TITLE
Agate graph enhancements: JSON Input batch upload, article-only output, Geocode invariant

### DIFF
--- a/apps/agate-ui/src/lib/flowValidation.test.ts
+++ b/apps/agate-ui/src/lib/flowValidation.test.ts
@@ -9,6 +9,7 @@ import {
   validateInputConnections,
   validateJsonInputNodes,
   validateNoOrphans,
+  validateRequiredUpstreamNodes,
   validateSingleBookends,
   type FlowGraph,
 } from './flowValidation'
@@ -443,7 +444,71 @@ describe('validateGraphForSave', () => {
         edges: [{ source: 'json', target: 'out' }],
       }),
     )
-    expect(result).toMatchObject({ ok: false, severity: 'error', title: 'Invalid JSON input' })
+    expect(result).toMatchObject({ ok: false, severity: 'error', title: 'Invalid content' })
+  })
+
+  it('fails when Geocode Agent has no Place Extract upstream', () => {
+    const result = validateGraphForSave(
+      graph({
+        nodes: [
+          { id: 'in', type: 'TextInput' },
+          { id: 'geo', type: 'GeocodeAgent' },
+          { id: 'out', type: 'DBOutput' },
+        ],
+        edges: [
+          { source: 'in', target: 'geo' },
+          { source: 'geo', target: 'out' },
+        ],
+      }),
+    )
+    expect(result).toMatchObject({
+      ok: false,
+      title: 'Geocode needs places',
+      severity: 'error',
+    })
+  })
+})
+
+describe('validateRequiredUpstreamNodes', () => {
+  it('passes when Geocode follows Place Extract', () => {
+    expect(
+      validateRequiredUpstreamNodes(
+        graph({
+          nodes: [
+            { id: 'in', type: 'TextInput' },
+            { id: 'pe', type: 'PlaceExtract' },
+            { id: 'geo', type: 'GeocodeAgent' },
+            { id: 'out', type: 'DBOutput' },
+          ],
+          edges: [
+            { source: 'in', target: 'pe' },
+            { source: 'pe', target: 'geo' },
+            { source: 'geo', target: 'out' },
+          ],
+        }),
+      ).ok,
+    ).toBe(true)
+  })
+
+  it('rejects Geocode on a sibling branch without Place Extract', () => {
+    expect(
+      validateRequiredUpstreamNodes(
+        graph({
+          nodes: [
+            { id: 'in', type: 'TextInput' },
+            { id: 'pe', type: 'PlaceExtract' },
+            { id: 'geo', type: 'GeocodeAgent' },
+            { id: 'out', type: 'DBOutput' },
+          ],
+          edges: [
+            { source: 'in', target: 'pe' },
+            { source: 'in', target: 'geo' },
+            { source: 'pe', target: 'out' },
+            { source: 'geo', target: 'out' },
+          ],
+        }),
+      ),
+    ).toMatchObject({ ok: false, title: 'Geocode needs places' })
   })
 })
 

--- a/apps/agate-ui/src/lib/flowValidation.ts
+++ b/apps/agate-ui/src/lib/flowValidation.ts
@@ -414,6 +414,59 @@ export function validateDocumentChunkerPlacement(graph: FlowGraph): FlowValidati
   return { ok: true }
 }
 
+/** Reject steps that declare requiredUpstreamNodes without a matching ancestor. */
+export function validateRequiredUpstreamNodes(graph: FlowGraph): FlowValidationResult {
+  const byId = new Map(graph.nodes.map((node) => [node.id, node]))
+  const incoming = new Map<string, string[]>()
+  for (const edge of graph.edges) {
+    if (!byId.has(edge.source) || !byId.has(edge.target)) continue
+    const parents = incoming.get(edge.target) ?? []
+    parents.push(edge.source)
+    incoming.set(edge.target, parents)
+  }
+
+  const ancestorTypes = (nodeId: string): Set<string> => {
+    const found = new Set<string>()
+    const queue = [...(incoming.get(nodeId) ?? [])]
+    const seen = new Set<string>()
+    while (queue.length > 0) {
+      const current = queue.shift()
+      if (!current || seen.has(current)) continue
+      seen.add(current)
+      const node = byId.get(current)
+      if (!node?.type) continue
+      found.add(node.type)
+      queue.push(...(incoming.get(current) ?? []))
+    }
+    return found
+  }
+
+  for (const node of graph.nodes) {
+    if (!node.type) continue
+    const meta = nodeMetadata.find((entry) => entry.type === node.type)
+    const required = meta?.requiredUpstreamNodes ?? []
+    if (required.length === 0) continue
+    const ancestors = ancestorTypes(node.id)
+    if (!required.some((type) => ancestors.has(type))) {
+      if (node.type === 'GeocodeAgent') {
+        return {
+          ok: false,
+          title: 'Geocode needs places',
+          description: 'Add Place Extract before Geocode Agent on the same branch.',
+          severity: 'error',
+        }
+      }
+      return {
+        ok: false,
+        title: 'Missing earlier step',
+        description: `${nodeDisplayLabel(node.type)} needs a required earlier step on the same branch.`,
+        severity: 'error',
+      }
+    }
+  }
+  return { ok: true }
+}
+
 /** Run all graph save validations; returns the first failure or success. */
 export function validateGraphForSave(graph: FlowGraph): FlowValidationResult {
   const checks: Array<(g: FlowGraph) => FlowValidationResult> = [
@@ -421,6 +474,7 @@ export function validateGraphForSave(graph: FlowGraph): FlowValidationResult {
     validateNoOrphans,
     validateInputConnections,
     validateDocumentChunkerPlacement,
+    validateRequiredUpstreamNodes,
     validateCustomExtractRecordTypes,
     (g) => validateJsonInputNodes(g.nodes),
     (g) => validateS3InputBuckets(g.nodes),

--- a/apps/agate-ui/src/lib/flowValidation.ts
+++ b/apps/agate-ui/src/lib/flowValidation.ts
@@ -1,7 +1,8 @@
 import {
   isJsonInputInvalidNodeData,
+  isJsonInputMultiDocument,
   isValidJsonInputData,
-  stripJsonInputEditorMarkers,
+  normalizeJsonInputParamsForSave,
 } from '@/lib/jsonInputValidation'
 import { INGRESS_NODE_TYPES, inferIngressPublicAlias } from '@/lib/ingressApiRuns'
 import { resolvedStylebookId } from '@/lib/nodePanelAiModel'
@@ -100,18 +101,20 @@ export function validateJsonInputNodes(nodes: FlowGraphNode[]): FlowValidationRe
     if (isJsonInputInvalidNodeData(node.data)) {
       return {
         ok: false,
-        title: 'Invalid JSON input',
+        title: 'Invalid content',
         description:
-          'Fix the JSON in your content source step before saving. It must be valid JSON with a string "text" field.',
+          'Fix the content in your JSON source step before saving. Each item needs valid structure with a text field.',
         severity: 'error',
       }
     }
     if (!isValidJsonInputData(node.data)) {
+      const multiHint = isJsonInputMultiDocument(node.data as Record<string, unknown>)
       return {
         ok: false,
-        title: 'Invalid JSON input',
-        description:
-          'Your content source JSON must be an object with a string "text" field.',
+        title: 'Invalid content',
+        description: multiHint
+          ? 'Each uploaded file must be an object with a text field. You can include up to 20 files.'
+          : 'Your content must be an object with a text field.',
         severity: 'error',
       }
     }
@@ -125,7 +128,7 @@ export function paramsForGraphSave(
 ): Record<string, unknown> {
   let raw = { ...(node.data ?? {}) }
   if (node.type === 'JSONInput') {
-    raw = stripJsonInputEditorMarkers(raw)
+    raw = normalizeJsonInputParamsForSave(raw)
   }
   if (node.type === 'GeocodeAgent') {
     delete raw.stylebookId

--- a/apps/agate-ui/src/lib/jsonInputValidation.test.ts
+++ b/apps/agate-ui/src/lib/jsonInputValidation.test.ts
@@ -4,7 +4,10 @@ import {
   isValidJsonInputData,
   jsonInputInvalidNodeData,
   markJsonInputNodeDataInvalid,
+  mergeJsonInputUploads,
+  normalizeJsonInputParamsForSave,
   parseJsonInputEditorText,
+  parseJsonInputFileText,
 } from './jsonInputValidation'
 
 describe('jsonInputValidation', () => {
@@ -36,5 +39,71 @@ describe('jsonInputValidation', () => {
       headline: 'Hi',
       __jsonInputInvalid: true,
     })
+  })
+
+  it('accepts multi-document node data', () => {
+    expect(
+      isValidJsonInputData({
+        documents: [
+          { text: 'a', source_file: 'a.json' },
+          { text: 'b', source_file: 'b.json' },
+        ],
+      }),
+    ).toBe(true)
+  })
+
+  it('rejects documents lists outside 2–20', () => {
+    expect(isValidJsonInputData({ documents: [{ text: 'only' }] })).toBe(false)
+    const tooMany = {
+      documents: Array.from({ length: 21 }, (_, i) => ({
+        text: `t${i}`,
+        source_file: `${i}.json`,
+      })),
+    }
+    expect(isValidJsonInputData(tooMany)).toBe(false)
+  })
+
+  it('collapses length-1 documents on save normalize', () => {
+    expect(
+      normalizeJsonInputParamsForSave({
+        public_alias: 'in',
+        documents: [{ text: 'solo', source_file: 'a.json', headline: 'H' }],
+      }),
+    ).toEqual({ public_alias: 'in', text: 'solo', headline: 'H' })
+  })
+
+  it('parses uploaded file text with plain-language errors', () => {
+    expect(parseJsonInputFileText('{"text":"hi"}', 'story.json')).toEqual({
+      ok: true,
+      document: { text: 'hi', source_file: 'story.json' },
+    })
+    expect(parseJsonInputFileText('[1]', 'bad.json').ok).toBe(false)
+  })
+
+  it('merges uploads: one file replaces flat; multiple files promote existing content', () => {
+    const first = mergeJsonInputUploads({ text: '' }, [
+      { text: 'one', source_file: 'a.json' },
+    ])
+    expect(first.ok).toBe(true)
+    if (first.ok) {
+      expect(first.data).toEqual({ text: 'one' })
+    }
+
+    const replace = mergeJsonInputUploads({ text: 'kept', headline: 'H' }, [
+      { text: 'two', source_file: 'b.json' },
+    ])
+    expect(replace.ok).toBe(true)
+    if (replace.ok) {
+      expect(replace.data).toEqual({ text: 'two' })
+    }
+
+    const multi = mergeJsonInputUploads({ text: 'kept', headline: 'H' }, [
+      { text: 'two', source_file: 'b.json' },
+      { text: 'three', source_file: 'c.json' },
+    ])
+    expect(multi.ok).toBe(true)
+    if (multi.ok) {
+      expect(multi.data.documents).toHaveLength(3)
+    }
   })
 })

--- a/apps/agate-ui/src/lib/jsonInputValidation.test.ts
+++ b/apps/agate-ui/src/lib/jsonInputValidation.test.ts
@@ -80,13 +80,13 @@ describe('jsonInputValidation', () => {
     expect(parseJsonInputFileText('[1]', 'bad.json').ok).toBe(false)
   })
 
-  it('merges uploads: one file replaces flat; multiple files promote existing content', () => {
-    const first = mergeJsonInputUploads({ text: '' }, [
+  it('merges uploads: flat node uses uploads only; multi node appends', () => {
+    const single = mergeJsonInputUploads({ text: '' }, [
       { text: 'one', source_file: 'a.json' },
     ])
-    expect(first.ok).toBe(true)
-    if (first.ok) {
-      expect(first.data).toEqual({ text: 'one' })
+    expect(single.ok).toBe(true)
+    if (single.ok) {
+      expect(single.data).toEqual({ text: 'one' })
     }
 
     const replace = mergeJsonInputUploads({ text: 'kept', headline: 'H' }, [
@@ -97,13 +97,31 @@ describe('jsonInputValidation', () => {
       expect(replace.data).toEqual({ text: 'two' })
     }
 
-    const multi = mergeJsonInputUploads({ text: 'kept', headline: 'H' }, [
+    const batch = mergeJsonInputUploads({ text: 'kept', headline: 'H' }, [
       { text: 'two', source_file: 'b.json' },
       { text: 'three', source_file: 'c.json' },
     ])
-    expect(multi.ok).toBe(true)
-    if (multi.ok) {
-      expect(multi.data.documents).toHaveLength(3)
+    expect(batch.ok).toBe(true)
+    if (batch.ok) {
+      expect(batch.data.documents).toHaveLength(2)
+      expect(batch.data.documents).toEqual([
+        { text: 'two', source_file: 'b.json' },
+        { text: 'three', source_file: 'c.json' },
+      ])
+    }
+
+    const append = mergeJsonInputUploads(
+      {
+        documents: [
+          { text: 'a', source_file: 'a.json' },
+          { text: 'b', source_file: 'b.json' },
+        ],
+      },
+      [{ text: 'c', source_file: 'c.json' }],
+    )
+    expect(append.ok).toBe(true)
+    if (append.ok) {
+      expect(append.data.documents).toHaveLength(3)
     }
   })
 })

--- a/apps/agate-ui/src/lib/jsonInputValidation.ts
+++ b/apps/agate-ui/src/lib/jsonInputValidation.ts
@@ -255,15 +255,9 @@ export function parseJsonInputFileText(
   }
 }
 
-function flatHasUserContent(data: Record<string, unknown>): boolean {
-  const fields = articleFieldsFromNodeData(data)
-  if (typeof fields.text === 'string' && fields.text.trim()) return true
-  return Object.keys(fields).some((key) => key !== 'text')
-}
-
 /**
  * Merge newly parsed uploads into node data.
- * One file on a flat node replaces content; additional files promote to ``documents``.
+ * Uploads on a flat node replace editor content; uploads append when already multi-file.
  */
 export function mergeJsonInputUploads(
   current: Record<string, unknown> | undefined,
@@ -274,26 +268,11 @@ export function mergeJsonInputUploads(
   }
 
   const existing = current ?? {}
-  if (!isJsonInputMultiDocument(existing) && uploads.length === 1) {
+  if (!isJsonInputMultiDocument(existing)) {
     return { ok: true, data: buildJsonInputNodeData(uploads, existing) }
   }
 
-  let baseDocs: JsonInputDocument[]
-  if (isJsonInputMultiDocument(existing)) {
-    baseDocs = getJsonInputDocumentList(existing)
-  } else if (flatHasUserContent(existing)) {
-    baseDocs = [
-      {
-        ...articleFieldsFromNodeData(existing),
-        text:
-          typeof existing.text === 'string' ? existing.text : '',
-        [JSON_INPUT_SOURCE_FILE_KEY]: 'Current content.json',
-      },
-    ]
-  } else {
-    baseDocs = []
-  }
-
+  const baseDocs = getJsonInputDocumentList(existing)
   const merged = [...baseDocs, ...uploads]
   if (merged.length > JSON_INPUT_MAX_DOCUMENTS) {
     return {

--- a/apps/agate-ui/src/lib/jsonInputValidation.ts
+++ b/apps/agate-ui/src/lib/jsonInputValidation.ts
@@ -1,6 +1,23 @@
 /** Set on node data while the JSON editor content fails validation (not persisted on save). */
 export const JSON_INPUT_INVALID_MARKER = '__jsonInputInvalid'
 
+export const JSON_INPUT_DOCUMENTS_KEY = 'documents'
+export const JSON_INPUT_SOURCE_FILE_KEY = 'source_file'
+export const JSON_INPUT_MAX_DOCUMENTS = 20
+export const JSON_INPUT_PUBLIC_ALIAS_KEY = 'public_alias'
+
+const NODE_LEVEL_KEYS = new Set([
+  JSON_INPUT_INVALID_MARKER,
+  JSON_INPUT_DOCUMENTS_KEY,
+  JSON_INPUT_PUBLIC_ALIAS_KEY,
+  'onChange',
+])
+
+export type JsonInputDocument = Record<string, unknown> & {
+  text: string
+  source_file?: string
+}
+
 export function jsonInputInvalidNodeData(
   existing?: Record<string, unknown>,
 ): Record<string, unknown> {
@@ -30,20 +47,40 @@ export function stripJsonInputEditorMarkers(
   return out
 }
 
-/** Valid JSON Input node data: a JSON object with a string `text` field (may be empty). */
+function isDocumentObject(value: unknown): value is JsonInputDocument {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false
+  }
+  const rec = value as Record<string, unknown>
+  if (!('text' in rec)) return false
+  return typeof rec.text === 'string'
+}
+
+/** Valid JSON Input node data: flat object or multi-file ``documents`` (2–20). */
 export function isValidJsonInputData(
   data: unknown,
-): data is Record<string, unknown> & { text: string } {
+): data is Record<string, unknown> & { text?: string; documents?: JsonInputDocument[] } {
   if (isJsonInputInvalidNodeData(data)) {
     return false
   }
   if (typeof data !== 'object' || data === null || Array.isArray(data)) {
     return false
   }
-  if (!('text' in data)) {
+  const rec = data as Record<string, unknown>
+  const docs = rec[JSON_INPUT_DOCUMENTS_KEY]
+  if (docs !== undefined) {
+    if (!Array.isArray(docs)) return false
+    if (docs.length < 2 || docs.length > JSON_INPUT_MAX_DOCUMENTS) return false
+    return docs.every((entry) => {
+      if (!isDocumentObject(entry)) return false
+      const name = entry[JSON_INPUT_SOURCE_FILE_KEY]
+      return name === undefined || typeof name === 'string'
+    })
+  }
+  if (!('text' in rec)) {
     return false
   }
-  return typeof (data as Record<string, unknown>).text === 'string'
+  return typeof rec.text === 'string'
 }
 
 export type JsonInputParseResult =
@@ -72,4 +109,197 @@ export function parseJsonInputEditorText(value: string): JsonInputParseResult {
   }
 
   return { ok: true, data: rec as Record<string, unknown> & { text: string } }
+}
+
+export function articleFieldsFromNodeData(
+  data: Record<string, unknown>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(data)) {
+    if (NODE_LEVEL_KEYS.has(key)) continue
+    out[key] = value
+  }
+  return out
+}
+
+export function getJsonInputDocumentList(
+  data: Record<string, unknown> | undefined,
+): JsonInputDocument[] {
+  if (!data) return [{ text: '' }]
+  const docs = data[JSON_INPUT_DOCUMENTS_KEY]
+  if (Array.isArray(docs) && docs.length >= 2) {
+    return docs.filter(isDocumentObject).map((entry) => {
+      const source =
+        typeof entry[JSON_INPUT_SOURCE_FILE_KEY] === 'string' &&
+        entry[JSON_INPUT_SOURCE_FILE_KEY].trim()
+          ? String(entry[JSON_INPUT_SOURCE_FILE_KEY]).trim()
+          : 'document.json'
+      return { ...entry, [JSON_INPUT_SOURCE_FILE_KEY]: source, text: entry.text }
+    })
+  }
+  const flat = articleFieldsFromNodeData(data)
+  const text = typeof flat.text === 'string' ? flat.text : ''
+  return [{ ...flat, text }]
+}
+
+export function isJsonInputMultiDocument(
+  data: Record<string, unknown> | undefined,
+): boolean {
+  const docs = data?.[JSON_INPUT_DOCUMENTS_KEY]
+  return Array.isArray(docs) && docs.length >= 2
+}
+
+function preserveNodeLevelFields(
+  data: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+  if (!data) return out
+  if (typeof data[JSON_INPUT_PUBLIC_ALIAS_KEY] === 'string') {
+    out[JSON_INPUT_PUBLIC_ALIAS_KEY] = data[JSON_INPUT_PUBLIC_ALIAS_KEY]
+  }
+  return out
+}
+
+/** Build node data from one or more documents; collapses length ≤1 to flat params. */
+export function buildJsonInputNodeData(
+  documents: JsonInputDocument[],
+  previous?: Record<string, unknown>,
+): Record<string, unknown> {
+  const preserved = preserveNodeLevelFields(previous)
+  if (documents.length === 0) {
+    return { ...preserved, text: '' }
+  }
+  if (documents.length === 1) {
+    const only = documents[0]
+    const fields: Record<string, unknown> = { ...only }
+    delete fields[JSON_INPUT_SOURCE_FILE_KEY]
+    delete fields[JSON_INPUT_DOCUMENTS_KEY]
+    return { ...preserved, ...fields, text: typeof only.text === 'string' ? only.text : '' }
+  }
+  const capped = documents.slice(0, JSON_INPUT_MAX_DOCUMENTS).map((doc, index) => {
+    const source =
+      typeof doc[JSON_INPUT_SOURCE_FILE_KEY] === 'string' &&
+      String(doc[JSON_INPUT_SOURCE_FILE_KEY]).trim()
+        ? String(doc[JSON_INPUT_SOURCE_FILE_KEY]).trim()
+        : `document-${index + 1}.json`
+    const fields: Record<string, unknown> = { ...doc, [JSON_INPUT_SOURCE_FILE_KEY]: source }
+    delete fields[JSON_INPUT_DOCUMENTS_KEY]
+    return fields
+  })
+  return { ...preserved, [JSON_INPUT_DOCUMENTS_KEY]: capped }
+}
+
+/** Normalize saved params: collapse length-1 documents; drop invalid marker. */
+export function normalizeJsonInputParamsForSave(
+  params: Record<string, unknown>,
+): Record<string, unknown> {
+  const stripped = stripJsonInputEditorMarkers(params)
+  const docs = stripped[JSON_INPUT_DOCUMENTS_KEY]
+  if (!Array.isArray(docs)) {
+    return stripped
+  }
+  if (docs.length <= 1) {
+    return buildJsonInputNodeData(
+      docs.filter(isDocumentObject).map((d) => ({ ...d, text: d.text })),
+      stripped,
+    )
+  }
+  if (docs.length > JSON_INPUT_MAX_DOCUMENTS) {
+    return buildJsonInputNodeData(
+      docs
+        .filter(isDocumentObject)
+        .slice(0, JSON_INPUT_MAX_DOCUMENTS)
+        .map((d) => ({ ...d, text: d.text })),
+      stripped,
+    )
+  }
+  return stripped
+}
+
+export type JsonFileParseResult =
+  | { ok: true; document: JsonInputDocument }
+  | { ok: false; error: string }
+
+/** Parse an uploaded file body into a JSON Input document (plain-language errors). */
+export function parseJsonInputFileText(
+  raw: string,
+  fileName: string,
+): JsonFileParseResult {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw) as unknown
+  } catch {
+    return { ok: false, error: `“${fileName}” is not valid JSON.` }
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return {
+      ok: false,
+      error: `“${fileName}” must contain a single JSON object.`,
+    }
+  }
+  const rec = parsed as Record<string, unknown>
+  if (!('text' in rec) || typeof rec.text !== 'string') {
+    return {
+      ok: false,
+      error: `“${fileName}” needs a text field (a string, which may be empty).`,
+    }
+  }
+  const baseName = fileName.trim() || 'document.json'
+  return {
+    ok: true,
+    document: {
+      ...rec,
+      text: rec.text,
+      [JSON_INPUT_SOURCE_FILE_KEY]: baseName,
+    },
+  }
+}
+
+function flatHasUserContent(data: Record<string, unknown>): boolean {
+  const fields = articleFieldsFromNodeData(data)
+  if (typeof fields.text === 'string' && fields.text.trim()) return true
+  return Object.keys(fields).some((key) => key !== 'text')
+}
+
+/**
+ * Merge newly parsed uploads into node data.
+ * One file on a flat node replaces content; additional files promote to ``documents``.
+ */
+export function mergeJsonInputUploads(
+  current: Record<string, unknown> | undefined,
+  uploads: JsonInputDocument[],
+): { ok: true; data: Record<string, unknown> } | { ok: false; error: string } {
+  if (uploads.length === 0) {
+    return { ok: false, error: 'Choose at least one JSON file.' }
+  }
+
+  const existing = current ?? {}
+  if (!isJsonInputMultiDocument(existing) && uploads.length === 1) {
+    return { ok: true, data: buildJsonInputNodeData(uploads, existing) }
+  }
+
+  let baseDocs: JsonInputDocument[]
+  if (isJsonInputMultiDocument(existing)) {
+    baseDocs = getJsonInputDocumentList(existing)
+  } else if (flatHasUserContent(existing)) {
+    baseDocs = [
+      {
+        ...articleFieldsFromNodeData(existing),
+        text:
+          typeof existing.text === 'string' ? existing.text : '',
+        [JSON_INPUT_SOURCE_FILE_KEY]: 'Current content.json',
+      },
+    ]
+  } else {
+    baseDocs = []
+  }
+
+  const merged = [...baseDocs, ...uploads]
+  if (merged.length > JSON_INPUT_MAX_DOCUMENTS) {
+    return {
+      ok: false,
+      error: `You can add up to ${JSON_INPUT_MAX_DOCUMENTS} files at a time.`,
+    }
+  }
+  return { ok: true, data: buildJsonInputNodeData(merged, existing) }
 }

--- a/apps/agate-ui/src/nodes/json_input/JsonFileDropZone.tsx
+++ b/apps/agate-ui/src/nodes/json_input/JsonFileDropZone.tsx
@@ -1,0 +1,98 @@
+import { useCallback, useRef, useState, type DragEvent, type ReactNode } from 'react'
+
+import { cn } from '@/lib/utils'
+
+interface JsonFileDropZoneProps {
+  disabled?: boolean
+  onFiles: (files: File[]) => void | Promise<void>
+  children?: ReactNode
+}
+
+function isJsonFileName(name: string): boolean {
+  return name.toLowerCase().endsWith('.json')
+}
+
+export default function JsonFileDropZone({
+  disabled,
+  onFiles,
+  children,
+}: JsonFileDropZoneProps) {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [dragOver, setDragOver] = useState(false)
+
+  const takeFiles = useCallback(
+    async (list: FileList | File[] | null) => {
+      if (!list || disabled) return
+      const files = Array.from(list).filter((file) => isJsonFileName(file.name))
+      if (files.length === 0) return
+      await onFiles(files)
+    },
+    [disabled, onFiles],
+  )
+
+  const onDragEnter = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault()
+    event.stopPropagation()
+    if (!disabled) setDragOver(true)
+  }
+
+  const onDragOver = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault()
+    event.stopPropagation()
+    if (!disabled) setDragOver(true)
+  }
+
+  const onDragLeave = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault()
+    event.stopPropagation()
+    setDragOver(false)
+  }
+
+  const onDrop = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault()
+    event.stopPropagation()
+    setDragOver(false)
+    void takeFiles(event.dataTransfer.files)
+  }
+
+  return (
+    <div
+      className={cn(
+        'rounded-md border border-dashed border-muted-foreground/40 bg-muted/20 p-3 transition-colors',
+        dragOver && !disabled && 'border-primary bg-primary/5',
+        disabled && 'opacity-60',
+      )}
+      onDragEnter={onDragEnter}
+      onDragOver={onDragOver}
+      onDragLeave={onDragLeave}
+      onDrop={onDrop}
+    >
+      <input
+        ref={inputRef}
+        type="file"
+        accept=".json,application/json"
+        multiple
+        className="sr-only"
+        disabled={disabled}
+        onChange={(event) => {
+          void takeFiles(event.target.files)
+          event.target.value = ''
+        }}
+      />
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <p className="text-sm text-muted-foreground">
+          Drop JSON files here, or choose files to add. Up to 20 files.
+        </p>
+        <button
+          type="button"
+          className="inline-flex h-9 shrink-0 items-center justify-center rounded-md border border-input bg-background px-3 text-sm font-medium hover:bg-accent hover:text-accent-foreground disabled:pointer-events-none disabled:opacity-50"
+          disabled={disabled}
+          onClick={() => inputRef.current?.click()}
+        >
+          Choose files
+        </button>
+      </div>
+      {children}
+    </div>
+  )
+}

--- a/apps/agate-ui/src/nodes/json_input/PanelComponent.tsx
+++ b/apps/agate-ui/src/nodes/json_input/PanelComponent.tsx
@@ -26,11 +26,19 @@ import type { GraphPanelContext } from '@/components/NodePanel'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
 import {
-  JSON_INPUT_INVALID_MARKER,
+  JSON_INPUT_MAX_DOCUMENTS,
+  JSON_INPUT_SOURCE_FILE_KEY,
+  buildJsonInputNodeData,
+  getJsonInputDocumentList,
+  isJsonInputMultiDocument,
   markJsonInputNodeDataInvalid,
+  mergeJsonInputUploads,
   parseJsonInputEditorText,
+  parseJsonInputFileText,
+  type JsonInputDocument,
 } from '@/lib/jsonInputValidation'
 import { getNodeOutputById, type NodeOutputLookupSpec } from '@/lib/nodeOutputs'
+import JsonFileDropZone from './JsonFileDropZone'
 import { JSON_INPUT_SCHEMA_EXAMPLE } from './schemaExample'
 
 interface JSONInputPanelProps {
@@ -40,6 +48,12 @@ interface JSONInputPanelProps {
   setNodes?: (nodes: any) => void
   graphContext?: GraphPanelContext
   nodeOutputLookupSpec?: NodeOutputLookupSpec | null
+}
+
+function editorTextForDocument(doc: JsonInputDocument): string {
+  const fields = { ...doc }
+  delete fields[JSON_INPUT_SOURCE_FILE_KEY]
+  return JSON.stringify(fields, null, 2)
 }
 
 export default function JSONInputPanel({
@@ -52,18 +66,32 @@ export default function JSONInputPanel({
 }: JSONInputPanelProps) {
   const [jsonText, setJsonText] = useState('')
   const [jsonError, setJsonError] = useState('')
+  const [uploadError, setUploadError] = useState('')
+  const [selectedIndex, setSelectedIndex] = useState(0)
+
+  const nodeData = (node.data || {}) as Record<string, unknown>
+  const documents = getJsonInputDocumentList(nodeData)
+  const multi = isJsonInputMultiDocument(nodeData)
+  const safeIndex = Math.min(selectedIndex, Math.max(0, documents.length - 1))
 
   useEffect(() => {
+    setSelectedIndex(0)
     try {
-      const base = { ...(node.data || {}), text: (node.data?.text as string) ?? '' }
-      delete (base as { onChange?: unknown }).onChange
-      delete base[JSON_INPUT_INVALID_MARKER]
-      setJsonText(JSON.stringify(base, null, 2))
+      const docs = getJsonInputDocumentList((node.data || {}) as Record<string, unknown>)
+      setJsonText(editorTextForDocument(docs[0] ?? { text: '' }))
       setJsonError('')
+      setUploadError('')
     } catch {
       setJsonText('{\n  "text": ""\n}')
     }
   }, [node.id])
+
+  const patchNodeData = (next: Record<string, unknown>) => {
+    if (!setNodes) return
+    setNodes((nds: any[]) =>
+      nds.map((n: any) => (n.id === node.id ? { ...n, data: next } : n)),
+    )
+  }
 
   const handleJsonChange = (value: string) => {
     setJsonText(value)
@@ -84,12 +112,64 @@ export default function JSONInputPanel({
     }
 
     setJsonError('')
-
-    if (setNodes) {
-      setNodes((nds: any[]) =>
-        nds.map((n: any) => (n.id === node.id ? { ...n, data: result.data } : n)),
-      )
+    const currentDocs = getJsonInputDocumentList(nodeData)
+    const index = Math.min(selectedIndex, Math.max(0, currentDocs.length - 1))
+    const previous = currentDocs[index]
+    const sourceName =
+      typeof previous?.[JSON_INPUT_SOURCE_FILE_KEY] === 'string'
+        ? String(previous[JSON_INPUT_SOURCE_FILE_KEY])
+        : undefined
+    const updated: JsonInputDocument = {
+      ...result.data,
+      text: result.data.text,
+      ...(sourceName ? { [JSON_INPUT_SOURCE_FILE_KEY]: sourceName } : {}),
     }
+    const nextDocs = currentDocs.map((doc, i) => (i === index ? updated : doc))
+    patchNodeData(buildJsonInputNodeData(nextDocs, nodeData))
+  }
+
+  const handleFiles = async (files: File[]) => {
+    setUploadError('')
+    const uploads: JsonInputDocument[] = []
+    for (const file of files) {
+      const raw = await file.text()
+      const parsed = parseJsonInputFileText(raw, file.name)
+      if (!parsed.ok) {
+        setUploadError(parsed.error)
+        return
+      }
+      uploads.push(parsed.document)
+    }
+    const merged = mergeJsonInputUploads(nodeData, uploads)
+    if (!merged.ok) {
+      setUploadError(merged.error)
+      return
+    }
+    const nextDocs = getJsonInputDocumentList(merged.data)
+    const nextIndex = Math.max(0, nextDocs.length - uploads.length)
+    setSelectedIndex(nextIndex)
+    setJsonText(editorTextForDocument(nextDocs[nextIndex] ?? { text: '' }))
+    setJsonError('')
+    patchNodeData(merged.data)
+  }
+
+  const removeDocumentAt = (index: number) => {
+    const nextDocs = documents.filter((_, i) => i !== index)
+    const nextData = buildJsonInputNodeData(nextDocs, nodeData)
+    let nextIndex = selectedIndex
+    if (nextDocs.length === 0) nextIndex = 0
+    else if (selectedIndex > index) nextIndex = selectedIndex - 1
+    else if (selectedIndex >= nextDocs.length) nextIndex = nextDocs.length - 1
+    setSelectedIndex(nextIndex)
+    setJsonText(editorTextForDocument(nextDocs[nextIndex] ?? { text: '' }))
+    setJsonError('')
+    patchNodeData(nextData)
+  }
+
+  const selectDocument = (index: number) => {
+    setSelectedIndex(index)
+    setJsonText(editorTextForDocument(documents[index] ?? { text: '' }))
+    setJsonError('')
   }
 
   const isDisabled = !(editMode && setNodes)
@@ -104,17 +184,64 @@ export default function JSONInputPanel({
   return (
     <>
       <NodePanelTabGate tab="settings">
-        <div className="space-y-2">
-          <Label htmlFor="node-json">JSON data (must include &quot;text&quot;)</Label>
-          <Textarea
-            id="node-json"
-            value={jsonText}
-            onChange={(e) => handleJsonChange(e.target.value)}
-            placeholder={`{\n  "text": "Your text here...",\n  "headline": "Optional headline"\n}`}
-            className="min-h-[300px] mt-1 font-mono text-xs"
-            disabled={isDisabled}
-          />
-          {jsonError && <p className="text-xs text-red-500 mt-1">{jsonError}</p>}
+        <div className="space-y-3">
+          <JsonFileDropZone disabled={isDisabled} onFiles={handleFiles} />
+          {uploadError ? <p className="text-xs text-red-500">{uploadError}</p> : null}
+
+          {multi ? (
+            <div className="space-y-1">
+              <Label>
+                Files ({documents.length} of {JSON_INPUT_MAX_DOCUMENTS})
+              </Label>
+              <ul className="max-h-40 space-y-1 overflow-y-auto rounded-md border p-1">
+                {documents.map((doc, index) => {
+                  const name =
+                    typeof doc[JSON_INPUT_SOURCE_FILE_KEY] === 'string'
+                      ? String(doc[JSON_INPUT_SOURCE_FILE_KEY])
+                      : `File ${index + 1}`
+                  const selected = index === safeIndex
+                  return (
+                    <li key={`${name}-${index}`} className="flex items-center gap-1">
+                      <button
+                        type="button"
+                        className={
+                          selected
+                            ? 'flex-1 truncate rounded px-2 py-1 text-left text-xs bg-accent'
+                            : 'flex-1 truncate rounded px-2 py-1 text-left text-xs hover:bg-muted'
+                        }
+                        disabled={isDisabled}
+                        onClick={() => selectDocument(index)}
+                      >
+                        {name}
+                      </button>
+                      <button
+                        type="button"
+                        className="shrink-0 rounded px-2 py-1 text-xs text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-50"
+                        disabled={isDisabled}
+                        onClick={() => removeDocumentAt(index)}
+                        aria-label={`Remove ${name}`}
+                      >
+                        Remove
+                      </button>
+                    </li>
+                  )
+                })}
+              </ul>
+            </div>
+          ) : null}
+
+          <div className="space-y-2">
+            <Label htmlFor="node-json">{multi ? 'Selected file content' : 'Content'}</Label>
+            <Textarea
+              id="node-json"
+              value={jsonText}
+              onChange={(e) => handleJsonChange(e.target.value)}
+              placeholder={`{\n  "text": "Your text here...",\n  "headline": "Optional headline"\n}`}
+              className="min-h-[300px] mt-1 font-mono text-xs"
+              disabled={isDisabled}
+            />
+            {jsonError && <p className="text-xs text-red-500 mt-1">{jsonError}</p>}
+          </div>
         </div>
 
         <IngressApiRunsSection
@@ -129,10 +256,10 @@ export default function JSONInputPanel({
       <NodePanelTabGate tab="info">
         <div className="space-y-2">
           <p className="text-sm text-muted-foreground leading-relaxed">
-            Use a single JSON object. Include a <span className="font-mono">text</span> field (it may
-            be empty); other top-level fields are optional and can be referenced in prompts (for
-            example{' '}
-            <span className="font-mono">{'{headline}'}</span>).
+            Paste content or upload one or more JSON files (up to {JSON_INPUT_MAX_DOCUMENTS}).
+            Each file becomes its own item when you run the flow. Include a text field in each
+            object (it may be empty); other fields are optional and can be referenced in prompts
+            (for example {'{headline}'}).
           </p>
           <Label htmlFor="node-json-schema">Example shape</Label>
           <Textarea

--- a/apps/worker/src/worker/celery_logging.py
+++ b/apps/worker/src/worker/celery_logging.py
@@ -19,6 +19,7 @@ _RUN_ID_TASKS = frozenset(
     {
         "worker.tasks.execute_agate_run",
         "worker.tasks.execute_s3_batch_setup",
+        "worker.tasks.execute_json_input_batch_setup",
         "worker.tasks.execute_run_replay_setup",
         "worker.tasks.finalize_s3_parent_run",
     }

--- a/apps/worker/src/worker/substrate/orchestration.py
+++ b/apps/worker/src/worker/substrate/orchestration.py
@@ -6,6 +6,7 @@ import logging
 from dataclasses import dataclass
 from typing import Any
 
+from agate_runtime.nodes.json_input import resolve_document_body_text
 from backfield_entities.ingest.db_output_settings import (
     DbOutputCanonicalSettings,
     ReconciliationPolicy,
@@ -92,12 +93,18 @@ def _has_custom_records(consolidated: dict[str, Any]) -> bool:
     return isinstance(block, dict) and bool(block)
 
 
+def _has_article_body(consolidated: dict[str, Any]) -> bool:
+    """True when consolidated has a non-empty resolvable article body (JSON Input aliases)."""
+    return bool(resolve_document_body_text(consolidated))
+
+
 def _has_persistable_consolidated_content(consolidated: dict[str, Any]) -> bool:
     return (
         bool(_active_handler_keys(consolidated))
         or _has_article_embedding(consolidated)
         or _has_article_metadata(consolidated)
         or _has_custom_records(consolidated)
+        or _has_article_body(consolidated)
     )
 
 
@@ -134,9 +141,10 @@ def persist_from_consolidated(
     active_keys = _active_handler_keys(consolidated)
     if not _has_persistable_consolidated_content(consolidated):
         raise RuntimeError(
-            "DBOutput persistence requires consolidated['places'], consolidated['people'], "
-            "consolidated['organizations'], consolidated['article_embedding'], "
-            "consolidated['article_metadata'], and/or consolidated['custom_records']"
+            "DBOutput persistence requires a non-empty article body, and/or "
+            "consolidated['places'], consolidated['people'], consolidated['organizations'], "
+            "consolidated['article_embedding'], consolidated['article_metadata'], "
+            "and/or consolidated['custom_records']"
         )
 
     upsert = _upsert_article(

--- a/apps/worker/src/worker/tasks.py
+++ b/apps/worker/src/worker/tasks.py
@@ -20,6 +20,7 @@ from agate_nodes.s3_output.node import (
     upload_s3_output_body,
 )
 from agate_runtime import GraphSpec, execute_graph
+from agate_runtime.json_input_batch import json_input_batch_documents_from_spec
 from agate_runtime.nodes import NODE_RUNNERS
 from agate_runtime.nodes.json_input import json_input_output_from_dict
 from agate_runtime.run_graph_spec import (
@@ -858,6 +859,161 @@ def execute_agate_run(run_id: str, spec_json: str | None = None) -> None:
             correlation={"run_id": run_id},
         )
         _kick_webhook_dispatch(session)
+
+
+@celery_app.task(name="worker.tasks.execute_json_input_batch_setup")
+def execute_json_input_batch_setup(run_id: str) -> None:
+    """Create processed items from multi-file JSONInput ``documents`` and chord execution."""
+    engine = get_engine()
+    with Session(engine) as session:
+        run = session.get(AgateRun, run_id)
+        if not run:
+            return
+        graph = session.get(AgateGraph, run.graph_id)
+        if not graph:
+            previous_status = run.status
+            run.status = "failed"
+            run.error_message = "Graph not found"
+            run.updated_at = datetime.now(UTC)
+            session.add(run)
+            record_run_terminal_event(session, run)
+            session.commit()
+            emit_run_terminal(
+                previous_status=previous_status,
+                new_status="failed",
+                identity=worker_identity(),
+                correlation={"run_id": run_id},
+            )
+            _kick_webhook_dispatch(session)
+            return
+
+        claimed_at = datetime.now(UTC)
+        claim_result = session.execute(
+            update(AgateRun)
+            .where(
+                AgateRun.id == run_id,
+                AgateRun.status == "pending",
+            )
+            .values(status="running", updated_at=claimed_at)
+        )
+        session.commit()
+        if int(claim_result.rowcount or 0) != 1:
+            return
+
+        run = session.get(AgateRun, run_id)
+        if not run or run.status != "running":
+            return
+
+        try:
+            spec_json = resolve_run_graph_spec_json(
+                run_result_json=run.result_json,
+                graph_spec_json=graph.spec_json,
+            )
+            spec = GraphSpec.model_validate_json(spec_json)
+            documents = json_input_batch_documents_from_spec(spec)
+
+            pending: list[tuple[int, int]] = []
+            for source_file, doc in documents:
+                row = AgateProcessedItem(
+                    run_id=run_id,
+                    source_file=source_file,
+                    input_json=json.dumps(doc),
+                    status="pending",
+                )
+                session.add(row)
+                session.flush()
+                if row.id is None:
+                    raise RuntimeError("Processed item id missing after save")
+                text_len = len(str(doc.get("text") or ""))
+                pending.append((int(row.id), text_len))
+
+            batch_meta = {
+                "total_documents": len(documents),
+                "valid_executed": len(pending),
+            }
+            run = session.exec(
+                select(AgateRun)
+                .where(AgateRun.id == run_id)
+                .with_for_update()
+                .execution_options(populate_existing=True)
+            ).first()
+            if run is None or run.status != "running":
+                session.rollback()
+                return
+            run.result_json = merge_run_result_payload(
+                run.result_json,
+                json_input_batch=batch_meta,
+                graph_spec_json=spec_json,
+            )
+            run.updated_at = datetime.now(UTC)
+            session.add(run)
+            session.commit()
+
+            if not pending:
+                run = session.exec(
+                    select(AgateRun)
+                    .where(AgateRun.id == run_id)
+                    .with_for_update()
+                    .execution_options(populate_existing=True)
+                ).first()
+                if run is None or run.status != "running":
+                    session.rollback()
+                    return
+                previous_status = run.status
+                run.status = "failed"
+                run.error_message = (
+                    "No valid JSON documents with a non-empty article body to process."
+                )
+                run.updated_at = datetime.now(UTC)
+                session.add(run)
+                record_run_terminal_event(session, run)
+                session.commit()
+                emit_run_terminal(
+                    previous_status=previous_status,
+                    new_status="failed",
+                    identity=worker_identity(),
+                    correlation={"run_id": run_id},
+                )
+                _kick_webhook_dispatch(session)
+                return
+
+            logger.info(
+                "execute_json_input_batch_setup: queueing chord of %d "
+                "execute_processed_item task(s) for run %s",
+                len(pending),
+                run_id,
+            )
+            pending_sorted = sorted(pending, key=lambda row: row[1], reverse=True)
+            ordered_ids = [item_id for item_id, _ in pending_sorted]
+            header = group(execute_processed_item.s(item_id) for item_id in ordered_ids)
+            _queue = os.environ.get("CELERY_QUEUE", "agate")
+            chord(header, finalize_s3_parent_run.s(run_id)).apply_async(queue=_queue)
+        except Exception as e:
+            logger.exception("JSON Input batch setup failed for run %s", run_id)
+            with Session(engine) as session3:
+                run_fail = session3.exec(
+                    select(AgateRun)
+                    .where(AgateRun.id == run_id)
+                    .with_for_update()
+                    .execution_options(populate_existing=True)
+                ).first()
+                if run_fail is None or run_fail.status != "running":
+                    session3.rollback()
+                    return
+                previous_status = run_fail.status
+                run_fail.status = "failed"
+                run_fail.error_message = str(e)
+                run_fail.updated_at = datetime.now(UTC)
+                session3.add(run_fail)
+                record_run_terminal_event(session3, run_fail)
+                session3.commit()
+                emit_run_terminal(
+                    previous_status=previous_status,
+                    new_status="failed",
+                    identity=worker_identity(),
+                    correlation={"run_id": run_id},
+                )
+                _kick_webhook_dispatch(session3)
 
 
 @celery_app.task(name="worker.tasks.execute_s3_batch_setup")

--- a/docs/architecture/runtime.md
+++ b/docs/architecture/runtime.md
@@ -84,9 +84,12 @@ regenerates chunks from the original `input_json` and pinned graph.
 ## Backfield Output
 
 Backfield Output consolidates article content and supported domains, then persists them through
-worker handlers. Current handlers cover locations, people, and organizations; article metadata,
-custom records, images, and article embeddings use their own persistence paths. Node settings
-control:
+worker handlers. A non-empty article body alone is enough to upsert the article (for example
+Text/JSON Input wired directly to Backfield Output). Current handlers cover locations, people,
+and organizations; article metadata, custom records, images, and article embeddings use their
+own persistence paths. Stylebook matching, automatic connections, and semantic indexing apply
+only when this run produces the relevant domains or mentions; otherwise they are no-ops. Node
+settings control:
 
 - Stylebook matching and optional explicit Stylebook id;
 - rules or AI-assisted canonicalization;

--- a/docs/architecture/runtime.md
+++ b/docs/architecture/runtime.md
@@ -17,8 +17,12 @@ request hash, run link, and enqueue descriptor—never the input body. Unkeyed p
 enqueue best-effort after commit; clients that need durable trigger semantics should send
 `Idempotency-Key`.
 
-TextInput and JSONInput runs create one `agate_processed_item` and enqueue
-`execute_processed_item`. S3Input runs enqueue `execute_s3_batch_setup`, which:
+TextInput runs create one `agate_processed_item` and enqueue `execute_processed_item`.
+JSONInput with a single document (pasted or one uploaded file) does the same. JSONInput with
+two or more uploaded files stores them under node `documents` (capped at 20) and enqueues
+`execute_json_input_batch_setup`, which creates one processed item per file and dispatches a
+Celery chord—the same completion path as S3 (`finalize_s3_parent_run`). S3Input runs enqueue
+`execute_s3_batch_setup`, which:
 
 1. Ensures a stable `source_id` on the S3 Input node (minted and persisted when missing).
 2. Lists JSON objects under the snapshotted bucket and prefix (paginated), including list

--- a/docs/development/nodes.md
+++ b/docs/development/nodes.md
@@ -13,7 +13,7 @@ Use `.cursor/skills/add-agate-node/SKILL.md` for a new pipeline node.
 
 | Profile | Role | Current examples | Typical review |
 |---|---|---|---|
-| Input | Ingress text, JSON, or an S3 batch | `TextInput`, `JSONInput`, `S3Input` | None |
+| Input | Ingress text, JSON (one or many files), or an S3 batch | `TextInput`, `JSONInput`, `S3Input` | None |
 | Output | Return JSON, persist Backfield data, or write S3 | `Output`, `DBOutput`, `S3Output` | JSON; entity review after DBOutput |
 | Extract | Produce grounded structured records | `PlaceExtract`, `PersonExtract`, `OrganizationExtract`, `CustomExtract` | Entity tabs or Custom |
 | Enrich | Transform or resolve upstream values | `GeocodeAgent`, `ArticleMetadata` | Existing entity tab or Meta |
@@ -219,6 +219,11 @@ and step display names.
 Input bookends are `TextInput`, `JSONInput`, and `S3Input`. Output bookends are
 `Output`, `DBOutput`, and `S3Output`; all other enabled metadata nodes are middle
 steps.
+
+JSON Input accepts pasted content or uploaded `.json` files (drag-and-drop or file
+picker). A single document stays on the flat params / single-item run path. Two or
+more files (capped at 20) are stored under `documents` on the node and run as an
+inline batch—one `agate_processed_item` per file—via `execute_json_input_batch_setup`.
 
 S3 Input scans claim object revisions through `agate_s3_ingestion_ledger` so unchanged
 content is skipped across runs. A stable `source_id` is stored on the node params

--- a/docs/development/nodes.md
+++ b/docs/development/nodes.md
@@ -242,6 +242,11 @@ bookend. At most one Chunker is allowed per flow, and every first-hop branch mus
 through it when present (enforced in guided UI, Agate API graph create/update, run
 trigger, and `execute_graph`).
 
+`GeocodeAgent` must have `PlaceExtract` in its transitive branch ancestry (same rule as
+metadata `requiredUpstreamNodes`). Guided save, canvas invalid highlighting, Run, Agate
+API create/update, run trigger, and `execute_graph` all reject Geocode without Place
+Extract on that branch.
+
 Defaults are approximately 4,000-token pieces with 250-token overlap. Splitting prefers
 paragraph boundaries, then sentence boundaries, then a hard cut. Short documents emit
 one chunk with `split_required=false`. Flows reject documents that would exceed 50

--- a/packages/backfield-agate/src/agate_nodes/json_input/node.py
+++ b/packages/backfield-agate/src/agate_nodes/json_input/node.py
@@ -8,13 +8,42 @@ that merged dict.
 Some CMS exports reuse ``text`` for a short section label (e.g. "Music") while the
 article body lives in ``article_text``, ``body``, or ``content``. :func:`resolve_document_body_text`
 picks the longest non-empty string among known body fields so extraction sees real copy.
+
+Multi-file uploads store two or more objects under the reserved ``documents`` key. Each
+entry is one pipeline item (same as S3 Input). A single pasted/uploaded object keeps the
+flat params shape for backward compatibility.
 """
 
 from __future__ import annotations
 
 from typing import Any
 
-_STRIP_PARAM_KEYS = frozenset({"onChange"})
+DOCUMENTS_PARAM = "documents"
+SOURCE_FILE_KEY = "source_file"
+PUBLIC_ALIAS_PARAM = "public_alias"
+JSON_INPUT_MAX_DOCUMENTS = 20
+DEFAULT_INLINE_SOURCE_FILE = "inline:json"
+
+_STRIP_PARAM_KEYS = frozenset({"onChange", DOCUMENTS_PARAM})
+
+# Dropped when unpacking a documents[] entry (node-level / editor keys).
+_DOCUMENT_ENTRY_STRIP_KEYS = frozenset(
+    {
+        "onChange",
+        DOCUMENTS_PARAM,
+        PUBLIC_ALIAS_PARAM,
+        "__jsonInputInvalid",
+    }
+)
+
+# Dropped from flat single-document params before execution (keep public_alias passthrough).
+_FLAT_PARAM_STRIP_KEYS = frozenset(
+    {
+        "onChange",
+        DOCUMENTS_PARAM,
+        "__jsonInputInvalid",
+    }
+)
 
 _BODY_TEXT_KEYS: tuple[str, ...] = (
     "article_text",
@@ -69,3 +98,122 @@ def json_input_output_from_dict(data: dict[str, Any]) -> dict[str, Any]:
 def run_json_input(params: dict[str, Any], inputs: dict[str, Any]) -> dict[str, Any]:
     del inputs
     return json_input_output_from_dict(params)
+
+
+def _document_payload(raw: dict[str, Any]) -> dict[str, Any]:
+    """Return article fields from a documents[] entry (drops node-level keys)."""
+    return {
+        key: value
+        for key, value in raw.items()
+        if key not in _DOCUMENT_ENTRY_STRIP_KEYS
+    }
+
+
+def flat_document_from_params(params: dict[str, Any]) -> dict[str, Any]:
+    """Article fields from a single-document (flat) JSONInput params object."""
+    return {
+        key: value
+        for key, value in params.items()
+        if key not in _FLAT_PARAM_STRIP_KEYS
+    }
+
+
+def raw_documents_list(params: dict[str, Any]) -> list[Any] | None:
+    """Return the ``documents`` list when present, else ``None``."""
+    raw = params.get(DOCUMENTS_PARAM)
+    if raw is None:
+        return None
+    if not isinstance(raw, list):
+        raise ValueError("JSONInput 'documents' must be a list of JSON objects.")
+    return raw
+
+
+def is_json_input_multi_document(params: dict[str, Any]) -> bool:
+    """True when params hold two or more uploaded documents (batch path)."""
+    docs = raw_documents_list(params)
+    return docs is not None and len(docs) >= 2
+
+
+def normalize_source_file(raw: Any, *, fallback: str = DEFAULT_INLINE_SOURCE_FILE) -> str:
+    if raw is None:
+        return fallback
+    cleaned = str(raw).strip()
+    return cleaned or fallback
+
+
+def parse_documents_entries(
+    params: dict[str, Any],
+    *,
+    max_documents: int = JSON_INPUT_MAX_DOCUMENTS,
+) -> list[tuple[str, dict[str, Any]]]:
+    """Validate ``documents`` and return ``(source_file, article_payload)`` pairs.
+
+    Does not require a non-empty body (save-time may allow empty ``text``); callers that
+    execute a run should normalize via :func:`json_input_output_from_dict`.
+    """
+    docs = raw_documents_list(params)
+    if docs is None:
+        raise ValueError("JSONInput params have no 'documents' list.")
+    if len(docs) < 2:
+        raise ValueError(
+            "JSONInput 'documents' requires at least two files for batch mode; "
+            "use flat params for a single document."
+        )
+    if len(docs) > max_documents:
+        raise ValueError(
+            f"JSONInput accepts at most {max_documents} files at a time "
+            f"(got {len(docs)})."
+        )
+
+    out: list[tuple[str, dict[str, Any]]] = []
+    for index, entry in enumerate(docs):
+        if not isinstance(entry, dict):
+            raise ValueError(
+                f"JSONInput documents[{index}] must be a JSON object."
+            )
+        source_file = normalize_source_file(
+            entry.get(SOURCE_FILE_KEY),
+            fallback=f"document-{index + 1}.json",
+        )
+        payload = {**_document_payload(entry), SOURCE_FILE_KEY: source_file}
+        out.append((source_file, payload))
+    return out
+
+
+def documents_for_batch_execution(
+    params: dict[str, Any],
+    *,
+    max_documents: int = JSON_INPUT_MAX_DOCUMENTS,
+) -> list[tuple[str, dict[str, Any]]]:
+    """Return ``(source_file, normalized_doc)`` ready for ``agate_processed_item`` rows."""
+    entries = parse_documents_entries(params, max_documents=max_documents)
+    normalized: list[tuple[str, dict[str, Any]]] = []
+    for source_file, payload in entries:
+        doc = json_input_output_from_dict(payload)
+        normalized.append((source_file, doc))
+    return normalized
+
+
+def single_document_from_params(params: dict[str, Any]) -> tuple[dict[str, Any], str]:
+    """Resolve one document for the single-item path.
+
+    Prefers a length-1 ``documents`` list when present; otherwise uses flat params.
+    """
+    docs = raw_documents_list(params)
+    if docs is not None:
+        if len(docs) == 0:
+            raise ValueError("JSONInput 'documents' list is empty.")
+        if len(docs) >= 2:
+            raise ValueError(
+                "JSONInput with multiple documents uses batch setup, not single-item ingress."
+            )
+        entry = docs[0]
+        if not isinstance(entry, dict):
+            raise ValueError("JSONInput documents[0] must be a JSON object.")
+        source_file = normalize_source_file(entry.get(SOURCE_FILE_KEY))
+        payload = _document_payload(entry)
+        if SOURCE_FILE_KEY not in payload and source_file != DEFAULT_INLINE_SOURCE_FILE:
+            payload = {**payload, SOURCE_FILE_KEY: source_file}
+        return payload, source_file
+
+    return flat_document_from_params(params), DEFAULT_INLINE_SOURCE_FILE

--- a/packages/backfield-agate/src/agate_nodes/json_input/ui/JsonFileDropZone.tsx
+++ b/packages/backfield-agate/src/agate_nodes/json_input/ui/JsonFileDropZone.tsx
@@ -1,0 +1,98 @@
+import { useCallback, useRef, useState, type DragEvent, type ReactNode } from 'react'
+
+import { cn } from '@/lib/utils'
+
+interface JsonFileDropZoneProps {
+  disabled?: boolean
+  onFiles: (files: File[]) => void | Promise<void>
+  children?: ReactNode
+}
+
+function isJsonFileName(name: string): boolean {
+  return name.toLowerCase().endsWith('.json')
+}
+
+export default function JsonFileDropZone({
+  disabled,
+  onFiles,
+  children,
+}: JsonFileDropZoneProps) {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [dragOver, setDragOver] = useState(false)
+
+  const takeFiles = useCallback(
+    async (list: FileList | File[] | null) => {
+      if (!list || disabled) return
+      const files = Array.from(list).filter((file) => isJsonFileName(file.name))
+      if (files.length === 0) return
+      await onFiles(files)
+    },
+    [disabled, onFiles],
+  )
+
+  const onDragEnter = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault()
+    event.stopPropagation()
+    if (!disabled) setDragOver(true)
+  }
+
+  const onDragOver = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault()
+    event.stopPropagation()
+    if (!disabled) setDragOver(true)
+  }
+
+  const onDragLeave = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault()
+    event.stopPropagation()
+    setDragOver(false)
+  }
+
+  const onDrop = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault()
+    event.stopPropagation()
+    setDragOver(false)
+    void takeFiles(event.dataTransfer.files)
+  }
+
+  return (
+    <div
+      className={cn(
+        'rounded-md border border-dashed border-muted-foreground/40 bg-muted/20 p-3 transition-colors',
+        dragOver && !disabled && 'border-primary bg-primary/5',
+        disabled && 'opacity-60',
+      )}
+      onDragEnter={onDragEnter}
+      onDragOver={onDragOver}
+      onDragLeave={onDragLeave}
+      onDrop={onDrop}
+    >
+      <input
+        ref={inputRef}
+        type="file"
+        accept=".json,application/json"
+        multiple
+        className="sr-only"
+        disabled={disabled}
+        onChange={(event) => {
+          void takeFiles(event.target.files)
+          event.target.value = ''
+        }}
+      />
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <p className="text-sm text-muted-foreground">
+          Drop JSON files here, or choose files to add. Up to 20 files.
+        </p>
+        <button
+          type="button"
+          className="inline-flex h-9 shrink-0 items-center justify-center rounded-md border border-input bg-background px-3 text-sm font-medium hover:bg-accent hover:text-accent-foreground disabled:pointer-events-none disabled:opacity-50"
+          disabled={disabled}
+          onClick={() => inputRef.current?.click()}
+        >
+          Choose files
+        </button>
+      </div>
+      {children}
+    </div>
+  )
+}

--- a/packages/backfield-agate/src/agate_nodes/json_input/ui/PanelComponent.tsx
+++ b/packages/backfield-agate/src/agate_nodes/json_input/ui/PanelComponent.tsx
@@ -5,11 +5,19 @@ import type { GraphPanelContext } from '@/components/NodePanel'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
 import {
-  JSON_INPUT_INVALID_MARKER,
+  JSON_INPUT_MAX_DOCUMENTS,
+  JSON_INPUT_SOURCE_FILE_KEY,
+  buildJsonInputNodeData,
+  getJsonInputDocumentList,
+  isJsonInputMultiDocument,
   markJsonInputNodeDataInvalid,
+  mergeJsonInputUploads,
   parseJsonInputEditorText,
+  parseJsonInputFileText,
+  type JsonInputDocument,
 } from '@/lib/jsonInputValidation'
 import { getNodeOutputById, type NodeOutputLookupSpec } from '@/lib/nodeOutputs'
+import JsonFileDropZone from './JsonFileDropZone'
 import { JSON_INPUT_SCHEMA_EXAMPLE } from './schemaExample'
 
 interface JSONInputPanelProps {
@@ -19,6 +27,12 @@ interface JSONInputPanelProps {
   setNodes?: (nodes: any) => void
   graphContext?: GraphPanelContext
   nodeOutputLookupSpec?: NodeOutputLookupSpec | null
+}
+
+function editorTextForDocument(doc: JsonInputDocument): string {
+  const fields = { ...doc }
+  delete fields[JSON_INPUT_SOURCE_FILE_KEY]
+  return JSON.stringify(fields, null, 2)
 }
 
 export default function JSONInputPanel({
@@ -31,18 +45,32 @@ export default function JSONInputPanel({
 }: JSONInputPanelProps) {
   const [jsonText, setJsonText] = useState('')
   const [jsonError, setJsonError] = useState('')
+  const [uploadError, setUploadError] = useState('')
+  const [selectedIndex, setSelectedIndex] = useState(0)
+
+  const nodeData = (node.data || {}) as Record<string, unknown>
+  const documents = getJsonInputDocumentList(nodeData)
+  const multi = isJsonInputMultiDocument(nodeData)
+  const safeIndex = Math.min(selectedIndex, Math.max(0, documents.length - 1))
 
   useEffect(() => {
+    setSelectedIndex(0)
     try {
-      const base = { ...(node.data || {}), text: (node.data?.text as string) ?? '' }
-      delete (base as { onChange?: unknown }).onChange
-      delete base[JSON_INPUT_INVALID_MARKER]
-      setJsonText(JSON.stringify(base, null, 2))
+      const docs = getJsonInputDocumentList((node.data || {}) as Record<string, unknown>)
+      setJsonText(editorTextForDocument(docs[0] ?? { text: '' }))
       setJsonError('')
+      setUploadError('')
     } catch {
       setJsonText('{\n  "text": ""\n}')
     }
   }, [node.id])
+
+  const patchNodeData = (next: Record<string, unknown>) => {
+    if (!setNodes) return
+    setNodes((nds: any[]) =>
+      nds.map((n: any) => (n.id === node.id ? { ...n, data: next } : n)),
+    )
+  }
 
   const handleJsonChange = (value: string) => {
     setJsonText(value)
@@ -63,12 +91,64 @@ export default function JSONInputPanel({
     }
 
     setJsonError('')
-
-    if (setNodes) {
-      setNodes((nds: any[]) =>
-        nds.map((n: any) => (n.id === node.id ? { ...n, data: result.data } : n)),
-      )
+    const currentDocs = getJsonInputDocumentList(nodeData)
+    const index = Math.min(selectedIndex, Math.max(0, currentDocs.length - 1))
+    const previous = currentDocs[index]
+    const sourceName =
+      typeof previous?.[JSON_INPUT_SOURCE_FILE_KEY] === 'string'
+        ? String(previous[JSON_INPUT_SOURCE_FILE_KEY])
+        : undefined
+    const updated: JsonInputDocument = {
+      ...result.data,
+      text: result.data.text,
+      ...(sourceName ? { [JSON_INPUT_SOURCE_FILE_KEY]: sourceName } : {}),
     }
+    const nextDocs = currentDocs.map((doc, i) => (i === index ? updated : doc))
+    patchNodeData(buildJsonInputNodeData(nextDocs, nodeData))
+  }
+
+  const handleFiles = async (files: File[]) => {
+    setUploadError('')
+    const uploads: JsonInputDocument[] = []
+    for (const file of files) {
+      const raw = await file.text()
+      const parsed = parseJsonInputFileText(raw, file.name)
+      if (!parsed.ok) {
+        setUploadError(parsed.error)
+        return
+      }
+      uploads.push(parsed.document)
+    }
+    const merged = mergeJsonInputUploads(nodeData, uploads)
+    if (!merged.ok) {
+      setUploadError(merged.error)
+      return
+    }
+    const nextDocs = getJsonInputDocumentList(merged.data)
+    const nextIndex = Math.max(0, nextDocs.length - uploads.length)
+    setSelectedIndex(nextIndex)
+    setJsonText(editorTextForDocument(nextDocs[nextIndex] ?? { text: '' }))
+    setJsonError('')
+    patchNodeData(merged.data)
+  }
+
+  const removeDocumentAt = (index: number) => {
+    const nextDocs = documents.filter((_, i) => i !== index)
+    const nextData = buildJsonInputNodeData(nextDocs, nodeData)
+    let nextIndex = selectedIndex
+    if (nextDocs.length === 0) nextIndex = 0
+    else if (selectedIndex > index) nextIndex = selectedIndex - 1
+    else if (selectedIndex >= nextDocs.length) nextIndex = nextDocs.length - 1
+    setSelectedIndex(nextIndex)
+    setJsonText(editorTextForDocument(nextDocs[nextIndex] ?? { text: '' }))
+    setJsonError('')
+    patchNodeData(nextData)
+  }
+
+  const selectDocument = (index: number) => {
+    setSelectedIndex(index)
+    setJsonText(editorTextForDocument(documents[index] ?? { text: '' }))
+    setJsonError('')
   }
 
   const isDisabled = !(editMode && setNodes)
@@ -83,17 +163,64 @@ export default function JSONInputPanel({
   return (
     <>
       <NodePanelTabGate tab="settings">
-        <div className="space-y-2">
-          <Label htmlFor="node-json">JSON data (must include &quot;text&quot;)</Label>
-          <Textarea
-            id="node-json"
-            value={jsonText}
-            onChange={(e) => handleJsonChange(e.target.value)}
-            placeholder={`{\n  "text": "Your text here...",\n  "headline": "Optional headline"\n}`}
-            className="min-h-[300px] mt-1 font-mono text-xs"
-            disabled={isDisabled}
-          />
-          {jsonError && <p className="text-xs text-red-500 mt-1">{jsonError}</p>}
+        <div className="space-y-3">
+          <JsonFileDropZone disabled={isDisabled} onFiles={handleFiles} />
+          {uploadError ? <p className="text-xs text-red-500">{uploadError}</p> : null}
+
+          {multi ? (
+            <div className="space-y-1">
+              <Label>
+                Files ({documents.length} of {JSON_INPUT_MAX_DOCUMENTS})
+              </Label>
+              <ul className="max-h-40 space-y-1 overflow-y-auto rounded-md border p-1">
+                {documents.map((doc, index) => {
+                  const name =
+                    typeof doc[JSON_INPUT_SOURCE_FILE_KEY] === 'string'
+                      ? String(doc[JSON_INPUT_SOURCE_FILE_KEY])
+                      : `File ${index + 1}`
+                  const selected = index === safeIndex
+                  return (
+                    <li key={`${name}-${index}`} className="flex items-center gap-1">
+                      <button
+                        type="button"
+                        className={
+                          selected
+                            ? 'flex-1 truncate rounded px-2 py-1 text-left text-xs bg-accent'
+                            : 'flex-1 truncate rounded px-2 py-1 text-left text-xs hover:bg-muted'
+                        }
+                        disabled={isDisabled}
+                        onClick={() => selectDocument(index)}
+                      >
+                        {name}
+                      </button>
+                      <button
+                        type="button"
+                        className="shrink-0 rounded px-2 py-1 text-xs text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-50"
+                        disabled={isDisabled}
+                        onClick={() => removeDocumentAt(index)}
+                        aria-label={`Remove ${name}`}
+                      >
+                        Remove
+                      </button>
+                    </li>
+                  )
+                })}
+              </ul>
+            </div>
+          ) : null}
+
+          <div className="space-y-2">
+            <Label htmlFor="node-json">{multi ? 'Selected file content' : 'Content'}</Label>
+            <Textarea
+              id="node-json"
+              value={jsonText}
+              onChange={(e) => handleJsonChange(e.target.value)}
+              placeholder={`{\n  "text": "Your text here...",\n  "headline": "Optional headline"\n}`}
+              className="min-h-[300px] mt-1 font-mono text-xs"
+              disabled={isDisabled}
+            />
+            {jsonError && <p className="text-xs text-red-500 mt-1">{jsonError}</p>}
+          </div>
         </div>
 
         <IngressApiRunsSection
@@ -108,10 +235,10 @@ export default function JSONInputPanel({
       <NodePanelTabGate tab="info">
         <div className="space-y-2">
           <p className="text-sm text-muted-foreground leading-relaxed">
-            Use a single JSON object. Include a <span className="font-mono">text</span> field (it may
-            be empty); other top-level fields are optional and can be referenced in prompts (for
-            example{' '}
-            <span className="font-mono">{'{headline}'}</span>).
+            Paste content or upload one or more JSON files (up to {JSON_INPUT_MAX_DOCUMENTS}).
+            Each file becomes its own item when you run the flow. Include a text field in each
+            object (it may be empty); other fields are optional and can be referenced in prompts
+            (for example {'{headline}'}).
           </p>
           <Label htmlFor="node-json-schema">Example shape</Label>
           <Textarea

--- a/packages/backfield-agate/src/agate_runtime/graph_validation.py
+++ b/packages/backfield-agate/src/agate_runtime/graph_validation.py
@@ -9,6 +9,11 @@ from agate_runtime.types import GraphSpec
 INPUT_BOOKEND_TYPES = frozenset({"TextInput", "JSONInput", "S3Input"})
 DOCUMENT_CHUNKER_TYPE = "DocumentChunker"
 
+# Mirrors metadata ``requiredUpstreamNodes`` (at least one type must appear in ancestry).
+REQUIRED_UPSTREAM_BY_TYPE: dict[str, frozenset[str]] = {
+    "GeocodeAgent": frozenset({"PlaceExtract"}),
+}
+
 
 class GraphInvariantError(ValueError):
     """Raised when a graph violates product placement rules."""
@@ -62,9 +67,52 @@ def validate_document_chunker_placement(spec: GraphSpec) -> None:
         )
 
 
+def _ancestor_types(spec: GraphSpec, node_id: str) -> set[str]:
+    """Return node types reachable by walking incoming edges (excludes ``node_id`` itself)."""
+    by_id = {node.id: node for node in spec.nodes}
+    incoming: dict[str, list[str]] = defaultdict(list)
+    for edge in spec.edges:
+        if edge.source in by_id and edge.target in by_id:
+            incoming[edge.target].append(edge.source)
+
+    found: set[str] = set()
+    queue: deque[str] = deque(incoming.get(node_id, []))
+    seen: set[str] = set()
+    while queue:
+        current = queue.popleft()
+        if current in seen:
+            continue
+        seen.add(current)
+        node = by_id.get(current)
+        if node is None:
+            continue
+        found.add(node.type)
+        queue.extend(incoming.get(current, []))
+    return found
+
+
+def validate_required_upstream_nodes(spec: GraphSpec) -> None:
+    """Enforce metadata-style ``requiredUpstreamNodes`` via transitive ancestry."""
+    for node in spec.nodes:
+        required = REQUIRED_UPSTREAM_BY_TYPE.get(node.type)
+        if not required:
+            continue
+        ancestors = _ancestor_types(spec, node.id)
+        if ancestors.isdisjoint(required):
+            if node.type == "GeocodeAgent":
+                raise GraphInvariantError(
+                    "Geocode Agent must follow Place Extract in the same branch."
+                )
+            needed = ", ".join(sorted(required))
+            raise GraphInvariantError(
+                f"{node.type} requires one of these earlier steps in the same branch: {needed}."
+            )
+
+
 def validate_graph_invariants(spec: GraphSpec) -> None:
     """Run all product-level graph invariants."""
     validate_document_chunker_placement(spec)
+    validate_required_upstream_nodes(spec)
     _assert_acyclic(spec)
 
 

--- a/packages/backfield-agate/src/agate_runtime/json_input_batch.py
+++ b/packages/backfield-agate/src/agate_runtime/json_input_batch.py
@@ -1,0 +1,51 @@
+"""Detect and extract multi-document JSONInput batches (inline files on the node)."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agate_nodes.json_input.node import (
+    JSON_INPUT_MAX_DOCUMENTS,
+    documents_for_batch_execution,
+    is_json_input_multi_document,
+)
+
+from agate_runtime.types import GraphSpec
+
+
+def first_json_input_params(spec: GraphSpec) -> dict[str, Any]:
+    for node in spec.nodes:
+        if node.type == "JSONInput":
+            return dict(node.params) if isinstance(node.params, dict) else {}
+    raise ValueError("Graph has no JSONInput node.")
+
+
+def graph_spec_json_contains_json_input_batch(spec_json: str) -> bool:
+    """True when the graph's JSONInput holds two or more ``documents`` entries."""
+    try:
+        data = json.loads(spec_json)
+    except json.JSONDecodeError:
+        return False
+    nodes = data.get("nodes")
+    if not isinstance(nodes, list):
+        return False
+    for node in nodes:
+        if not isinstance(node, dict) or node.get("type") != "JSONInput":
+            continue
+        params = node.get("params")
+        if isinstance(params, dict) and is_json_input_multi_document(params):
+            return True
+    return False
+
+
+def json_input_batch_documents_from_spec(
+    spec: GraphSpec,
+    *,
+    max_documents: int = JSON_INPUT_MAX_DOCUMENTS,
+) -> list[tuple[str, dict[str, Any]]]:
+    """Return ``(source_file, normalized_doc)`` for each multi-file JSONInput document."""
+    params = first_json_input_params(spec)
+    if not is_json_input_multi_document(params):
+        raise ValueError("JSONInput is not in multi-document batch mode.")
+    return documents_for_batch_execution(params, max_documents=max_documents)

--- a/packages/backfield-agate/src/agate_runtime/nodes/json_input.py
+++ b/packages/backfield-agate/src/agate_runtime/nodes/json_input.py
@@ -1,9 +1,33 @@
 """Public JSONInput runner exports."""
 
 from agate_nodes.json_input.node import (
+    DEFAULT_INLINE_SOURCE_FILE,
+    DOCUMENTS_PARAM,
+    JSON_INPUT_MAX_DOCUMENTS,
+    PUBLIC_ALIAS_PARAM,
+    SOURCE_FILE_KEY,
+    documents_for_batch_execution,
+    flat_document_from_params,
+    is_json_input_multi_document,
     json_input_output_from_dict,
+    parse_documents_entries,
     resolve_document_body_text,
     run_json_input,
+    single_document_from_params,
 )
 
-__all__ = ["json_input_output_from_dict", "resolve_document_body_text", "run_json_input"]
+__all__ = [
+    "DEFAULT_INLINE_SOURCE_FILE",
+    "DOCUMENTS_PARAM",
+    "JSON_INPUT_MAX_DOCUMENTS",
+    "PUBLIC_ALIAS_PARAM",
+    "SOURCE_FILE_KEY",
+    "documents_for_batch_execution",
+    "flat_document_from_params",
+    "is_json_input_multi_document",
+    "json_input_output_from_dict",
+    "parse_documents_entries",
+    "resolve_document_body_text",
+    "run_json_input",
+    "single_document_from_params",
+]

--- a/packages/backfield-agate/src/agate_runtime/run_trigger.py
+++ b/packages/backfield-agate/src/agate_runtime/run_trigger.py
@@ -12,6 +12,7 @@ from backfield_db import AgateGraph, AgateProcessedItem, AgateRun
 from sqlmodel import Session
 
 from agate_runtime.graph_validation import validate_graph_invariants
+from agate_runtime.json_input_batch import graph_spec_json_contains_json_input_batch
 from agate_runtime.nodes.json_input import json_input_output_from_dict
 from agate_runtime.run_graph_spec import merge_run_result_payload
 from agate_runtime.s3_batch import graph_spec_json_contains_s3_input, s3_max_files_from_params
@@ -165,9 +166,12 @@ def trigger_agate_run(
     effective = apply_inputs_to_spec(spec, inputs)
     effective_json = effective.model_dump_json()
     is_s3_batch = graph_spec_json_contains_s3_input(effective_json)
+    is_json_input_batch = (
+        not is_s3_batch and graph_spec_json_contains_json_input_batch(effective_json)
+    )
     input_doc: dict[str, Any] | None = None
     source_file: str | None = None
-    if not is_s3_batch:
+    if not is_s3_batch and not is_json_input_batch:
         input_doc, source_file = build_single_item_input_from_graph_spec_json(effective_json)
 
     run = AgateRun(
@@ -192,6 +196,25 @@ def trigger_agate_run(
             run=run,
             processed_item=None,
             enqueue_task_name="worker.tasks.execute_s3_batch_setup",
+            enqueue_args=[run.id],
+        )
+        if commit:
+            result.enqueue(enqueue)
+        return result
+
+    if is_json_input_batch:
+        run.result_json = merge_run_result_payload(None, graph_spec_json=effective_json)
+        run.updated_at = datetime.now(UTC)
+        session.add(run)
+        if commit:
+            session.commit()
+        else:
+            session.flush()
+        session.refresh(run)
+        result = TriggerRunResult(
+            run=run,
+            processed_item=None,
+            enqueue_task_name="worker.tasks.execute_json_input_batch_setup",
             enqueue_args=[run.id],
         )
         if commit:

--- a/packages/backfield-agate/src/agate_runtime/single_item.py
+++ b/packages/backfield-agate/src/agate_runtime/single_item.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 from typing import Any
 
-from agate_runtime.nodes.json_input import json_input_output_from_dict
+from agate_runtime.json_input_batch import graph_spec_json_contains_json_input_batch
+from agate_runtime.nodes.json_input import (
+    json_input_output_from_dict,
+    single_document_from_params,
+)
 from agate_runtime.s3_batch import graph_spec_json_contains_s3_input
 from agate_runtime.types import GraphSpec, NodeConfig
 
@@ -22,6 +26,10 @@ def build_single_item_input_from_graph_spec_json(spec_json: str) -> tuple[dict[s
     """
     if graph_spec_json_contains_s3_input(spec_json):
         raise ValueError("Graphs with S3Input use batch setup, not single-item ingress.")
+    if graph_spec_json_contains_json_input_batch(spec_json):
+        raise ValueError(
+            "JSONInput with multiple documents uses batch setup, not single-item ingress."
+        )
 
     spec = GraphSpec.model_validate_json(spec_json)
     ingress = _ingress_nodes(spec)
@@ -46,6 +54,7 @@ def build_single_item_input_from_graph_spec_json(spec_json: str) -> tuple[dict[s
 
     if node.type == "JSONInput":
         params = dict(node.params) if isinstance(node.params, dict) else {}
-        return json_input_output_from_dict(params), "inline:json"
+        payload, source_file = single_document_from_params(params)
+        return json_input_output_from_dict(payload), source_file
 
     raise ValueError(f"Unsupported ingress node type: {node.type!r}")

--- a/packages/backfield-agate/tests/test_graph_validation.py
+++ b/packages/backfield-agate/tests/test_graph_validation.py
@@ -99,3 +99,56 @@ def test_validate_graph_invariants_rejects_cycles() -> None:
     )
     with pytest.raises(GraphInvariantError, match="cycle"):
         validate_graph_invariants(spec)
+
+
+def test_validate_graph_invariants_allows_geocode_after_place_extract() -> None:
+    spec = _spec(
+        [
+            NodeConfig(id="in", type="TextInput"),
+            NodeConfig(id="pe", type="PlaceExtract"),
+            NodeConfig(id="geo", type="GeocodeAgent"),
+            NodeConfig(id="out", type="DBOutput"),
+        ],
+        [
+            Edge(source="in", target="pe"),
+            Edge(source="pe", target="geo"),
+            Edge(source="geo", target="out"),
+        ],
+    )
+    validate_graph_invariants(spec)
+
+
+def test_validate_graph_invariants_rejects_geocode_without_place_extract() -> None:
+    spec = _spec(
+        [
+            NodeConfig(id="in", type="TextInput"),
+            NodeConfig(id="geo", type="GeocodeAgent"),
+            NodeConfig(id="out", type="DBOutput"),
+        ],
+        [
+            Edge(source="in", target="geo"),
+            Edge(source="geo", target="out"),
+        ],
+    )
+    with pytest.raises(GraphInvariantError, match="Geocode Agent must follow Place Extract"):
+        validate_graph_invariants(spec)
+
+
+def test_validate_graph_invariants_rejects_geocode_on_sibling_branch_without_place() -> None:
+    """Place Extract on another branch does not satisfy Geocode ancestry."""
+    spec = _spec(
+        [
+            NodeConfig(id="in", type="TextInput"),
+            NodeConfig(id="pe", type="PlaceExtract"),
+            NodeConfig(id="geo", type="GeocodeAgent"),
+            NodeConfig(id="out", type="DBOutput"),
+        ],
+        [
+            Edge(source="in", target="pe"),
+            Edge(source="in", target="geo"),
+            Edge(source="pe", target="out"),
+            Edge(source="geo", target="out"),
+        ],
+    )
+    with pytest.raises(GraphInvariantError, match="Geocode Agent must follow Place Extract"):
+        validate_graph_invariants(spec)

--- a/packages/backfield-agate/tests/test_json_input.py
+++ b/packages/backfield-agate/tests/test_json_input.py
@@ -1,9 +1,14 @@
 """JSONInput and shared document normalization."""
 
+import pytest
 from agate_runtime.nodes.json_input import (
+    documents_for_batch_execution,
+    is_json_input_multi_document,
     json_input_output_from_dict,
+    parse_documents_entries,
     resolve_document_body_text,
     run_json_input,
+    single_document_from_params,
 )
 
 
@@ -33,3 +38,65 @@ def test_resolve_document_body_text_prefers_longer_field_over_short_text_label()
     out = json_input_output_from_dict(doc)
     assert out["text"] == doc["article_text"]
     assert out["headline"] == "Events"
+
+
+def test_is_json_input_multi_document() -> None:
+    assert is_json_input_multi_document({"text": "a"}) is False
+    assert (
+        is_json_input_multi_document(
+            {
+                "documents": [
+                    {"text": "a", "source_file": "a.json"},
+                    {"text": "b", "source_file": "b.json"},
+                ]
+            }
+        )
+        is True
+    )
+
+
+def test_parse_documents_entries_and_batch_normalize() -> None:
+    params = {
+        "public_alias": "ingress",
+        "documents": [
+            {"source_file": "a.json", "text": " First ", "headline": "A"},
+            {"source_file": "b.json", "article_text": "Second body", "text": "x"},
+        ],
+    }
+    entries = parse_documents_entries(params)
+    assert len(entries) == 2
+    assert entries[0][0] == "a.json"
+    batch = documents_for_batch_execution(params)
+    assert batch[0][1]["text"] == "First"
+    assert batch[0][1]["headline"] == "A"
+    assert batch[0][1]["source_file"] == "a.json"
+    assert batch[1][1]["text"] == "Second body"
+
+
+def test_parse_documents_rejects_over_cap() -> None:
+    docs = [{"text": f"body {i}", "source_file": f"{i}.json"} for i in range(21)]
+    with pytest.raises(ValueError, match="at most 20"):
+        parse_documents_entries({"documents": docs})
+
+
+def test_single_document_from_flat_and_length_one_list() -> None:
+    flat, source = single_document_from_params({"text": "hi", "public_alias": "x"})
+    assert flat["text"] == "hi"
+    assert flat["public_alias"] == "x"
+    assert source == "inline:json"
+
+    one, source_one = single_document_from_params(
+        {"documents": [{"source_file": "only.json", "text": "solo"}]}
+    )
+    assert one["text"] == "solo"
+    assert source_one == "only.json"
+
+    with pytest.raises(ValueError, match="batch setup"):
+        single_document_from_params(
+            {
+                "documents": [
+                    {"text": "a", "source_file": "a.json"},
+                    {"text": "b", "source_file": "b.json"},
+                ]
+            }
+        )

--- a/packages/backfield-agate/tests/test_json_input_batch.py
+++ b/packages/backfield-agate/tests/test_json_input_batch.py
@@ -1,0 +1,66 @@
+"""Tests for multi-document JSONInput batch detection."""
+
+from __future__ import annotations
+
+import json
+
+from agate_runtime.json_input_batch import (
+    graph_spec_json_contains_json_input_batch,
+    json_input_batch_documents_from_spec,
+)
+from agate_runtime.types import GraphSpec
+
+
+def test_graph_spec_json_contains_json_input_batch() -> None:
+    multi = json.dumps(
+        {
+            "name": "m",
+            "nodes": [
+                {
+                    "id": "j",
+                    "type": "JSONInput",
+                    "params": {
+                        "documents": [
+                            {"text": "a", "source_file": "a.json"},
+                            {"text": "b", "source_file": "b.json"},
+                        ]
+                    },
+                }
+            ],
+            "edges": [],
+        }
+    )
+    single = json.dumps(
+        {
+            "name": "s",
+            "nodes": [{"id": "j", "type": "JSONInput", "params": {"text": "only"}}],
+            "edges": [],
+        }
+    )
+    assert graph_spec_json_contains_json_input_batch(multi) is True
+    assert graph_spec_json_contains_json_input_batch(single) is False
+
+
+def test_json_input_batch_documents_from_spec() -> None:
+    spec = GraphSpec.model_validate(
+        {
+            "name": "m",
+            "nodes": [
+                {
+                    "id": "j",
+                    "type": "JSONInput",
+                    "params": {
+                        "documents": [
+                            {"text": " Alpha ", "source_file": "a.json", "headline": "A"},
+                            {"text": "Beta", "source_file": "b.json"},
+                        ]
+                    },
+                }
+            ],
+            "edges": [],
+        }
+    )
+    docs = json_input_batch_documents_from_spec(spec)
+    assert [name for name, _ in docs] == ["a.json", "b.json"]
+    assert docs[0][1]["text"] == "Alpha"
+    assert docs[0][1]["headline"] == "A"

--- a/packages/backfield-agate/tests/test_single_item.py
+++ b/packages/backfield-agate/tests/test_single_item.py
@@ -44,6 +44,29 @@ def test_build_from_json_input() -> None:
     assert source == "inline:json"
 
 
+def test_rejects_json_input_multi_document_batch() -> None:
+    spec = json.dumps(
+        {
+            "name": "j",
+            "nodes": [
+                {
+                    "id": "a",
+                    "type": "JSONInput",
+                    "params": {
+                        "documents": [
+                            {"text": "a", "source_file": "a.json"},
+                            {"text": "b", "source_file": "b.json"},
+                        ]
+                    },
+                },
+            ],
+            "edges": [],
+        }
+    )
+    with pytest.raises(ValueError, match="batch setup"):
+        build_single_item_input_from_graph_spec_json(spec)
+
+
 def test_rejects_s3_graph() -> None:
     spec = json.dumps(
         {

--- a/tests/agate_api/test_project_stylebook_ownership.py
+++ b/tests/agate_api/test_project_stylebook_ownership.py
@@ -498,6 +498,8 @@ def test_graph_write_normalizes_runtime_nodes_to_project_stylebook(
             "spec": {
                 "name": "normalized",
                 "nodes": [
+                    {"id": "in", "type": "TextInput", "params": {"text": "hello"}},
+                    {"id": "pe", "type": "PlaceExtract", "params": {}},
                     {
                         "id": "geo",
                         "type": "GeocodeAgent",
@@ -509,17 +511,23 @@ def test_graph_write_normalizes_runtime_nodes_to_project_stylebook(
                         "params": {"stylebook_id": ownership_fixture.original_stylebook_id},
                     },
                 ],
-                "edges": [],
+                "edges": [
+                    {"source": "in", "target": "pe"},
+                    {"source": "pe", "target": "geo"},
+                    {"source": "geo", "target": "out"},
+                ],
             },
         },
     )
 
     assert response.status_code == 200, response.text
-    params = [node["params"] for node in response.json()["spec"]["nodes"]]
-    assert params == [
-        {"stylebook_id": ownership_fixture.original_stylebook_id},
-        {"stylebook_id": ownership_fixture.original_stylebook_id},
-    ]
+    by_type = {node["type"]: node["params"] for node in response.json()["spec"]["nodes"]}
+    assert by_type["GeocodeAgent"] == {
+        "stylebook_id": ownership_fixture.original_stylebook_id,
+    }
+    assert by_type["DBOutput"] == {
+        "stylebook_id": ownership_fixture.original_stylebook_id,
+    }
 
 
 def test_graph_create_and_update_reject_conflicting_runtime_stylebook(

--- a/tests/agate_runtime/test_run_trigger.py
+++ b/tests/agate_runtime/test_run_trigger.py
@@ -133,3 +133,52 @@ def test_trigger_agate_run_pins_effective_spec_and_enqueues() -> None:
         item = result.processed_item
         assert item.input_json is not None
         assert "From API" in item.input_json
+
+
+def _json_multi_spec() -> GraphSpec:
+    return GraphSpec(
+        name="json-batch",
+        nodes=[
+            NodeConfig(
+                id="j1",
+                type="JSONInput",
+                params={
+                    "documents": [
+                        {"text": "First body", "source_file": "a.json"},
+                        {"text": "Second body", "source_file": "b.json"},
+                    ]
+                },
+            ),
+            NodeConfig(id="n2", type="Output", params={}),
+        ],
+        edges=[],
+    )
+
+
+def test_trigger_agate_run_json_input_batch_enqueues_setup() -> None:
+    engine = create_engine("sqlite://", connect_args={"check_same_thread": False})
+    SQLModel.metadata.create_all(engine)
+    enqueued: list[tuple[str, list[object]]] = []
+
+    def enqueue(name: str, args: list[object]) -> None:
+        enqueued.append((name, args))
+
+    with Session(engine) as session:
+        graph = AgateGraph(
+            id="g-json-batch",
+            name="JSON Batch",
+            spec_json=_json_multi_spec().model_dump_json(),
+            project_id=1,
+        )
+        session.add(graph)
+        session.commit()
+
+        result = trigger_agate_run(session, graph=graph, enqueue=enqueue)
+        assert result.processed_item is None
+        assert result.run.status == "pending"
+        assert enqueued == [
+            ("worker.tasks.execute_json_input_batch_setup", [result.run.id])
+        ]
+        run = session.get(AgateRun, result.run.id)
+        assert run is not None
+        assert "graph_spec_json" in parse_run_result_payload(run.result_json)

--- a/tests/worker/test_db_output_article_only.py
+++ b/tests/worker/test_db_output_article_only.py
@@ -1,0 +1,111 @@
+"""DBOutput persistence when only article body is present (Input → Backfield Output)."""
+
+from __future__ import annotations
+
+import pytest
+from backfield_db import AgateRun, SubstrateArticle
+from sqlmodel import Session, SQLModel, create_engine
+from worker.substrate import persist_from_consolidated
+
+from tests.worker.test_substrate_persistence import _bootstrap_project
+
+
+def _engine():
+    engine = create_engine("sqlite://", echo=False)
+    SQLModel.metadata.create_all(engine)
+    return engine
+
+
+def test_persist_from_consolidated_accepts_article_body_only() -> None:
+    engine = _engine()
+    with Session(engine) as session:
+        project_id = _bootstrap_project(
+            session,
+            org_slug="org-article-only",
+            project_slug="proj-article-only",
+        )
+        session.add(
+            AgateRun(id="run-article-only", graph_id="graph-article-only", status="pending")
+        )
+        session.commit()
+
+        result = persist_from_consolidated(
+            session,
+            project_id=project_id,
+            graph_id="graph-article-only",
+            run_id="run-article-only",
+            consolidated={
+                "text": "Story body text.",
+                "headline": "Headline",
+                "url": "https://example.com/article-only",
+            },
+            db_output_params={"semantic_indexing_enabled": False},
+        )
+        session.commit()
+
+        assert result.consolidated_domain_keys == ()
+        assert result.reconciliation_summary.domain == "article"
+        article = session.get(SubstrateArticle, result.article_id)
+        assert article is not None
+        assert article.text == "Story body text."
+        assert article.headline == "Headline"
+
+
+def test_persist_from_consolidated_accepts_article_body_via_alias() -> None:
+    engine = _engine()
+    with Session(engine) as session:
+        project_id = _bootstrap_project(
+            session,
+            org_slug="org-article-alias",
+            project_slug="proj-article-alias",
+        )
+        session.add(
+            AgateRun(id="run-article-alias", graph_id="graph-article-alias", status="pending")
+        )
+        session.commit()
+
+        result = persist_from_consolidated(
+            session,
+            project_id=project_id,
+            graph_id="graph-article-alias",
+            run_id="run-article-alias",
+            consolidated={
+                "article_text": "The longer body used for extraction and persist.",
+                "headline": "Events",
+                "url": "https://example.com/article-alias",
+            },
+            db_output_params={"semantic_indexing_enabled": False},
+        )
+        session.commit()
+
+        article = session.get(SubstrateArticle, result.article_id)
+        assert article is not None
+        assert article.text == "The longer body used for extraction and persist."
+
+
+def test_persist_from_consolidated_rejects_empty_body_without_domains() -> None:
+    engine = _engine()
+    with Session(engine) as session:
+        project_id = _bootstrap_project(
+            session,
+            org_slug="org-article-empty",
+            project_slug="proj-article-empty",
+        )
+        session.add(
+            AgateRun(id="run-article-empty", graph_id="graph-article-empty", status="pending")
+        )
+        session.commit()
+
+        with pytest.raises(RuntimeError, match="non-empty article body"):
+            persist_from_consolidated(
+                session,
+                project_id=project_id,
+                graph_id="graph-article-empty",
+                run_id="run-article-empty",
+                consolidated={
+                    "text": "   ",
+                    "headline": "Headline only",
+                    "url": "https://example.com/article-empty",
+                },
+                db_output_params={"semantic_indexing_enabled": False},
+            )


### PR DESCRIPTION
## Summary

Four related Agate graph improvements:

- **JSON Input multi-file upload** — Upload or drag-and-drop up to 20 `.json` files. One file keeps flat params; two or more create an S3-style `documents[]` batch (one processed item per file). Includes panel UI, runtime batch setup, and docs.
- **Article-only Backfield Output** — Allow persisting when the consolidated payload has a resolvable article body but no extract domains (matching/connections/indexing remain soft no-ops; empty body still fails).
- **Geocode upstream invariant** — Reject graphs where Geocode Agent lacks Place Extract on the same branch (API save, run trigger, execute, guided UI save). Sibling-branch Place Extract does not count.
- **JSON Input upload fix** — File uploads on a flat node replace editor content instead of promoting it as a phantom `Current content.json` entry.

## Project scope check

- [x] This change targets local development / source inspection (production self-hosting is unsupported in this repo)
- [x] Docs under `docs/` updated if behavior, architecture, or operations changed
- [x] First-admin provisioning still uses `backfield init` / `backfield seed` only (no HTTP/env bootstrap paths)

## Test plan

- [x] `make lint`
- [x] `make test`
- [ ] `make ui-typecheck ui-test` (if UI/TypeScript changed)
- [ ] `make smoke-fast` (if live-stack behavior changed)
- [ ] `make smoke` (if golden-path / provider-dependent runtime changed; configure **Settings → AI models**)

## Notes for reviewers

- JSON Input batch path mirrors S3 batch chord semantics via `execute_json_input_batch_setup`.
- Geocode validation is enforced at save and run time; one API test fixture was updated to use `TextInput → PlaceExtract → Geocode → DBOutput`.
- Upload merge behavior: flat node → uploads replace; already multi-file → uploads append.


Made with [Cursor](https://cursor.com)