### PR TITLE
Fix connection graph, map tiles, and nav flash

### DIFF
--- a/apps/agate-ui/src/App.tsx
+++ b/apps/agate-ui/src/App.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react"
-import { Routes, Route, Navigate, useLocation, useNavigate } from "react-router-dom"
+import { Routes, Route, Navigate, Outlet, useLocation, useNavigate } from "react-router-dom"
 import ProjectDetailPage from './pages/ProjectDetailPage'
 import WorkspacesHomePage from './pages/WorkspacesHomePage'
 import WorkspaceDetailPage from './pages/WorkspaceDetailPage'
@@ -52,6 +52,14 @@ function ProtectedRoute({ children }: { children: ReactNode }) {
   return <>{children}</>
 }
 
+function ProtectedHubLayout() {
+  return (
+    <ProtectedRoute>
+      <HubLayout />
+    </ProtectedRoute>
+  )
+}
+
 function OrgAdminRoute({ children }: { children: ReactNode }) {
   const { isOrgAdmin, loading, isAuthenticated } = useAuth()
   const location = useLocation()
@@ -75,6 +83,14 @@ function OrgAdminRoute({ children }: { children: ReactNode }) {
   return <>{children}</>
 }
 
+function OrgAdminOutlet() {
+  return (
+    <OrgAdminRoute>
+      <Outlet />
+    </OrgAdminRoute>
+  )
+}
+
 function AppRoutes() {
   const location = useLocation()
   const navigate = useNavigate()
@@ -90,6 +106,12 @@ function AppRoutes() {
     ? scopeOrganizationPath(location.pathname, location.search, organizationSlug)
     : null
   const scopedPathname = pathScope?.scopedPathname ?? location.pathname
+  const shouldHealOrgPath =
+    !loading &&
+    isAuthenticated &&
+    Boolean(organizationSlug) &&
+    location.pathname !== "/login" &&
+    Boolean(pathScope?.redirectPath)
 
   if (shouldForcePasswordChange({ loading, isAuthenticated, mustChangePassword })) {
     return (
@@ -109,210 +131,68 @@ function AppRoutes() {
     )
   }
 
-  if (
-    !loading &&
-    isAuthenticated &&
-    organizationSlug &&
-    location.pathname !== "/login" &&
-    pathScope?.redirectPath
-  ) {
-    return <Navigate to={pathScope.redirectPath} replace />
-  }
-
   return (
-    <Routes location={{ ...location, pathname: scopedPathname }}>
-      <Route path="/login" element={<Login />} />
-      <Route
-        path="/flow/new"
-        element={
-          <ProtectedRoute>
-            <GuidedFlowBuilder />
-          </ProtectedRoute>
-        }
-      />
-      <Route
-        path="/flow/:graphId/edit"
-        element={
-          <ProtectedRoute>
-            <GuidedFlowBuilder />
-          </ProtectedRoute>
-        }
-      />
-      <Route
-        path="/"
-        element={
-          <ProtectedRoute>
-            <HubLayout>
-              <WorkspacesHomePage />
-            </HubLayout>
-          </ProtectedRoute>
-        }
-      />
-      <Route
-        path="/workspace/:workspaceSlug"
-        element={
-          <ProtectedRoute>
-            <HubLayout>
-              <WorkspaceDetailPage />
-            </HubLayout>
-          </ProtectedRoute>
-        }
-      />
-      <Route
-        path="/project/:projectSlug"
-        element={
-          <ProtectedRoute>
-            <HubLayout>
-              <ProjectDetailPage />
-            </HubLayout>
-          </ProtectedRoute>
-        }
-      />
-      <Route
-        path="/flows"
-        element={
-          <ProtectedRoute>
-            <HubLayout>
-              <FlowsPage />
-            </HubLayout>
-          </ProtectedRoute>
-        }
-      />
-      <Route
-        path="/runs"
-        element={
-          <ProtectedRoute>
-            <HubLayout>
-              <RunsList />
-            </HubLayout>
-          </ProtectedRoute>
-        }
-      />
-      <Route
-        path="/templates"
-        element={
-          <ProtectedRoute>
-            <HubLayout>
-              <TemplatesPage />
-            </HubLayout>
-          </ProtectedRoute>
-        }
-      />
-      <Route
-        path="/help"
-        element={
-          <ProtectedRoute>
-            <HubLayout>
-              <HelpPlaceholderPage />
-            </HubLayout>
-          </ProtectedRoute>
-        }
-      />
-      <Route
-        path="/account/password"
-        element={
-          <ProtectedRoute>
-            <HubLayout>
-              <ChangePasswordPage />
-            </HubLayout>
-          </ProtectedRoute>
-        }
-      />
-      <Route
-        path="/admin/users"
-        element={
-          <ProtectedRoute>
-            <OrgAdminRoute>
-              <HubLayout>
-                <ManageUsers />
-              </HubLayout>
-            </OrgAdminRoute>
-          </ProtectedRoute>
-        }
-      />
-      <Route path="/admin/catalogs" element={<Navigate to="/admin/stylebooks" replace />} />
-      <Route
-        path="/admin/stylebooks"
-        element={
-          <ProtectedRoute>
-            <OrgAdminRoute>
-              <HubLayout>
-                <ManageCatalogs />
-              </HubLayout>
-            </OrgAdminRoute>
-          </ProtectedRoute>
-        }
-      />
-      <Route path="/admin/ai-models" element={<Navigate to="/settings/models" replace />} />
-      <Route path="/admin/integrations" element={<Navigate to="/settings/integrations" replace />} />
-      <Route
-        path="/settings"
-        element={
-          <ProtectedRoute>
-            <OrgAdminRoute>
-              <HubLayout>
-                <SettingsLayout />
-              </HubLayout>
-            </OrgAdminRoute>
-          </ProtectedRoute>
-        }
-      >
-        <Route index element={<SettingsHub />} />
-        <Route path="models" element={<AiModelsSettings />} />
-        <Route path="integrations" element={<OrgIntegrationsSettings />} />
-        <Route path="webhooks" element={<WebhooksSettings />} />
-        <Route path="other" element={<OtherSettings />} />
-        <Route path="*" element={<NotFound />} />
-      </Route>
-      <Route
-        path="/flow/:graphId"
-        element={
-          <ProtectedRoute>
-            <RunGraph />
-          </ProtectedRoute>
-        }
-      />
-      <Route
-        path="/runs/:runId"
-        element={
-          <ProtectedRoute>
-            <HubLayout>
-              <RunDetail />
-            </HubLayout>
-          </ProtectedRoute>
-        }
-      />
-      <Route
-        path="/runs/:runId/items/:itemId"
-        element={
-          <ProtectedRoute>
-            <HubLayout>
-              <ProcessedItemDetail />
-            </HubLayout>
-          </ProtectedRoute>
-        }
-      />
-      <Route
-        path="/dev/leaflet-map"
-        element={
-          <ProtectedRoute>
-            <HubLayout>
-              <LeafletMapHarness />
-            </HubLayout>
-          </ProtectedRoute>
-        }
-      />
-      <Route
-        path="*"
-        element={
-          <ProtectedRoute>
-            <HubLayout>
-              <NotFound />
-            </HubLayout>
-          </ProtectedRoute>
-        }
-      />
-    </Routes>
+    <>
+      {shouldHealOrgPath && pathScope?.redirectPath ? (
+        <Navigate to={pathScope.redirectPath} replace />
+      ) : null}
+      <Routes location={{ ...location, pathname: scopedPathname }}>
+        <Route path="/login" element={<Login />} />
+        <Route
+          path="/flow/new"
+          element={
+            <ProtectedRoute>
+              <GuidedFlowBuilder />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/flow/:graphId/edit"
+          element={
+            <ProtectedRoute>
+              <GuidedFlowBuilder />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/flow/:graphId"
+          element={
+            <ProtectedRoute>
+              <RunGraph />
+            </ProtectedRoute>
+          }
+        />
+        <Route element={<ProtectedHubLayout />}>
+          <Route path="/" element={<WorkspacesHomePage />} />
+          <Route path="/workspace/:workspaceSlug" element={<WorkspaceDetailPage />} />
+          <Route path="/project/:projectSlug" element={<ProjectDetailPage />} />
+          <Route path="/flows" element={<FlowsPage />} />
+          <Route path="/runs" element={<RunsList />} />
+          <Route path="/templates" element={<TemplatesPage />} />
+          <Route path="/help" element={<HelpPlaceholderPage />} />
+          <Route path="/account/password" element={<ChangePasswordPage />} />
+          <Route path="/runs/:runId" element={<RunDetail />} />
+          <Route path="/runs/:runId/items/:itemId" element={<ProcessedItemDetail />} />
+          <Route path="/dev/leaflet-map" element={<LeafletMapHarness />} />
+          <Route element={<OrgAdminOutlet />}>
+            <Route path="/admin/users" element={<ManageUsers />} />
+            <Route path="/admin/catalogs" element={<Navigate to="/admin/stylebooks" replace />} />
+            <Route path="/admin/stylebooks" element={<ManageCatalogs />} />
+            <Route path="/admin/ai-models" element={<Navigate to="/settings/models" replace />} />
+            <Route path="/admin/integrations" element={<Navigate to="/settings/integrations" replace />} />
+            <Route path="/settings" element={<SettingsLayout />}>
+              <Route index element={<SettingsHub />} />
+              <Route path="models" element={<AiModelsSettings />} />
+              <Route path="integrations" element={<OrgIntegrationsSettings />} />
+              <Route path="webhooks" element={<WebhooksSettings />} />
+              <Route path="other" element={<OtherSettings />} />
+              <Route path="*" element={<NotFound />} />
+            </Route>
+          </Route>
+          <Route path="*" element={<NotFound />} />
+        </Route>
+      </Routes>
+    </>
   )
 }
 

--- a/apps/agate-ui/src/components/HubLayout.tsx
+++ b/apps/agate-ui/src/components/HubLayout.tsx
@@ -1,15 +1,10 @@
-import { ReactNode } from "react"
-import { useNavigate } from "react-router-dom"
+import { Outlet, useNavigate } from "react-router-dom"
 import { AgateProductMark, ShellProductBrand, UserAccountMenu } from "@backfield/ui"
 import AppSidebar from "./AppSidebar"
 import OrganizationSetupBanner from "./OrganizationSetupBanner"
 import { useAuth } from "@/lib/auth"
 
-interface HubLayoutProps {
-  children: ReactNode
-}
-
-export default function HubLayout({ children }: HubLayoutProps) {
+export default function HubLayout() {
   const navigate = useNavigate()
   const { username, logout } = useAuth()
 
@@ -39,7 +34,7 @@ export default function HubLayout({ children }: HubLayoutProps) {
         <main className="flex-1 min-w-0 min-h-0 overflow-y-auto overscroll-y-contain">
           <div className="w-full max-w-none px-4 sm:px-6 lg:px-8 py-8">
             <OrganizationSetupBanner />
-            {children}
+            <Outlet />
           </div>
         </main>
       </div>

--- a/apps/api-playground/README.md
+++ b/apps/api-playground/README.md
@@ -98,7 +98,7 @@ sufficient by itself.
 - Generated curl uses `$BACKFIELD_PROJECT_API_KEY` instead of printing the entered key.
 - The production build injects a restrictive Content Security Policy. `index.html` also sets
   `Referrer-Policy: no-referrer` through a meta policy, which works on any static host.
-  Map tiles are loaded from `https://*.basemaps.cartocdn.com` (allowed in `img-src`).
+  Map tiles are loaded from `https://*.tile.openstreetmap.org` (allowed in `img-src`).
 - The production static host should send the same CSP and `Referrer-Policy: no-referrer` as HTTP
   response headers. The in-document policies remain a defense when an operator has not yet added
   host-level headers.

--- a/apps/api-playground/src/components/GeoAreaMap.tsx
+++ b/apps/api-playground/src/components/GeoAreaMap.tsx
@@ -251,8 +251,8 @@ export default function GeoAreaMap({
           className="map-selector-map"
         >
           <TileLayer
-            url="https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png"
-            attribution=""
+            url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+            attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
           />
           <AreaInteraction
             mode={mode}

--- a/apps/api-playground/src/components/H3CellMap.tsx
+++ b/apps/api-playground/src/components/H3CellMap.tsx
@@ -407,8 +407,8 @@ export default function H3CellMap({
           className="map-selector-map"
         >
           <TileLayer
-            url="https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png"
-            attribution=""
+            url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+            attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
           />
           <MapViewSync center={center} resolution={activeResolution} />
           <ShiftPaintLayer resolution={activeResolution} onPaintCell={paintCell}>

--- a/apps/api-playground/vite.config.ts
+++ b/apps/api-playground/vite.config.ts
@@ -5,8 +5,8 @@ import { defineConfig, type Plugin } from "vite"
 
 const appRoot = path.dirname(fileURLToPath(import.meta.url))
 
-// Leaflet basemaps load raster tiles from CARTO (see GeoAreaMap / H3CellMap).
-const mapTileImgSrc = "https://*.basemaps.cartocdn.com"
+// Leaflet basemaps load raster tiles from OpenStreetMap (see GeoAreaMap / H3CellMap).
+const mapTileImgSrc = "https://*.tile.openstreetmap.org"
 
 const productionCsp = [
   "default-src 'none'",

--- a/apps/stylebook-ui/src/App.tsx
+++ b/apps/stylebook-ui/src/App.tsx
@@ -194,17 +194,18 @@ function OrganizationScopedRoutes() {
     )
   }
 
-  if (
+  const shouldHealOrgPath =
     !loading &&
     isAuthenticated &&
-    organizationSlug &&
+    Boolean(organizationSlug) &&
     location.pathname !== "/login" &&
-    pathScope?.redirectPath
-  ) {
-    return <Navigate to={pathScope.redirectPath} replace />
-  }
+    Boolean(pathScope?.redirectPath)
 
   return (
+    <>
+      {shouldHealOrgPath && pathScope?.redirectPath ? (
+        <Navigate to={pathScope.redirectPath} replace />
+      ) : null}
         <Routes location={{ ...location, pathname: scopedPathname }}>
           <Route path="/login" element={<Login />} />
 
@@ -312,5 +313,6 @@ function OrganizationScopedRoutes() {
             <Route path="*" element={<NotFound />} />
           </Route>
         </Routes>
+    </>
   )
 }

--- a/apps/stylebook-ui/src/components/ConnectionGraphDetailPanel.tsx
+++ b/apps/stylebook-ui/src/components/ConnectionGraphDetailPanel.tsx
@@ -375,12 +375,8 @@ function EntityHeader({
 function nodeHop(
   entityRef: GraphEntityRef,
   center: GraphEntityRef,
-  connections: Connection[],
 ): GraphHop {
-  if (entityRefKey(entityRef) === entityRefKey(center)) return 0
-  const touching = connectionsTouchingEntity(connections, entityRef)
-  if (touching.some((conn) => classifyConnectionHop(conn, center) === 1)) return 1
-  return 2
+  return entityRefKey(entityRef) === entityRefKey(center) ? 0 : 1
 }
 
 export default function ConnectionGraphDetailPanel({
@@ -506,7 +502,7 @@ export default function ConnectionGraphDetailPanel({
             )?.displayName ?? "Unknown",
   }
 
-  const hop = nodeHop(entityRef, center, connections)
+  const hop = nodeHop(entityRef, center)
   const profileSeedLines =
     entityRefKey(entityRef) === entityRefKey(center) ? centerProfileLines : undefined
 

--- a/apps/stylebook-ui/src/components/ConnectionsGraph.tsx
+++ b/apps/stylebook-ui/src/components/ConnectionsGraph.tsx
@@ -21,9 +21,13 @@ import ConnectionGraphDetailPanel, {
 import type { GraphEntityProfileLines } from "@/lib/connectionGraphEntityProfile"
 import {
   bundleEdgeLabel,
-  classifyConnectionHop,
+  egoGraphLayoutMetrics,
   entityRefKey,
+  GRAPH_NODE_LAYOUT_HEIGHT,
+  GRAPH_NODE_LAYOUT_WIDTH,
   groupConnectionsByDirectedEdge,
+  layoutNeighborGrid,
+  neighborFromConnection,
   type ConnectionNeighborhood,
   type GraphEntityRef,
   type GraphHop,
@@ -34,19 +38,145 @@ import type { EntityType as ConnectionsEntityType } from "@/lib/entityTypes"
 import { entityDisplayName as catalogEntityLabel } from "@/lib/entityRegistry"
 import { useProjectCatalogScope } from "@/lib/catalogNavigation"
 
-const LAYOUT_CENTER_X = 500
-const NODE_LAYOUT_WIDTH = 176
-const NODE_LAYOUT_HEIGHT = 56
-const HOP_GAP_X = 28
-const HOP_GAP_Y = 36
-const HUB_GAP_X = 72
-
 type ConnectionGraphNodeData = {
   label: string
   entityType: ConnectionsEntityType
   hop: GraphHop
   isCenter: boolean
   isSelected: boolean
+}
+
+function nodeId(entityType: string, entityId: string | number): string {
+  return `${entityType}-${entityId}`
+}
+
+function parseNodeId(id: string): { entityType: ConnectionsEntityType; entityId: string } | null {
+  const match = id.match(/^(person|location|organization|work)-(.+)$/)
+  if (!match) return null
+  return { entityType: match[1] as ConnectionsEntityType, entityId: match[2] }
+}
+
+function buildGraphLayout(
+  center: GraphEntityRef,
+  connections: Connection[],
+  selection: GraphSelection | null,
+): { nodes: Node<ConnectionGraphNodeData>[]; edges: Edge[] } {
+  const centerKey = entityRefKey(center)
+  const neighborKeys: string[] = []
+  const neighborMeta = new Map<string, GraphEntityRef>()
+
+  for (const conn of connections) {
+    const neighbor = neighborFromConnection(conn, center)
+    if (!neighbor) continue
+    const key = entityRefKey(neighbor)
+    if (!neighborMeta.has(key)) {
+      neighborMeta.set(key, neighbor)
+      neighborKeys.push(key)
+    }
+  }
+
+  neighborKeys.sort((a, b) =>
+    (neighborMeta.get(a)?.displayName ?? "").localeCompare(
+      neighborMeta.get(b)?.displayName ?? "",
+      undefined,
+      { sensitivity: "base" },
+    ),
+  )
+
+  const { centerX, centerY, neighborTopY } = egoGraphLayoutMetrics(neighborKeys.length)
+  const positions = layoutNeighborGrid(neighborKeys, centerX, neighborTopY)
+  positions.set(centerKey, { x: centerX, y: centerY })
+
+  const selectedNodeId =
+    selection?.kind === "node"
+      ? nodeId(selection.entityType, selection.entityId)
+      : null
+  const selectedConnectionIds =
+    selection?.kind === "edge" ? new Set(selection.connectionIds) : null
+
+  const nodes: Node<ConnectionGraphNodeData>[] = [
+    {
+      id: nodeId(center.entityType, center.entityId),
+      type: "connectionGraph",
+      position: {
+        x: centerX - GRAPH_NODE_LAYOUT_WIDTH / 2,
+        y: centerY - GRAPH_NODE_LAYOUT_HEIGHT / 2,
+      },
+      data: {
+        label: center.displayName,
+        entityType: center.entityType,
+        hop: 0,
+        isCenter: true,
+        isSelected: selectedNodeId === nodeId(center.entityType, center.entityId),
+      },
+      selected: selectedNodeId === nodeId(center.entityType, center.entityId),
+    },
+    ...neighborKeys.map((key) => {
+      const ref = neighborMeta.get(key)!
+      const pos = positions.get(key) ?? { x: centerX, y: centerY }
+      const id = nodeId(ref.entityType, ref.entityId)
+      return {
+        id,
+        type: "connectionGraph" as const,
+        position: {
+          x: pos.x - GRAPH_NODE_LAYOUT_WIDTH / 2,
+          y: pos.y - GRAPH_NODE_LAYOUT_HEIGHT / 2,
+        },
+        data: {
+          label: ref.displayName,
+          entityType: ref.entityType,
+          hop: 1 as GraphHop,
+          isCenter: false,
+          isSelected: id === selectedNodeId,
+        },
+        selected: id === selectedNodeId,
+      }
+    }),
+  ]
+
+  const edges: Edge[] = Array.from(groupConnectionsByDirectedEdge(connections).entries()).map(
+    ([bundleKey, bundleConnections]) => {
+      const conn = bundleConnections[0]!
+      const connectionIds = bundleConnections.map((row) => row.id)
+      const isSelected = connectionIds.some((id) => selectedConnectionIds?.has(id))
+      const strokeColor = "hsl(var(--primary))"
+      return {
+        id: `bundle-${bundleKey}`,
+        source: nodeId(conn.from_entity_type, conn.from_entity_id),
+        target: nodeId(conn.to_entity_type, conn.to_entity_id),
+        label: bundleEdgeLabel(bundleConnections),
+        data: { connectionIds },
+        type: "smoothstep",
+        pathOptions: { borderRadius: 16, offset: 12 },
+        animated: false,
+        selected: isSelected,
+        style: {
+          stroke: strokeColor,
+          strokeWidth: isSelected ? 3 : 2,
+          opacity: 1,
+        },
+        labelStyle: {
+          fill: "hsl(var(--foreground))",
+          fontSize: 11,
+          fontWeight: 600,
+        },
+        labelBgStyle: {
+          fill: "hsl(var(--background))",
+          fillOpacity: 0.95,
+        },
+        labelBgPadding: [8, 4] as [number, number],
+        labelBgBorderRadius: 6,
+        markerEnd: {
+          type: MarkerType.ArrowClosed,
+          color: strokeColor,
+          width: 16,
+          height: 16,
+        },
+      }
+    },
+  )
+
+  return { nodes, edges }
 }
 
 const ENTITY_ICON: Record<ConnectionsEntityType, typeof User> = {
@@ -63,333 +193,11 @@ const ENTITY_RING_CLASS: Record<ConnectionsEntityType, string> = {
   work: "border-amber-200 bg-amber-50 text-amber-950",
 }
 
-function nodeId(entityType: string, entityId: string | number): string {
-  return `${entityType}-${entityId}`
-}
-
-function parseNodeId(id: string): { entityType: ConnectionsEntityType; entityId: string } | null {
-  const match = id.match(/^(person|location|organization|work)-(.+)$/)
-  if (!match) return null
-  return { entityType: match[1] as ConnectionsEntityType, entityId: match[2] }
-}
-
-function entityFromConnectionEnd(
-  conn: Connection,
-  side: "from" | "to",
-): GraphEntityRef {
-  if (side === "from") {
-    return {
-      entityType: conn.from_entity_type as ConnectionsEntityType,
-      entityId: String(conn.from_entity_id),
-      displayName: conn.from_display_name,
-    }
-  }
-  return {
-    entityType: conn.to_entity_type as ConnectionsEntityType,
-    entityId: String(conn.to_entity_id),
-    displayName: conn.to_display_name,
-  }
-}
-
-function hop1AnchorKey(
-  hop2Key: string,
-  connections: Connection[],
-  center: GraphEntityRef,
-  hop1Keys: ReadonlySet<string>,
-): string | null {
-  for (const conn of connections) {
-    if (classifyConnectionHop(conn, center) !== 2) continue
-    const ends = [entityFromConnectionEnd(conn, "from"), entityFromConnectionEnd(conn, "to")]
-    if (!ends.some((end) => entityRefKey(end) === hop2Key)) continue
-    for (const end of ends) {
-      const key = entityRefKey(end)
-      if (hop1Keys.has(key)) return key
-    }
-  }
-  return null
-}
-
-function gridColumns(count: number): number {
-  if (count <= 1) return 1
-  if (count <= 4) return 2
-  if (count <= 9) return 3
-  if (count <= 16) return 4
-  if (count <= 25) return 5
-  return 6
-}
-
-function gridWidth(cols: number, count: number): number {
-  const itemsInWidestRow = Math.min(cols, count)
-  if (itemsInWidestRow <= 1) return NODE_LAYOUT_WIDTH
-  return (itemsInWidestRow - 1) * (NODE_LAYOUT_WIDTH + HOP_GAP_X) + NODE_LAYOUT_WIDTH
-}
-
-function gridHeight(rows: number): number {
-  if (rows <= 1) return NODE_LAYOUT_HEIGHT
-  return (rows - 1) * (NODE_LAYOUT_HEIGHT + HOP_GAP_Y) + NODE_LAYOUT_HEIGHT
-}
-
-function layoutGrid(
-  keys: string[],
-  centerX: number,
-  topY: number,
-): Map<string, { x: number; y: number }> {
-  const positions = new Map<string, { x: number; y: number }>()
-  if (keys.length === 0) return positions
-
-  const cols = gridColumns(keys.length)
-  const rows = Math.ceil(keys.length / cols)
-
-  keys.forEach((key, index) => {
-    const row = Math.floor(index / cols)
-    const col = index % cols
-    const itemsInRow = Math.min(cols, keys.length - row * cols)
-    const rowWidth = gridWidth(cols, itemsInRow)
-    const x = centerX - rowWidth / 2 + col * (NODE_LAYOUT_WIDTH + HOP_GAP_X)
-    const y = topY + row * (NODE_LAYOUT_HEIGHT + HOP_GAP_Y)
-    positions.set(key, { x, y })
-  })
-
-  return positions
-}
-
-function buildGraphLayout(
-  center: GraphEntityRef,
-  connections: Connection[],
-  selection: GraphSelection | null,
-): { nodes: Node<ConnectionGraphNodeData>[]; edges: Edge[] } {
-  const centerKey = entityRefKey(center)
-  const nodeMeta = new Map<string, { ref: GraphEntityRef; hop: GraphHop }>()
-
-  nodeMeta.set(centerKey, { ref: center, hop: 0 })
-
-  for (const conn of connections) {
-    const hop = classifyConnectionHop(conn, center)
-    const ends = [entityFromConnectionEnd(conn, "from"), entityFromConnectionEnd(conn, "to")]
-    for (const end of ends) {
-      const key = entityRefKey(end)
-      if (key === centerKey) continue
-      const existing = nodeMeta.get(key)
-      const nextHop = hop === 1 ? 1 : Math.max(existing?.hop ?? 2, 2)
-      if (!existing) {
-        nodeMeta.set(key, { ref: end, hop: nextHop as GraphHop })
-      } else if (nextHop < existing.hop) {
-        nodeMeta.set(key, { ...existing, hop: nextHop as GraphHop })
-      }
-    }
-  }
-
-  const hop1Keys = Array.from(nodeMeta.entries())
-    .filter(([, meta]) => meta.hop === 1)
-    .map(([key]) => key)
-    .sort((a, b) =>
-      (nodeMeta.get(a)?.ref.displayName ?? "").localeCompare(
-        nodeMeta.get(b)?.ref.displayName ?? "",
-        undefined,
-        { sensitivity: "base" },
-      ),
-    )
-
-  const hop2Keys = Array.from(nodeMeta.entries())
-    .filter(([, meta]) => meta.hop === 2)
-    .map(([key]) => key)
-
-  const hop1KeySet = new Set(hop1Keys)
-  const hop2ByHop1 = new Map<string, string[]>()
-  const orphanHop2: string[] = []
-
-  for (const key of hop2Keys) {
-    const anchor = hop1AnchorKey(key, connections, center, hop1KeySet)
-    if (anchor) {
-      const bucket = hop2ByHop1.get(anchor) ?? []
-      bucket.push(key)
-      hop2ByHop1.set(anchor, bucket)
-    } else {
-      orphanHop2.push(key)
-    }
-  }
-
-  for (const [anchor, group] of hop2ByHop1) {
-    group.sort((a, b) =>
-      (nodeMeta.get(a)?.ref.displayName ?? "").localeCompare(
-        nodeMeta.get(b)?.ref.displayName ?? "",
-        undefined,
-        { sensitivity: "base" },
-      ),
-    )
-    hop2ByHop1.set(anchor, group)
-  }
-  orphanHop2.sort((a, b) =>
-    (nodeMeta.get(a)?.ref.displayName ?? "").localeCompare(
-      nodeMeta.get(b)?.ref.displayName ?? "",
-      undefined,
-      { sensitivity: "base" },
-    ),
-  )
-
-  type HubPlan = {
-    hop1Key: string
-    hop2Keys: string[]
-    cols: number
-    rows: number
-    width: number
-    height: number
-  }
-
-  const hubPlans: HubPlan[] = hop1Keys.map((hop1Key) => {
-    const group = hop2ByHop1.get(hop1Key) ?? []
-    const cols = gridColumns(group.length)
-    const rows = Math.max(1, Math.ceil(group.length / cols))
-    return {
-      hop1Key,
-      hop2Keys: group,
-      cols,
-      rows: group.length === 0 ? 0 : rows,
-      width: gridWidth(cols, group.length),
-      height: group.length === 0 ? 0 : gridHeight(rows),
-    }
-  })
-
-  if (orphanHop2.length > 0) {
-    const cols = gridColumns(orphanHop2.length)
-    const rows = Math.ceil(orphanHop2.length / cols)
-    hubPlans.push({
-      hop1Key: "__orphans__",
-      hop2Keys: orphanHop2,
-      cols,
-      rows,
-      width: gridWidth(cols, orphanHop2.length),
-      height: gridHeight(rows),
-    })
-  }
-
-  hubPlans.sort((a, b) => b.hop2Keys.length - a.hop2Keys.length)
-
-  const totalHubWidth = hubPlans.reduce(
-    (sum, plan, index) => sum + plan.width + (index > 0 ? HUB_GAP_X : 0),
-    0,
-  )
-  const maxHop2Height = Math.max(0, ...hubPlans.map((plan) => plan.height))
-  const centerY = 120 + maxHop2Height + NODE_LAYOUT_HEIGHT + HOP_GAP_Y + NODE_LAYOUT_HEIGHT + 48
-  const hop1Y = centerY - NODE_LAYOUT_HEIGHT - HOP_GAP_Y - NODE_LAYOUT_HEIGHT
-  const hop2TopY = 80
-
-  const positions = new Map<string, { x: number; y: number }>()
-  positions.set(centerKey, { x: LAYOUT_CENTER_X, y: centerY })
-
-  let cursorX = LAYOUT_CENTER_X - totalHubWidth / 2
-  for (const plan of hubPlans) {
-    const hubX = cursorX + plan.width / 2
-
-    if (plan.hop1Key !== "__orphans__") {
-      positions.set(plan.hop1Key, { x: hubX, y: hop1Y })
-    }
-
-    if (plan.hop2Keys.length > 0) {
-      const gridPositions = layoutGrid(plan.hop2Keys, hubX, hop2TopY)
-      for (const [key, pos] of gridPositions) {
-        positions.set(key, pos)
-      }
-    }
-
-    cursorX += plan.width + HUB_GAP_X
-  }
-
-  // Single hop-1 with no hop-2: keep hub centered above subject.
-  if (hop1Keys.length === 1 && hop2Keys.length === 0) {
-    positions.set(hop1Keys[0], { x: LAYOUT_CENTER_X, y: hop1Y })
-  }
-
-  const selectedNodeId =
-    selection?.kind === "node"
-      ? nodeId(selection.entityType, selection.entityId)
-      : null
-  const selectedConnectionIds =
-    selection?.kind === "edge" ? new Set(selection.connectionIds) : null
-
-  const nodes: Node<ConnectionGraphNodeData>[] = Array.from(nodeMeta.entries()).map(
-    ([key, meta]) => {
-      const colon = key.indexOf(":")
-      const entityType = key.slice(0, colon) as ConnectionsEntityType
-      const entityId = key.slice(colon + 1)
-      const pos = positions.get(key) ?? { x: LAYOUT_CENTER_X, y: centerY }
-      const id = nodeId(entityType, entityId)
-      return {
-        id,
-        type: "connectionGraph",
-        position: { x: pos.x - NODE_LAYOUT_WIDTH / 2, y: pos.y - NODE_LAYOUT_HEIGHT / 2 },
-        data: {
-          label: meta.ref.displayName,
-          entityType,
-          hop: meta.hop,
-          isCenter: key === centerKey,
-          isSelected: id === selectedNodeId,
-        },
-        selected: id === selectedNodeId,
-      }
-    },
-  )
-
-  const edges: Edge[] = Array.from(groupConnectionsByDirectedEdge(connections).entries()).map(
-    ([bundleKey, bundleConnections]) => {
-      const conn = bundleConnections[0]!
-      const hop = Math.min(
-        ...bundleConnections.map((row) => classifyConnectionHop(row, center)),
-      ) as GraphHop
-      const showLabel = hop === 1
-      const connectionIds = bundleConnections.map((row) => row.id)
-      const isSelected = connectionIds.some((id) => selectedConnectionIds?.has(id))
-      const strokeColor =
-        hop === 1 ? "hsl(var(--primary))" : "hsl(var(--muted-foreground) / 0.45)"
-      return {
-        id: `bundle-${bundleKey}`,
-        source: nodeId(conn.from_entity_type, conn.from_entity_id),
-        target: nodeId(conn.to_entity_type, conn.to_entity_id),
-        label: showLabel ? bundleEdgeLabel(bundleConnections) : undefined,
-        data: { connectionIds },
-        type: "smoothstep",
-        pathOptions: { borderRadius: 16, offset: hop === 1 ? 12 : 4 },
-        animated: false,
-        selected: isSelected,
-        style: {
-          stroke: strokeColor,
-          strokeWidth: isSelected ? (hop === 1 ? 3 : 2) : hop === 1 ? 2 : 1,
-          opacity: isSelected ? 1 : hop === 1 ? 1 : 0.7,
-        },
-        labelStyle: showLabel
-          ? {
-              fill: "hsl(var(--foreground))",
-              fontSize: 11,
-              fontWeight: 600,
-            }
-          : undefined,
-        labelBgStyle: showLabel
-          ? {
-              fill: "hsl(var(--background))",
-              fillOpacity: 0.95,
-            }
-          : undefined,
-        labelBgPadding: showLabel ? ([8, 4] as [number, number]) : undefined,
-        labelBgBorderRadius: showLabel ? 6 : undefined,
-        markerEnd: {
-          type: MarkerType.ArrowClosed,
-          color: strokeColor,
-          width: hop === 1 ? 16 : 12,
-          height: hop === 1 ? 16 : 12,
-        },
-      }
-    },
-  )
-
-  return { nodes, edges }
-}
-
 const ConnectionGraphNode = memo(function ConnectionGraphNode({
   data,
 }: NodeProps<ConnectionGraphNodeData>) {
   const Icon = ENTITY_ICON[data.entityType]
   const typeLabel = catalogEntityLabel(data.entityType)
-  const isLeaf = data.hop === 2
   return (
     <div
       className={cn(
@@ -398,7 +206,6 @@ const ConnectionGraphNode = memo(function ConnectionGraphNode({
           ? "border-primary bg-primary text-primary-foreground ring-2 ring-primary/20"
           : ENTITY_RING_CLASS[data.entityType],
         data.isSelected && !data.isCenter && "ring-2 ring-primary/50 shadow-md",
-        isLeaf && "opacity-95",
       )}
     >
       <Handle

--- a/apps/stylebook-ui/src/components/ConnectionsSection.tsx
+++ b/apps/stylebook-ui/src/components/ConnectionsSection.tsx
@@ -203,7 +203,6 @@ export default function ConnectionsSection({
         },
         {
           includeClosed: false,
-          expandHops: entityType === "person" ? 2 : 1,
         },
       )
       if (requestId !== graphRequestSeq.current) return
@@ -605,7 +604,17 @@ export default function ConnectionsSection({
                     Loading graph...
                   </div>
                 ) : (
-                <ConnectionsGraph
+                <>
+                  {graphNeighborhood &&
+                  (graphNeighborhood.skippedNeighborCount > 0 ||
+                    graphNeighborhood.totalCount > graphNeighborhood.connections.length) ? (
+                    <p className="mb-2 text-xs text-muted-foreground">
+                      Showing {graphNeighborhood.displayedNeighborCount} connected{" "}
+                      {graphNeighborhood.displayedNeighborCount === 1 ? "entry" : "entries"} in the
+                      graph. Use List to browse all {graphNeighborhood.totalCount} connections.
+                    </p>
+                  ) : null}
+                  <ConnectionsGraph
                   entityType={entityType}
                   entityId={entityId}
                   entityDisplayName={entityDisplayName}
@@ -615,6 +624,7 @@ export default function ConnectionsSection({
                   neighborhood={graphNeighborhood ?? EMPTY_CONNECTION_NEIGHBORHOOD}
                   onConnectionsChanged={refreshConnections}
                 />
+                </>
                 )}
               </TabsContent>
             </Tabs>

--- a/apps/stylebook-ui/src/components/Layout.tsx
+++ b/apps/stylebook-ui/src/components/Layout.tsx
@@ -272,7 +272,7 @@ export default function Layout({ children, headerContent }: LayoutProps) {
 
   useEffect(() => {
     void loadWorkspaces()
-  }, [loadWorkspaces, location.pathname])
+  }, [loadWorkspaces])
 
   useEffect(() => {
     const onChanged = () => {

--- a/apps/stylebook-ui/src/lib/connectionGraph.test.ts
+++ b/apps/stylebook-ui/src/lib/connectionGraph.test.ts
@@ -5,11 +5,14 @@ import {
   classifyConnectionHop,
   connectionsTouchingEntity,
   dedupeConnections,
+  egoGraphLayoutMetrics,
   formatNatureLabel,
+  gridColumns,
   groupConnectionsByDirectedEdge,
+  layoutNeighborGrid,
   neighborFromConnection,
   otherEndFromConnection,
-  selectNeighborsForHop2Expansion,
+  selectConnectionsForGraphDisplay,
   type GraphEntityRef,
 } from "@/lib/connectionGraph"
 import type { Connection } from "@/lib/stylebook-api/connections"
@@ -59,18 +62,42 @@ describe("connectionGraph", () => {
     expect(rows.map((r) => r.id)).toEqual([1, 2])
   })
 
-  it("prioritizes organizations when capping hop-2 expansion", () => {
-    const neighbors: GraphEntityRef[] = [
-      { entityType: "location", entityId: "l1", displayName: "Alpha Loc" },
-      { entityType: "organization", entityId: "o1", displayName: "Zeta Org" },
-      { entityType: "person", entityId: "p1", displayName: "Beta Person" },
+  it("prioritizes organizations when capping graph display", () => {
+    const center: GraphEntityRef = {
+      entityType: "person",
+      entityId: "peggy",
+      displayName: "Peggy Buffington",
+    }
+    const rows = [
+      conn({
+        id: 1,
+        from_entity_id: "peggy",
+        to_entity_type: "location",
+        to_entity_id: "l1",
+        to_display_name: "Alpha Loc",
+      }),
+      conn({
+        id: 2,
+        from_entity_id: "peggy",
+        to_entity_id: "o1",
+        to_display_name: "Zeta Org",
+      }),
+      conn({
+        id: 3,
+        from_entity_id: "peggy",
+        to_entity_type: "person",
+        to_entity_id: "p1",
+        to_display_name: "Beta Person",
+      }),
     ]
-    const { selected, skipped } = selectNeighborsForHop2Expansion(neighbors, 2)
-    expect(selected.map((n) => n.entityId)).toEqual(["o1", "p1"])
-    expect(skipped).toBe(1)
+    const { selected, displayedNeighborCount, skippedNeighborCount } =
+      selectConnectionsForGraphDisplay(rows, center, 2)
+    expect(displayedNeighborCount).toBe(2)
+    expect(skippedNeighborCount).toBe(1)
+    expect(selected.map((row) => row.to_entity_id)).toEqual(["o1", "p1"])
   })
 
-  it("classifies hop-1 vs hop-2 edges", () => {
+  it("classifies direct connections as hop 1 and others as hop 0", () => {
     const center = { entityType: "person" as const, entityId: "peggy" }
     expect(
       classifyConnectionHop(
@@ -93,7 +120,25 @@ describe("connectionGraph", () => {
         }),
         center,
       ),
-    ).toBe(2)
+    ).toBe(0)
+  })
+
+  it("lays out neighbors in a compact grid above the center", () => {
+    expect(gridColumns(1)).toBe(1)
+    expect(gridColumns(5)).toBe(3)
+    expect(gridColumns(20)).toBe(5)
+
+    const keys = ["organization:o1", "person:p1", "location:l1"]
+    const positions = layoutNeighborGrid(keys, 500, 48)
+    expect(positions.size).toBe(3)
+    expect(positions.get("organization:o1")).toEqual({ x: 310, y: 48 })
+    expect(positions.get("person:p1")).toEqual({ x: 514, y: 48 })
+    expect(positions.get("location:l1")).toEqual({ x: 412, y: 140 })
+
+    const metrics = egoGraphLayoutMetrics(3)
+    expect(metrics.centerX).toBe(500)
+    expect(metrics.neighborTopY).toBe(48)
+    expect(metrics.centerY).toBeGreaterThan(metrics.neighborTopY)
   })
 
   it("formats nature labels for display", () => {

--- a/apps/stylebook-ui/src/lib/connectionGraph.ts
+++ b/apps/stylebook-ui/src/lib/connectionGraph.ts
@@ -7,11 +7,12 @@ import {
   type Connection,
 } from "@/lib/stylebook-api/connections"
 
-export const GRAPH_HOP1_LIMIT = 500
-export const GRAPH_HOP2_NEIGHBOR_CAP = 18
-export const GRAPH_HOP2_PER_NEIGHBOR_LIMIT = 40
+/** Max connections fetched before prioritizing neighbors for the graph. */
+export const GRAPH_HOP1_FETCH_LIMIT = 128
+/** Max unique neighbors rendered in the ego graph. */
+export const GRAPH_HOP1_DISPLAY_CAP = 32
 
-export type GraphHop = 0 | 1 | 2
+export type GraphHop = 0 | 1
 
 export interface GraphEntityRef {
   entityType: EntityType
@@ -21,18 +22,19 @@ export interface GraphEntityRef {
 
 export interface ConnectionNeighborhood {
   connections: Connection[]
-  hop1ConnectionCount: number
-  hop2ConnectionCount: number
-  neighborsExpanded: number
-  neighborsSkipped: number
+  /** Total open connections for the center entity (from API). */
+  totalCount: number
+  /** Unique neighbors represented in `connections`. */
+  displayedNeighborCount: number
+  /** Unique neighbors omitted because of `GRAPH_HOP1_DISPLAY_CAP`. */
+  skippedNeighborCount: number
 }
 
 export const EMPTY_CONNECTION_NEIGHBORHOOD: ConnectionNeighborhood = {
   connections: [],
-  hop1ConnectionCount: 0,
-  hop2ConnectionCount: 0,
-  neighborsExpanded: 0,
-  neighborsSkipped: 0,
+  totalCount: 0,
+  displayedNeighborCount: 0,
+  skippedNeighborCount: 0,
 }
 
 export function entityRefKey(ref: Pick<GraphEntityRef, "entityType" | "entityId">): string {
@@ -80,72 +82,76 @@ export function dedupeConnections(connections: Connection[]): Connection[] {
   return out
 }
 
-function neighborExpansionPriority(ref: GraphEntityRef): number {
+function neighborDisplayPriority(ref: GraphEntityRef): number {
   if (ref.entityType === "organization") return 0
   if (ref.entityType === "person") return 1
   if (ref.entityType === "location") return 2
   return 3
 }
 
-export function selectNeighborsForHop2Expansion(
-  neighbors: GraphEntityRef[],
-  cap: number = GRAPH_HOP2_NEIGHBOR_CAP,
-): { selected: GraphEntityRef[]; skipped: number } {
-  const unique = new Map<string, GraphEntityRef>()
-  for (const ref of neighbors) {
-    unique.set(entityRefKey(ref), ref)
+export function selectConnectionsForGraphDisplay(
+  connections: Connection[],
+  center: GraphEntityRef,
+  cap: number = GRAPH_HOP1_DISPLAY_CAP,
+): {
+  selected: Connection[]
+  displayedNeighborCount: number
+  skippedNeighborCount: number
+} {
+  const byNeighbor = new Map<string, { ref: GraphEntityRef; connections: Connection[] }>()
+  for (const conn of connections) {
+    const neighbor = neighborFromConnection(conn, center)
+    if (!neighbor) continue
+    const key = entityRefKey(neighbor)
+    const bucket = byNeighbor.get(key)
+    if (bucket) {
+      bucket.connections.push(conn)
+    } else {
+      byNeighbor.set(key, { ref: neighbor, connections: [conn] })
+    }
   }
-  const sorted = Array.from(unique.values()).sort((a, b) => {
-    const priority = neighborExpansionPriority(a) - neighborExpansionPriority(b)
+
+  const groups = Array.from(byNeighbor.values()).sort((a, b) => {
+    const priority = neighborDisplayPriority(a.ref) - neighborDisplayPriority(b.ref)
     if (priority !== 0) return priority
-    return a.displayName.localeCompare(b.displayName, undefined, { sensitivity: "base" })
+    return a.ref.displayName.localeCompare(b.ref.displayName, undefined, {
+      sensitivity: "base",
+    })
   })
-  if (sorted.length <= cap) {
-    return { selected: sorted, skipped: 0 }
+
+  const picked = groups.slice(0, cap)
+  const skippedNeighborCount = Math.max(0, groups.length - picked.length)
+  return {
+    selected: picked.flatMap((group) => group.connections),
+    displayedNeighborCount: picked.length,
+    skippedNeighborCount,
   }
-  return { selected: sorted.slice(0, cap), skipped: sorted.length - cap }
 }
 
 async function listConnectionsForEntity(
   stylebookSlug: string,
   ref: Pick<GraphEntityRef, "entityType" | "entityId">,
   options: { limit: number; includeClosed?: boolean },
-): Promise<Connection[]> {
+): Promise<{ connections: Connection[]; total: number }> {
   const canonicalId = String(ref.entityId)
   const fetchOptions = { limit: options.limit, offset: 0, includeClosed: options.includeClosed }
   if (ref.entityType === "person") {
-    return (await listStylebookConnectionsForPerson(stylebookSlug, canonicalId, fetchOptions))
-      .connections
+    const res = await listStylebookConnectionsForPerson(stylebookSlug, canonicalId, fetchOptions)
+    return { connections: res.connections, total: res.total }
   }
   if (ref.entityType === "organization") {
-    return (
-      await listStylebookConnectionsForOrganization(stylebookSlug, canonicalId, fetchOptions)
-    ).connections
+    const res = await listStylebookConnectionsForOrganization(
+      stylebookSlug,
+      canonicalId,
+      fetchOptions,
+    )
+    return { connections: res.connections, total: res.total }
   }
   if (ref.entityType === "location") {
-    return (await listStylebookConnectionsForLocation(stylebookSlug, canonicalId, fetchOptions))
-      .connections
+    const res = await listStylebookConnectionsForLocation(stylebookSlug, canonicalId, fetchOptions)
+    return { connections: res.connections, total: res.total }
   }
-  return []
-}
-
-async function mapConcurrent<T, R>(
-  items: T[],
-  concurrency: number,
-  fn: (item: T) => Promise<R>,
-): Promise<R[]> {
-  if (items.length === 0) return []
-  const results: R[] = new Array(items.length)
-  let index = 0
-  const workers = Array.from({ length: Math.min(concurrency, items.length) }, async () => {
-    while (index < items.length) {
-      const current = index
-      index += 1
-      results[current] = await fn(items[current])
-    }
-  })
-  await Promise.all(workers)
-  return results
+  return { connections: [], total: 0 }
 }
 
 export async function fetchConnectionNeighborhood(
@@ -153,70 +159,22 @@ export async function fetchConnectionNeighborhood(
   center: GraphEntityRef,
   options?: {
     includeClosed?: boolean
-    expandHops?: 1 | 2
-    hop2NeighborCap?: number
+    displayCap?: number
   },
 ): Promise<ConnectionNeighborhood> {
-  const expandHops = options?.expandHops ?? 1
-  const hop1 = await listConnectionsForEntity(stylebookSlug, center, {
-    limit: GRAPH_HOP1_LIMIT,
+  const { connections: fetched, total } = await listConnectionsForEntity(stylebookSlug, center, {
+    limit: GRAPH_HOP1_FETCH_LIMIT,
     includeClosed: options?.includeClosed,
   })
 
-  if (expandHops < 2) {
-    return {
-      connections: hop1,
-      hop1ConnectionCount: hop1.length,
-      hop2ConnectionCount: 0,
-      neighborsExpanded: 0,
-      neighborsSkipped: 0,
-    }
-  }
-
-  const hop1Neighbors = hop1
-    .map((conn) => neighborFromConnection(conn, center))
-    .filter((ref): ref is GraphEntityRef => ref !== null)
-
-  const { selected, skipped } = selectNeighborsForHop2Expansion(
-    hop1Neighbors,
-    options?.hop2NeighborCap ?? GRAPH_HOP2_NEIGHBOR_CAP,
-  )
-
-  const hop2Batches = await mapConcurrent(selected, 6, (neighbor) =>
-    listConnectionsForEntity(stylebookSlug, neighbor, {
-      limit: GRAPH_HOP2_PER_NEIGHBOR_LIMIT,
-      includeClosed: options?.includeClosed,
-    }),
-  )
-
-  const hop2: Connection[] = []
-  for (const batch of hop2Batches) {
-    for (const conn of batch) {
-      const fromKey = entityRefKey({
-        entityType: conn.from_entity_type as EntityType,
-        entityId: String(conn.from_entity_id),
-      })
-      const toKey = entityRefKey({
-        entityType: conn.to_entity_type as EntityType,
-        entityId: String(conn.to_entity_id),
-      })
-      if (fromKey === entityRefKey(center) || toKey === entityRefKey(center)) {
-        continue
-      }
-      hop2.push(conn)
-    }
-  }
-
-  const merged = dedupeConnections([...hop1, ...hop2])
-  const hop1Ids = new Set(hop1.map((c) => c.id))
-  const hop2Only = merged.filter((c) => !hop1Ids.has(c.id))
+  const { selected, displayedNeighborCount, skippedNeighborCount } =
+    selectConnectionsForGraphDisplay(fetched, center, options?.displayCap ?? GRAPH_HOP1_DISPLAY_CAP)
 
   return {
-    connections: merged,
-    hop1ConnectionCount: hop1.length,
-    hop2ConnectionCount: hop2Only.length,
-    neighborsExpanded: selected.length,
-    neighborsSkipped: skipped,
+    connections: selected,
+    totalCount: total,
+    displayedNeighborCount,
+    skippedNeighborCount,
   }
 }
 
@@ -241,8 +199,77 @@ export function classifyConnectionHop(
   conn: Connection,
   center: Pick<GraphEntityRef, "entityType" | "entityId">,
 ): GraphHop {
-  if (connectionTouchesEntity(conn, center)) return 1
-  return 2
+  return connectionTouchesEntity(conn, center) ? 1 : 0
+}
+
+export const GRAPH_NODE_LAYOUT_WIDTH = 176
+export const GRAPH_NODE_LAYOUT_HEIGHT = 56
+const GRAPH_GRID_GAP_X = 28
+const GRAPH_GRID_GAP_Y = 36
+
+export function gridColumns(count: number): number {
+  if (count <= 1) return 1
+  if (count <= 4) return 2
+  if (count <= 9) return 3
+  if (count <= 16) return 4
+  if (count <= 25) return 5
+  return 6
+}
+
+function gridWidth(cols: number, count: number): number {
+  const itemsInWidestRow = Math.min(cols, count)
+  if (itemsInWidestRow <= 1) return GRAPH_NODE_LAYOUT_WIDTH
+  return (
+    (itemsInWidestRow - 1) * (GRAPH_NODE_LAYOUT_WIDTH + GRAPH_GRID_GAP_X) +
+    GRAPH_NODE_LAYOUT_WIDTH
+  )
+}
+
+function gridHeight(rows: number): number {
+  if (rows <= 1) return GRAPH_NODE_LAYOUT_HEIGHT
+  return (rows - 1) * (GRAPH_NODE_LAYOUT_HEIGHT + GRAPH_GRID_GAP_Y) + GRAPH_NODE_LAYOUT_HEIGHT
+}
+
+/** Place neighbor node centers in a compact grid above the subject. */
+export function layoutNeighborGrid(
+  neighborKeys: string[],
+  centerX: number,
+  topY: number,
+): Map<string, { x: number; y: number }> {
+  const positions = new Map<string, { x: number; y: number }>()
+  if (neighborKeys.length === 0) return positions
+
+  const cols = gridColumns(neighborKeys.length)
+  const rows = Math.ceil(neighborKeys.length / cols)
+
+  neighborKeys.forEach((key, index) => {
+    const row = Math.floor(index / cols)
+    const col = index % cols
+    const itemsInRow = Math.min(cols, neighborKeys.length - row * cols)
+    const rowWidth = gridWidth(cols, itemsInRow)
+    const x = centerX - rowWidth / 2 + col * (GRAPH_NODE_LAYOUT_WIDTH + GRAPH_GRID_GAP_X)
+    const y = topY + row * (GRAPH_NODE_LAYOUT_HEIGHT + GRAPH_GRID_GAP_Y)
+    positions.set(key, { x, y })
+  })
+
+  return positions
+}
+
+export function egoGraphLayoutMetrics(neighborCount: number): {
+  centerX: number
+  centerY: number
+  neighborTopY: number
+  canvasMinHeight: number
+} {
+  const cols = gridColumns(neighborCount)
+  const rows = Math.max(1, Math.ceil(Math.max(neighborCount, 1) / cols))
+  const neighborGridHeight = gridHeight(rows)
+  const centerX = 500
+  const neighborTopY = 48
+  const centerY =
+    neighborTopY + neighborGridHeight + GRAPH_NODE_LAYOUT_HEIGHT + GRAPH_GRID_GAP_Y + 24
+  const canvasMinHeight = centerY + GRAPH_NODE_LAYOUT_HEIGHT + 48
+  return { centerX, centerY, neighborTopY, canvasMinHeight }
 }
 
 export function formatNatureLabel(nature?: string | null): string | null {

--- a/apps/stylebook-ui/src/pages/CreateLocation.tsx
+++ b/apps/stylebook-ui/src/pages/CreateLocation.tsx
@@ -573,16 +573,6 @@ export default function CreateLocation() {
                       : null
                   }
                   interactiveWhenEmpty={geometryEditing && geometryAddMode === "point" && !geometryDraft}
-                  tileUrl={
-                    geometryEditing
-                      ? "https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png"
-                      : undefined
-                  }
-                  tileAttribution={
-                    geometryEditing
-                      ? '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/attributions">CARTO</a>'
-                      : undefined
-                  }
                   onMapClick={
                     geometryEditing &&
                     geometryAddMode === "point" &&

--- a/packages/backfield-ui/src/GeometryEditLeafletMap.tsx
+++ b/packages/backfield-ui/src/GeometryEditLeafletMap.tsx
@@ -12,10 +12,6 @@ import {
   type LeafletMapProps,
 } from "./LeafletMap"
 
-const EDIT_TILE = "https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png"
-const EDIT_ATTR =
-  '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/attributions">CARTO</a>'
-
 function isPointGeometry(geometry: Record<string, unknown> | null): geometry is {
   type: "Point"
   coordinates: [number, number]
@@ -149,8 +145,6 @@ export function GeometryEditLeafletMap({
       initialCenter={addModeCenter ?? initialCenter}
       initialZoom={addModeZoom ?? initialZoom}
       interactiveWhenEmpty={geometryEditing && geometryAddMode === "point" && !geometryDraft}
-      tileUrl={geometryEditing ? EDIT_TILE : undefined}
-      tileAttribution={geometryEditing ? EDIT_ATTR : undefined}
       onFeatureClick={onFeatureClick}
       onMapClick={
         geometryEditing &&


### PR DESCRIPTION
## Summary

- Cap Stylebook connection-graph neighbors and lay them out in a compact grid above the center; drop 2-hop expansion so high-degree entities stay readable.
- Replace CARTO basemap tiles with OpenStreetMap (no API key) in the API Playground and shared Leaflet maps.
- Keep Agate/Stylebook left nav mounted across page changes by healing org paths without unmounting routes and sharing one Agate `HubLayout`.

## Project scope check

- [x] This change targets local development / source inspection (production self-hosting is unsupported in this repo)
- [x] Docs under `docs/` updated if behavior, architecture, or operations changed
- [x] First-admin provisioning still uses `backfield init` / `backfield seed` only (no HTTP/env bootstrap paths)

## Test plan

- [ ] `make lint`
- [ ] `make test`
- [x] `make ui-typecheck ui-test` (if UI/TypeScript changed) — ran Stylebook `connectionGraph` unit tests + `tsc`; Agate layout change is structural
- [ ] `make smoke-fast` (if live-stack behavior changed)
- [ ] `make smoke` (if golden-path / provider-dependent runtime changed; configure **Settings → AI models**)
- [ ] Manually: open a high-degree Stylebook entity Connections → Graph; confirm capped grid + notice
- [ ] Manually: API Playground area/H3 maps load without “API KEY REQUIRED”
- [ ] Manually: click between Agate and Stylebook pages; left nav should not flash/reload

## Notes for reviewers

- Graph display cap is 32 unique neighbors (fetch pool 128); full list remains on the List tab.
- Org-prefixed URL heal still runs, but `<Routes>` stays mounted so the shell does not remount.
- API Playground CSP `img-src` now allows `*.tile.openstreetmap.org` instead of CARTO.


Made with [Cursor](https://cursor.com)