### PR TITLE
Fix flow deletion when article metadata references runs

### DIFF
--- a/apps/agate-api/src/api/routers/graphs.py
+++ b/apps/agate-api/src/api/routers/graphs.py
@@ -16,6 +16,7 @@ from backfield_db import (
     BackfieldAiCallRecord,
     BackfieldProject,
     SubstrateArticle,
+    SubstrateArticleMeta,
 )
 from backfield_entities.catalog.graph_stylebook_refs import (
     StylebookGraphRefsError,
@@ -227,6 +228,11 @@ def delete_graph(
             update(SubstrateArticle)
             .where(SubstrateArticle.source_run_id.in_(run_ids))
             .values(source_run_id=None, source_item_id=None)
+        )
+        session.exec(
+            update(SubstrateArticleMeta)
+            .where(SubstrateArticleMeta.source_run_id.in_(run_ids))
+            .values(source_run_id=None)
         )
         session.exec(delete(BackfieldAiCallRecord).where(BackfieldAiCallRecord.run_id.in_(run_ids)))
         session.exec(delete(AgateProcessedItem).where(AgateProcessedItem.run_id.in_(run_ids)))

--- a/tests/agate_api/test_agate_api.py
+++ b/tests/agate_api/test_agate_api.py
@@ -26,6 +26,7 @@ from backfield_db import (
     BackfieldWorkspace,
     BackfieldWorkspaceMembership,
     SubstrateArticle,
+    SubstrateArticleMeta,
     SubstratePerson,
     SubstratePersonMention,
 )
@@ -944,12 +945,26 @@ def test_delete_graph_cleans_up_run_dependencies(monkeypatch, tmp_path):
                 source_item_id=item.id,
             )
             s.add(article)
+            s.flush()
+            assert article.id is not None
+
+            meta = SubstrateArticleMeta(
+                article_id=article.id,
+                meta_type="subject",
+                category="local_news",
+                rationale="Smoke test metadata",
+                confidence=0.9,
+                source_run_id=run_id,
+            )
+            s.add(meta)
             s.commit()
             s.refresh(call)
             s.refresh(article)
+            s.refresh(meta)
             call_id = call.id
             article_id = article.id
             item_id = item.id
+            meta_id = meta.id
 
         resp = tc.delete(f"/graphs/{graph['id']}")
         assert resp.status_code == 204
@@ -963,6 +978,9 @@ def test_delete_graph_cleans_up_run_dependencies(monkeypatch, tmp_path):
             assert article_row is not None
             assert article_row.source_run_id is None
             assert article_row.source_item_id is None
+            meta_row = s.get(SubstrateArticleMeta, meta_id)
+            assert meta_row is not None
+            assert meta_row.source_run_id is None
     finally:
         app.dependency_overrides.clear()
 


### PR DESCRIPTION
## Summary
- Clear `substrate_article_meta.source_run_id` when deleting a graph, matching the existing `substrate_article` provenance cleanup before run rows are removed.
- Fixes `DELETE /api/agate/graphs/{id}` returning 500 on flows that produced Article Metadata output (`substrate_article_meta_source_run_id_fkey`).

## Test plan
- [x] `uv run pytest tests/agate_api/test_agate_api.py::test_delete_graph_cleans_up_run_dependencies -q`
- [x] `uv run ruff check` on changed files
- [ ] Delete a metadata-producing flow on staging/canary and confirm 204


Made with [Cursor](https://cursor.com)