### PR TITLE
Agate UX: project Articles search, Runs pagination, per-item stats

### DIFF
--- a/apps/agate-api/src/api/project_processed_items.py
+++ b/apps/agate-api/src/api/project_processed_items.py
@@ -1,0 +1,226 @@
+"""Project-scoped processed-item list and headline/URL search for Agate UI."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+from backfield_db import AgateGraph, AgateProcessedItem, AgateRun, SubstrateArticle
+from backfield_entities.public.keyword_query import article_keyword_tsquery
+from sqlalchemy import String, cast, func, literal, or_
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlmodel import Session, col, select
+
+_GENERIC_HEADLINES = frozenset({"article"})
+_INPUT_HEADLINE_KEYS = ("headline", "title", "input_headline")
+_INPUT_URL_KEYS = ("url",)
+
+
+@dataclass(frozen=True)
+class ProjectProcessedItemRow:
+    id: int
+    run_id: str
+    flow_name: str
+    title: str
+    url: str | None
+    status: str
+    created_at: datetime
+    source_file: str | None
+
+
+def _parse_input_obj(input_json: str | None) -> dict[str, Any]:
+    if not input_json:
+        return {}
+    try:
+        parsed = json.loads(input_json)
+    except json.JSONDecodeError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _string_from_input(input_obj: dict[str, Any], keys: tuple[str, ...]) -> str | None:
+    for key in keys:
+        value = input_obj.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _source_file_label(source_file: str | None) -> str | None:
+    if not source_file or source_file.startswith("inline:"):
+        return None
+    return source_file.rsplit("/", 1)[-1] or source_file
+
+
+def _display_headline(
+    *,
+    article_headline: str | None,
+    input_obj: dict[str, Any],
+) -> str | None:
+    input_hl = _string_from_input(input_obj, _INPUT_HEADLINE_KEYS)
+    sub_hl = article_headline.strip() if isinstance(article_headline, str) else ""
+    if sub_hl and sub_hl.lower() not in _GENERIC_HEADLINES:
+        return sub_hl
+    return input_hl or (sub_hl or None)
+
+
+def resolve_project_item_title_and_url(
+    *,
+    item_id: int,
+    source_file: str | None,
+    input_json: str | None,
+    article_headline: str | None,
+    article_url: str | None,
+) -> tuple[str, str | None]:
+    """Title/URL for a project Articles row (headline primary, source fallback)."""
+    input_obj = _parse_input_obj(input_json)
+    title = _display_headline(article_headline=article_headline, input_obj=input_obj)
+    if not title:
+        title = _source_file_label(source_file) or f"Untitled article #{item_id}"
+
+    url = article_url.strip() if isinstance(article_url, str) and article_url.strip() else None
+    if not url:
+        url = _string_from_input(input_obj, _INPUT_URL_KEYS)
+    return title, url
+
+
+def _json_text_field(column: Any, key: str, *, dialect: str) -> Any:
+    if dialect == "postgresql":
+        return func.jsonb_extract_path_text(cast(column, JSONB), key)
+    return cast(func.json_extract(column, f"$.{key}"), String)
+
+
+def _headline_url_tsvector() -> Any:
+    empty = literal("")
+    space = literal(" ")
+    document = (
+        func.coalesce(SubstrateArticle.headline, empty)
+        .op("||")(space)
+        .op("||")(func.coalesce(SubstrateArticle.url, empty))
+    )
+    return func.to_tsvector("english", document)
+
+
+def _apply_project_item_keyword_filter(stmt: Any, q: str, session: Session) -> Any:
+    """Match headline/URL (article or input) and source_file — never article body."""
+    pattern = f"%{q.strip()}%"
+    bind = session.get_bind()
+    dialect = bind.dialect.name
+
+    input_headline = _json_text_field(AgateProcessedItem.input_json, "headline", dialect=dialect)
+    input_title = _json_text_field(AgateProcessedItem.input_json, "title", dialect=dialect)
+    input_input_headline = _json_text_field(
+        AgateProcessedItem.input_json, "input_headline", dialect=dialect
+    )
+    input_url = _json_text_field(AgateProcessedItem.input_json, "url", dialect=dialect)
+
+    field_matches = [
+        AgateProcessedItem.source_file.ilike(pattern),
+        input_headline.ilike(pattern),
+        input_title.ilike(pattern),
+        input_input_headline.ilike(pattern),
+        input_url.ilike(pattern),
+    ]
+
+    if dialect == "postgresql":
+        vector = _headline_url_tsvector()
+        ts_query = article_keyword_tsquery(q)
+        article_match = vector.op("@@")(ts_query)
+        return stmt.where(or_(article_match, *field_matches))
+
+    return stmt.where(
+        or_(
+            SubstrateArticle.headline.ilike(pattern),
+            SubstrateArticle.url.ilike(pattern),
+            *field_matches,
+        )
+    )
+
+
+def _base_project_items_stmt(project_id: int) -> Any:
+    return (
+        select(
+            AgateProcessedItem.id,
+            AgateProcessedItem.run_id,
+            AgateGraph.name,
+            AgateProcessedItem.status,
+            AgateProcessedItem.created_at,
+            AgateProcessedItem.source_file,
+            AgateProcessedItem.input_json,
+            SubstrateArticle.headline,
+            SubstrateArticle.url,
+        )
+        .join(AgateRun, AgateProcessedItem.run_id == AgateRun.id)
+        .join(AgateGraph, AgateRun.graph_id == AgateGraph.id)
+        .outerjoin(
+            SubstrateArticle,
+            col(AgateProcessedItem.substrate_article_id) == col(SubstrateArticle.id),
+        )
+        .where(AgateGraph.project_id == project_id)
+    )
+
+
+def list_project_processed_items(
+    session: Session,
+    project_id: int,
+    *,
+    q: str | None = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> tuple[list[ProjectProcessedItemRow], int]:
+    """Return recent (or keyword-filtered) processed items for a project."""
+    limit = max(1, min(int(limit), 500))
+    offset = max(0, int(offset))
+    query = (q or "").strip() or None
+
+    stmt = _base_project_items_stmt(project_id)
+    if query:
+        stmt = _apply_project_item_keyword_filter(stmt, query, session)
+
+    count_stmt = select(func.count()).select_from(stmt.subquery())
+    total = int(session.exec(count_stmt).one())
+
+    stmt = (
+        stmt.order_by(col(AgateProcessedItem.created_at).desc(), col(AgateProcessedItem.id).desc())
+        .offset(offset)
+        .limit(limit)
+    )
+    rows = session.exec(stmt).all()
+
+    out: list[ProjectProcessedItemRow] = []
+    for row in rows:
+        (
+            item_id,
+            run_id,
+            flow_name,
+            status,
+            created_at,
+            source_file,
+            input_json,
+            article_headline,
+            article_url,
+        ) = row
+        if item_id is None or not run_id:
+            continue
+        title, url = resolve_project_item_title_and_url(
+            item_id=int(item_id),
+            source_file=source_file,
+            input_json=input_json,
+            article_headline=article_headline,
+            article_url=article_url,
+        )
+        out.append(
+            ProjectProcessedItemRow(
+                id=int(item_id),
+                run_id=str(run_id),
+                flow_name=str(flow_name or ""),
+                title=title,
+                url=url,
+                status=str(status),
+                created_at=created_at,
+                source_file=source_file,
+            )
+        )
+    return out, total

--- a/apps/agate-api/src/api/routers/projects.py
+++ b/apps/agate-api/src/api/routers/projects.py
@@ -346,6 +346,7 @@ class ProjectStatsOut(BaseModel):
     avg_duration_ms_per_item: float | None = None
     slowest_flows: list[SlowestFlowOut] = Field(default_factory=list)
     avg_estimated_ai_cost_per_run: Decimal | None = None
+    avg_estimated_ai_cost_per_item: Decimal | None = None
     top_flows_by_cost: list[TopFlowByCostOut] = Field(default_factory=list)
     avg_estimated_ai_cost_currency: str | None = None
     avg_estimated_ai_cost_incomplete: bool = False
@@ -505,22 +506,26 @@ def _slowest_flows_for_project(
     *,
     limit: int = 5,
 ) -> list[SlowestFlowOut]:
+    """Flows ranked by mean terminal processed-item wall time (succeeded runs only)."""
     if not graph_ids:
         return []
-    run_duration_ms = _run_wall_duration_ms_expr()
+    item_duration_ms = _processed_item_duration_ms_expr()
     rows = session.exec(
         select(
             AgateGraph.id,
             AgateGraph.name,
-            func.avg(run_duration_ms),
+            func.avg(item_duration_ms),
         )
+        .select_from(AgateProcessedItem)
+        .join(AgateRun, AgateProcessedItem.run_id == AgateRun.id)
         .join(AgateGraph, AgateGraph.id == AgateRun.graph_id)
         .where(
             AgateRun.graph_id.in_(graph_ids),
             AgateRun.status == "succeeded",
+            col(AgateProcessedItem.status).in_(_ITEM_TERMINAL_STATUSES),
         )
         .group_by(AgateGraph.id, AgateGraph.name)
-        .order_by(func.avg(run_duration_ms).desc())
+        .order_by(func.avg(item_duration_ms).desc())
         .limit(limit)
     ).all()
     return [
@@ -541,34 +546,40 @@ def _top_flows_by_avg_ai_cost_for_project(
     *,
     limit: int = 5,
 ) -> list[TopFlowByCostOut]:
+    """Flows ranked by mean tracked LLM spend per terminal processed item."""
     if not graph_ids:
         return []
-    per_run_cost = func.coalesce(func.sum(BackfieldAiCallRecord.estimated_cost), 0)
-    per_run_subq = (
+    per_item_cost = func.coalesce(func.sum(BackfieldAiCallRecord.estimated_cost), 0)
+    per_item_subq = (
         select(
-            BackfieldAiCallRecord.run_id.label("run_id"),
-            per_run_cost.label("total_cost"),
+            BackfieldAiCallRecord.processed_item_id.label("item_id"),
+            per_item_cost.label("total_cost"),
         )
-        .where(BackfieldAiCallRecord.project_id == project_id)
-        .group_by(BackfieldAiCallRecord.run_id)
+        .where(
+            BackfieldAiCallRecord.project_id == project_id,
+            BackfieldAiCallRecord.processed_item_id.is_not(None),
+        )
+        .group_by(BackfieldAiCallRecord.processed_item_id)
         .subquery()
     )
-    run_total = func.coalesce(per_run_subq.c.total_cost, 0)
+    item_total = func.coalesce(per_item_subq.c.total_cost, 0)
     rows = session.exec(
         select(
             AgateGraph.id,
             AgateGraph.name,
-            func.avg(run_total),
+            func.avg(item_total),
         )
-        .select_from(AgateRun)
+        .select_from(AgateProcessedItem)
+        .join(AgateRun, AgateProcessedItem.run_id == AgateRun.id)
         .join(AgateGraph, AgateGraph.id == AgateRun.graph_id)
-        .outerjoin(per_run_subq, per_run_subq.c.run_id == AgateRun.id)
+        .outerjoin(per_item_subq, per_item_subq.c.item_id == AgateProcessedItem.id)
         .where(
             AgateRun.graph_id.in_(graph_ids),
             AgateRun.status == "succeeded",
+            col(AgateProcessedItem.status).in_(_ITEM_TERMINAL_STATUSES),
         )
         .group_by(AgateGraph.id, AgateGraph.name)
-        .order_by(func.avg(run_total).desc())
+        .order_by(func.avg(item_total).desc())
         .limit(limit)
     ).all()
     return [
@@ -656,6 +667,53 @@ def _avg_ai_cost_stats_for_succeeded_runs(
     return Decimal(str(avg_cost)), bool(incomplete_flag), currency
 
 
+def _avg_ai_cost_stats_for_terminal_items(
+    session: Session,
+    project_id: int,
+    graph_ids: list[str],
+) -> tuple[Decimal | None, bool, str | None]:
+    """Mean tracked LLM spend per terminal processed item on succeeded runs."""
+    if not graph_ids:
+        return None, False, None
+    succeeded_run_ids = select(AgateRun.id).where(
+        AgateRun.graph_id.in_(graph_ids),
+        AgateRun.status == "succeeded",
+    )
+    per_item_cost = func.coalesce(func.sum(BackfieldAiCallRecord.estimated_cost), 0)
+    per_item_subq = (
+        select(
+            BackfieldAiCallRecord.processed_item_id.label("item_id"),
+            per_item_cost.label("total_cost"),
+            _ai_cost_incomplete_aggregate().label("incomplete"),
+            func.max(BackfieldAiCallRecord.currency).label("currency"),
+        )
+        .where(
+            BackfieldAiCallRecord.project_id == project_id,
+            BackfieldAiCallRecord.processed_item_id.is_not(None),
+        )
+        .group_by(BackfieldAiCallRecord.processed_item_id)
+        .subquery()
+    )
+    item_total = func.coalesce(per_item_subq.c.total_cost, 0)
+    row = session.exec(
+        select(
+            func.avg(item_total),
+            func.max(case((per_item_subq.c.incomplete > 0, 1), else_=0)),
+            func.max(per_item_subq.c.currency),
+        )
+        .select_from(AgateProcessedItem)
+        .outerjoin(per_item_subq, per_item_subq.c.item_id == AgateProcessedItem.id)
+        .where(
+            AgateProcessedItem.run_id.in_(succeeded_run_ids),
+            col(AgateProcessedItem.status).in_(_ITEM_TERMINAL_STATUSES),
+        )
+    ).one()
+    avg_cost, incomplete_flag, currency = row
+    if avg_cost is None:
+        return None, bool(incomplete_flag), currency
+    return Decimal(str(avg_cost)), bool(incomplete_flag), currency
+
+
 def _project_stats(session: Session, p: BackfieldProject) -> ProjectStatsOut:
     graphs = session.exec(
         select(AgateGraph).where(AgateGraph.project_id == p.id)
@@ -718,6 +776,13 @@ def _project_stats(session: Session, p: BackfieldProject) -> ProjectStatsOut:
     avg_ai, ai_incomplete, ai_currency = _avg_ai_cost_stats_for_succeeded_runs(
         session, pid, graph_ids
     )
+    avg_ai_item, ai_item_incomplete, ai_item_currency = (
+        _avg_ai_cost_stats_for_terminal_items(session, pid, graph_ids)
+    )
+    if avg_ai_item is None:
+        avg_ai_item = avg_ai
+        ai_item_incomplete = ai_incomplete
+        ai_item_currency = ai_currency
     slowest_flows = _slowest_flows_for_project(session, graph_ids)
     top_flows_by_cost = _top_flows_by_avg_ai_cost_for_project(session, pid, graph_ids)
 
@@ -733,9 +798,14 @@ def _project_stats(session: Session, p: BackfieldProject) -> ProjectStatsOut:
         avg_duration_ms_per_item=avg_item_duration,
         slowest_flows=slowest_flows,
         avg_estimated_ai_cost_per_run=avg_ai,
+        avg_estimated_ai_cost_per_item=avg_ai_item,
         top_flows_by_cost=top_flows_by_cost,
-        avg_estimated_ai_cost_currency=ai_currency if runs_succeeded > 0 else None,
-        avg_estimated_ai_cost_incomplete=ai_incomplete if runs_succeeded > 0 else False,
+        avg_estimated_ai_cost_currency=(
+            ai_item_currency if runs_succeeded > 0 else None
+        ),
+        avg_estimated_ai_cost_incomplete=(
+            ai_item_incomplete if runs_succeeded > 0 else False
+        ),
     )
 
 

--- a/apps/agate-api/src/api/routers/projects.py
+++ b/apps/agate-api/src/api/routers/projects.py
@@ -11,6 +11,7 @@ from decimal import Decimal
 from typing import Any
 
 from api.deps import get_auth, get_session
+from api.project_processed_items import list_project_processed_items
 from backfield_auth.gate import (
     require_org_admin,
     require_project_access,
@@ -65,6 +66,27 @@ class ProjectEstimatedAiCostOut(BaseModel):
 class AiCostModelBreakdown(BaseModel):
     provider_model_id: str
     estimated_total: Decimal
+
+
+class ProjectProcessedItemOut(BaseModel):
+    """One processed item in a project Articles list (discovery → review)."""
+
+    id: int
+    run_id: str
+    flow_name: str
+    title: str
+    url: str | None = None
+    status: str
+    created_at: datetime
+    source_file: str | None = None
+
+
+class ProjectProcessedItemsPageOut(BaseModel):
+    total: int
+    limit: int
+    offset: int
+    q: str | None = None
+    items: list[ProjectProcessedItemOut]
 
 
 def _settings_dict(project: BackfieldProject) -> dict:
@@ -1013,4 +1035,56 @@ def get_project_estimated_ai_cost(
         incomplete_estimate=incomplete,
         attempt_count=attempt_count,
         model_breakdown=_project_ai_cost_model_breakdown(session, project_id),
+    )
+
+
+@router.get(
+    "/{project_id}/processed-items",
+    response_model=ProjectProcessedItemsPageOut,
+)
+def list_project_processed_items_endpoint(
+    project_id: int,
+    q: str | None = None,
+    limit: int = 50,
+    offset: int = 0,
+    session: Session = Depends(get_session),
+    auth: dict[str, Any] = Depends(get_auth),
+):
+    """List or search processed items in a project (Articles tab discovery)."""
+    require_project_access(session, auth, project_id)
+    p = session.get(BackfieldProject, project_id)
+    if not p:
+        raise HTTPException(404, "Project not found")
+
+    if limit < 1 or limit > 500:
+        raise HTTPException(400, "limit must be between 1 and 500")
+    if offset < 0:
+        raise HTTPException(400, "offset must be >= 0")
+
+    query = (q or "").strip() or None
+    rows, total = list_project_processed_items(
+        session,
+        project_id,
+        q=query,
+        limit=limit,
+        offset=offset,
+    )
+    return ProjectProcessedItemsPageOut(
+        total=total,
+        limit=limit,
+        offset=offset,
+        q=query,
+        items=[
+            ProjectProcessedItemOut(
+                id=row.id,
+                run_id=row.run_id,
+                flow_name=row.flow_name,
+                title=row.title,
+                url=row.url,
+                status=row.status,
+                created_at=row.created_at,
+                source_file=row.source_file,
+            )
+            for row in rows
+        ],
     )

--- a/apps/agate-ui/src/components/project/ProjectDetailArticlesTab.tsx
+++ b/apps/agate-ui/src/components/project/ProjectDetailArticlesTab.tsx
@@ -1,0 +1,257 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import {
+  listProjectProcessedItems,
+  type ProjectProcessedItem,
+} from '@/lib/api'
+import { formatDate } from '@/lib/utils'
+import {
+  AlertTriangle,
+  CheckCircle,
+  Clock,
+  Loader2,
+  Search,
+  XCircle,
+} from 'lucide-react'
+
+const PAGE_SIZE = 50
+const SEARCH_DEBOUNCE_MS = 300
+
+interface ProjectDetailArticlesTabProps {
+  projectId: number
+}
+
+function statusBadgeClass(status: string): string {
+  switch (status) {
+    case 'running':
+      return 'bg-yellow-100 text-yellow-800 border-yellow-200'
+    case 'succeeded':
+      return 'bg-green-100 text-green-800 border-green-200'
+    case 'failed':
+    case 'timed_out':
+      return 'bg-red-100 text-red-800 border-red-200'
+    case 'pending':
+      return 'bg-gray-100 text-gray-800 border-gray-200'
+    default:
+      return 'bg-gray-100 text-gray-800 border-gray-200'
+  }
+}
+
+function statusIcon(status: string) {
+  switch (status) {
+    case 'running':
+      return <Loader2 className="h-4 w-4 animate-spin" />
+    case 'succeeded':
+      return <CheckCircle className="h-4 w-4" />
+    case 'failed':
+    case 'timed_out':
+      return <XCircle className="h-4 w-4" />
+    case 'pending':
+      return <Clock className="h-4 w-4" />
+    default:
+      return <AlertTriangle className="h-4 w-4" />
+  }
+}
+
+function shortRunId(runId: string): string {
+  return runId.length > 8 ? `${runId.slice(0, 8)}…` : runId
+}
+
+export default function ProjectDetailArticlesTab({
+  projectId,
+}: ProjectDetailArticlesTabProps) {
+  const navigate = useNavigate()
+  const [query, setQuery] = useState('')
+  const [debouncedQuery, setDebouncedQuery] = useState('')
+  const [items, setItems] = useState<ProjectProcessedItem[]>([])
+  const [total, setTotal] = useState(0)
+  const [offset, setOffset] = useState(0)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const handle = window.setTimeout(() => {
+      setDebouncedQuery(query.trim())
+      setOffset(0)
+    }, SEARCH_DEBOUNCE_MS)
+    return () => window.clearTimeout(handle)
+  }, [query])
+
+  const loadPage = useCallback(
+    async (pageOffset: number) => {
+      setLoading(true)
+      setError(null)
+      try {
+        const page = await listProjectProcessedItems(projectId, {
+          q: debouncedQuery || null,
+          limit: PAGE_SIZE,
+          offset: pageOffset,
+        })
+        setItems(page.items)
+        setTotal(page.total)
+        setOffset(page.offset)
+      } catch (err) {
+        console.error(err)
+        setError('Could not load articles for this project.')
+        setItems([])
+        setTotal(0)
+      } finally {
+        setLoading(false)
+      }
+    },
+    [projectId, debouncedQuery],
+  )
+
+  useEffect(() => {
+    void loadPage(0)
+  }, [loadPage])
+
+  const hasQuery = debouncedQuery.length > 0
+  const canPrev = offset > 0
+  const canNext = offset + items.length < total
+
+  return (
+    <div className="space-y-4 w-full min-w-0">
+      <p className="text-sm text-muted-foreground mb-1">
+        Find stories processed in this project and open them for review.
+      </p>
+
+      <div className="relative max-w-xl">
+        <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Search by headline or URL"
+          className="pl-9"
+          aria-label="Search articles"
+        />
+      </div>
+
+      {loading ? (
+        <div className="flex items-center justify-center py-12">
+          <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+        </div>
+      ) : error ? (
+        <Card>
+          <CardContent className="py-12">
+            <p className="text-center text-muted-foreground">{error}</p>
+          </CardContent>
+        </Card>
+      ) : items.length === 0 ? (
+        <Card>
+          <CardContent className="py-12">
+            <p className="text-center text-muted-foreground">
+              {hasQuery
+                ? 'No articles match that search.'
+                : 'No articles yet for this project.'}
+            </p>
+          </CardContent>
+        </Card>
+      ) : (
+        <>
+          <Card className="overflow-hidden">
+            <CardContent className="p-0">
+              <div className="w-full overflow-x-auto">
+                <table className="w-full min-w-[720px] text-sm">
+                  <thead className="border-b bg-muted/50">
+                    <tr>
+                      <th className="text-left p-3 sm:p-4 font-medium">Article</th>
+                      <th className="text-left p-3 sm:p-4 font-medium">Status</th>
+                      <th className="text-left p-3 sm:p-4 font-medium hidden sm:table-cell">
+                        Flow
+                      </th>
+                      <th className="text-left p-3 sm:p-4 font-medium hidden md:table-cell">
+                        Run
+                      </th>
+                      <th className="text-left p-3 sm:p-4 font-medium hidden sm:table-cell">
+                        Processed
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {items.map((item) => (
+                      <tr
+                        key={item.id}
+                        className="border-b last:border-b-0 hover:bg-muted/[0.07] cursor-pointer transition-colors"
+                        onClick={() =>
+                          navigate(`/runs/${item.run_id}/items/${item.id}`)
+                        }
+                      >
+                        <td className="p-3 sm:p-4 align-top min-w-0">
+                          <div className="font-medium break-words">{item.title}</div>
+                          {item.url ? (
+                            <div className="text-xs text-muted-foreground mt-1 truncate max-w-[28rem]">
+                              {item.url}
+                            </div>
+                          ) : null}
+                        </td>
+                        <td className="p-3 sm:p-4 align-top">
+                          <Badge
+                            variant="outline"
+                            className={`${statusBadgeClass(item.status)} w-fit`}
+                          >
+                            {statusIcon(item.status)}
+                            <span className="ml-1 capitalize">
+                              {item.status.replace(/_/g, ' ')}
+                            </span>
+                          </Badge>
+                        </td>
+                        <td className="p-3 sm:p-4 text-muted-foreground align-top hidden sm:table-cell">
+                          {item.flow_name || '—'}
+                        </td>
+                        <td
+                          className="p-3 sm:p-4 text-muted-foreground align-top hidden md:table-cell font-mono text-xs"
+                          title={item.run_id}
+                        >
+                          {shortRunId(item.run_id)}
+                        </td>
+                        <td className="p-3 sm:p-4 text-muted-foreground align-top hidden sm:table-cell whitespace-nowrap">
+                          {formatDate(item.created_at, {
+                            dateStyle: 'medium',
+                            timeStyle: 'short',
+                          })}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </CardContent>
+          </Card>
+
+          {total > PAGE_SIZE ? (
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <p className="text-sm text-muted-foreground">
+                Showing {offset + 1}–{offset + items.length} of {total}
+              </p>
+              <div className="flex gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  disabled={!canPrev}
+                  onClick={() => void loadPage(Math.max(0, offset - PAGE_SIZE))}
+                >
+                  Previous
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  disabled={!canNext}
+                  onClick={() => void loadPage(offset + PAGE_SIZE)}
+                >
+                  Next
+                </Button>
+              </div>
+            </div>
+          ) : null}
+        </>
+      )}
+    </div>
+  )
+}

--- a/apps/agate-ui/src/components/project/ProjectDetailRunsTab.tsx
+++ b/apps/agate-ui/src/components/project/ProjectDetailRunsTab.tsx
@@ -32,311 +32,368 @@ export type ProjectDetailRunsTabHandle = {
   refresh: () => Promise<void>
 }
 
-const RUNS_PAGE_SIZE = 100
+const PAGE_SIZE = 50
 
 const ProjectDetailRunsTab = forwardRef<ProjectDetailRunsTabHandle, ProjectDetailRunsTabProps>(
   function ProjectDetailRunsTab({ projectId, onDataChanged }, ref) {
-  const { showConfirm, showError } = useAppMessage()
-  const [runs, setRuns] = useState<Run[]>([])
-  const [graphs, setGraphs] = useState<GraphSummary[]>([])
-  const [loading, setLoading] = useState(true)
-  const [selectedFlow, setSelectedFlow] = useState<string>('all')
-  const [selectedStatus, setSelectedStatus] = useState<string>('all')
-  const [cancellingRuns, setCancellingRuns] = useState<Set<string>>(new Set())
-  const navigate = useNavigate()
+    const { showConfirm, showError } = useAppMessage()
+    const [runs, setRuns] = useState<Run[]>([])
+    const [graphs, setGraphs] = useState<GraphSummary[]>([])
+    const [loading, setLoading] = useState(true)
+    const [offset, setOffset] = useState(0)
+    const [selectedFlow, setSelectedFlow] = useState<string>('all')
+    const [selectedStatus, setSelectedStatus] = useState<string>('all')
+    const [cancellingRuns, setCancellingRuns] = useState<Set<string>>(new Set())
+    const navigate = useNavigate()
 
-  const projectGraphs = useMemo(
-    () => graphs.filter((g) => g.project_id === projectId),
-    [graphs, projectId]
-  )
+    const projectGraphs = useMemo(
+      () => graphs.filter((g) => g.project_id === projectId),
+      [graphs, projectId],
+    )
 
-  const loadData = useCallback(async () => {
-    try {
-      setLoading(true)
-      const [runsData, graphsData] = await Promise.all([
-        listRuns({
+    const fetchRuns = useCallback(
+      async (pageOffset: number) => {
+        return listRuns({
           projectId,
-          limit: RUNS_PAGE_SIZE,
+          limit: PAGE_SIZE,
+          offset: pageOffset,
+          graphId: selectedFlow !== 'all' ? selectedFlow : undefined,
           includeResult: false,
           includeGraphSpecSnapshot: false,
-        }),
-        listGraphSummaries(projectId),
-      ])
-      setRuns(runsData)
-      setGraphs(graphsData)
-    } catch (error) {
-      console.error('Failed to load runs:', error)
-    } finally {
-      setLoading(false)
+        })
+      },
+      [projectId, selectedFlow],
+    )
+
+    const loadPage = useCallback(
+      async (pageOffset: number, options: { loadGraphs?: boolean; spinner?: boolean } = {}) => {
+        const { loadGraphs = false, spinner = true } = options
+        if (spinner) setLoading(true)
+        try {
+          if (loadGraphs) {
+            const [runsData, graphsData] = await Promise.all([
+              fetchRuns(pageOffset),
+              listGraphSummaries(projectId),
+            ])
+            setRuns(runsData)
+            setGraphs(graphsData)
+          } else {
+            setRuns(await fetchRuns(pageOffset))
+          }
+          setOffset(pageOffset)
+        } catch (error) {
+          console.error('Failed to load runs:', error)
+        } finally {
+          if (spinner) setLoading(false)
+        }
+      },
+      [fetchRuns, projectId],
+    )
+
+    // Reload from page 0 when project or flow filter changes.
+    useEffect(() => {
+      void loadPage(0, { loadGraphs: true, spinner: true })
+    }, [projectId, selectedFlow]) // eslint-disable-line react-hooks/exhaustive-deps -- intentional: not on loadPage identity
+
+    const handleRefresh = useCallback(async () => {
+      try {
+        setRuns(await fetchRuns(offset))
+        onDataChanged?.()
+      } catch (e) {
+        console.error(e)
+      }
+    }, [fetchRuns, offset, onDataChanged])
+
+    useImperativeHandle(ref, () => ({ refresh: handleRefresh }), [handleRefresh])
+
+    const handleFlowChange = (value: string) => {
+      setSelectedFlow(value)
     }
-  }, [projectId])
 
-  useEffect(() => {
-    void loadData()
-  }, [loadData])
+    const handleStatusChange = (value: string) => {
+      setSelectedStatus(value)
+      void loadPage(0, { spinner: true })
+    }
 
-  const handleRefresh = useCallback(async () => {
-    try {
-      const runsData = await listRuns({
-        projectId,
-        limit: RUNS_PAGE_SIZE,
-        includeResult: false,
-        includeGraphSpecSnapshot: false,
+    const handleCancelRun = async (runId: string, event: React.MouseEvent) => {
+      event.stopPropagation()
+      const ok = await showConfirm('Cancel this run? Pending and running work will stop.', {
+        title: 'Stop run',
+        confirmLabel: 'Stop run',
+        destructive: true,
       })
-      setRuns(runsData)
-      onDataChanged?.()
-    } catch (e) {
-      console.error(e)
+      if (!ok) return
+      setCancellingRuns((prev) => new Set(prev).add(runId))
+      try {
+        await cancelRun(runId)
+        setRuns(await fetchRuns(offset))
+        onDataChanged?.()
+      } catch (error) {
+        console.error('Failed to cancel run:', error)
+        showError('Failed to cancel run.')
+      } finally {
+        setCancellingRuns((prev) => {
+          const next = new Set(prev)
+          next.delete(runId)
+          return next
+        })
+      }
     }
-  }, [projectId, onDataChanged])
 
-  useImperativeHandle(ref, () => ({ refresh: handleRefresh }), [handleRefresh])
-
-  const handleCancelRun = async (runId: string, event: React.MouseEvent) => {
-    event.stopPropagation()
-    const ok = await showConfirm('Cancel this run? Pending and running work will stop.', {
-      title: 'Stop run',
-      confirmLabel: 'Stop run',
-      destructive: true,
-    })
-    if (!ok) return
-    setCancellingRuns((prev) => new Set(prev).add(runId))
-    try {
-      await cancelRun(runId)
-      const runsData = await listRuns({
-        projectId,
-        limit: RUNS_PAGE_SIZE,
-        includeResult: false,
-        includeGraphSpecSnapshot: false,
-      })
-      setRuns(runsData)
-      onDataChanged?.()
-    } catch (error) {
-      console.error('Failed to cancel run:', error)
-      showError('Failed to cancel run.')
-    } finally {
-      setCancellingRuns((prev) => {
-        const next = new Set(prev)
-        next.delete(runId)
-        return next
-      })
+    const getStatusColor = (status: string) => {
+      switch (status) {
+        case 'running':
+          return 'bg-yellow-100 text-yellow-800 border-yellow-200'
+        case 'completed':
+          return 'bg-green-100 text-green-800 border-green-200'
+        case 'completed_with_errors':
+          return 'bg-orange-100 text-orange-800 border-orange-200'
+        case 'pending':
+          return 'bg-gray-100 text-gray-800 border-gray-200'
+        default:
+          return 'bg-gray-100 text-gray-800 border-gray-200'
+      }
     }
-  }
 
-  const getStatusColor = (status: string) => {
-    switch (status) {
-      case 'running':
-        return 'bg-yellow-100 text-yellow-800 border-yellow-200'
-      case 'completed':
-        return 'bg-green-100 text-green-800 border-green-200'
-      case 'completed_with_errors':
-        return 'bg-orange-100 text-orange-800 border-orange-200'
-      case 'pending':
-        return 'bg-gray-100 text-gray-800 border-gray-200'
-      default:
-        return 'bg-gray-100 text-gray-800 border-gray-200'
+    const getStatusIcon = (status: string) => {
+      switch (status) {
+        case 'running':
+          return <Loader2 className="h-4 w-4 animate-spin" />
+        case 'completed':
+          return <CheckCircle className="h-4 w-4" />
+        case 'completed_with_errors':
+          return <AlertTriangle className="h-4 w-4" />
+        case 'pending':
+          return <Clock className="h-4 w-4" />
+        default:
+          return <Clock className="h-4 w-4" />
+      }
     }
-  }
 
-  const getStatusIcon = (status: string) => {
-    switch (status) {
-      case 'running':
-        return <Loader2 className="h-4 w-4 animate-spin" />
-      case 'completed':
-        return <CheckCircle className="h-4 w-4" />
-      case 'completed_with_errors':
-        return <AlertTriangle className="h-4 w-4" />
-      case 'pending':
-        return <Clock className="h-4 w-4" />
-      default:
-        return <Clock className="h-4 w-4" />
+    const getGraphName = (graphId: string) => {
+      const graph = graphs.find((g) => g.id === graphId)
+      return graph?.name || `Flow ${graphId}`
     }
-  }
 
-  const getGraphName = (graphId: string) => {
-    const graph = graphs.find((g) => g.id === graphId)
-    return graph?.name || `Flow ${graphId}`
-  }
+    const getDuration = (run: Run) => {
+      if (run.status === 'pending' || run.status === 'running') return 'Running…'
+      const start = new Date(run.created_at).getTime()
+      const end = new Date(run.updated_at).getTime()
+      const duration = end - start
+      if (duration < 1000) return '< 1s'
+      if (duration < 60000) return `${Math.round(duration / 1000)}s`
+      return `${Math.round(duration / 60000)}m ${Math.round((duration % 60000) / 1000)}s`
+    }
 
-  const getDuration = (run: Run) => {
-    if (run.status === 'pending' || run.status === 'running') return 'Running…'
-    const start = new Date(run.created_at).getTime()
-    const end = new Date(run.updated_at).getTime()
-    const duration = end - start
-    if (duration < 1000) return '< 1s'
-    if (duration < 60000) return `${Math.round(duration / 1000)}s`
-    return `${Math.round(duration / 60000)}m ${Math.round((duration % 60000) / 1000)}s`
-  }
+    // Flow is applied server-side; status remains a client filter on the current page.
+    const filteredRuns = useMemo(() => {
+      return runs
+        .filter((run) => selectedStatus === 'all' || run.status === selectedStatus)
+        .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
+    }, [runs, selectedStatus])
 
-  const filteredRuns = useMemo(() => {
-    return runs
-      .filter((run) => {
-        const flowMatch = selectedFlow === 'all' || run.graph_id === selectedFlow
-        const statusMatch = selectedStatus === 'all' || run.status === selectedStatus
-        return flowMatch && statusMatch
-      })
-      .sort(
-        (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+    const hasMore = runs.length === PAGE_SIZE
+    const canPrev = offset > 0
+    const canNext = hasMore
+    const showPager = canPrev || canNext
+
+    if (loading) {
+      return (
+        <div className="flex items-center justify-center py-12">
+          <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+        </div>
       )
-  }, [runs, selectedFlow, selectedStatus])
+    }
 
-  if (loading) {
     return (
-      <div className="flex items-center justify-center py-12">
-        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      <div className="space-y-4 w-full min-w-0">
+        <p className="text-sm text-muted-foreground mb-1">Runs for flows in this project.</p>
+
+        <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+          <div className="flex flex-col gap-1 min-w-0 sm:min-w-[10rem]">
+            <label className="text-sm font-medium">Flow</label>
+            <Select value={selectedFlow} onValueChange={handleFlowChange}>
+              <SelectTrigger className="w-full sm:w-[200px]">
+                <SelectValue placeholder="All flows" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All flows</SelectItem>
+                {projectGraphs.map((g) => (
+                  <SelectItem key={g.id} value={g.id}>
+                    {g.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="flex flex-col gap-1 min-w-0 sm:min-w-[10rem]">
+            <label className="text-sm font-medium">Status</label>
+            <Select value={selectedStatus} onValueChange={handleStatusChange}>
+              <SelectTrigger className="w-full sm:w-[180px]">
+                <SelectValue placeholder="All statuses" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All statuses</SelectItem>
+                <SelectItem value="pending">Pending</SelectItem>
+                <SelectItem value="running">Running</SelectItem>
+                <SelectItem value="completed">Completed</SelectItem>
+                <SelectItem value="completed_with_errors">Completed with errors</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        {filteredRuns.length === 0 ? (
+          <Card>
+            <CardContent className="py-12">
+              <p className="text-center text-muted-foreground">
+                {runs.length === 0
+                  ? 'No runs yet for this project.'
+                  : 'No runs match the current filters.'}
+              </p>
+            </CardContent>
+          </Card>
+        ) : (
+          <>
+            <Card className="overflow-hidden">
+              <CardContent className="p-0">
+                <div className="w-full overflow-x-auto">
+                  <table className="w-full min-w-[640px] text-sm">
+                    <thead className="border-b bg-muted/50">
+                      <tr>
+                        <th className="text-left p-3 sm:p-4 font-medium">Flow</th>
+                        <th className="text-left p-3 sm:p-4 font-medium">Status</th>
+                        <th className="text-left p-3 sm:p-4 font-medium hidden sm:table-cell">
+                          Created
+                        </th>
+                        <th className="text-left p-3 sm:p-4 font-medium hidden sm:table-cell">
+                          Estimated cost
+                        </th>
+                        <th className="text-left p-3 sm:p-4 font-medium hidden md:table-cell">
+                          Duration
+                        </th>
+                        <th className="text-right p-3 sm:p-4 font-medium">Actions</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {filteredRuns.map((run) => {
+                        const costFmt = formatRunEstimatedAiCost(run)
+                        return (
+                          <tr
+                            key={run.id}
+                            className="border-b last:border-b-0 hover:bg-muted/[0.07] cursor-pointer transition-colors"
+                            onClick={() => navigate(`/runs/${run.id}`)}
+                          >
+                            <td className="p-3 sm:p-4 align-top">
+                              <div className="font-medium">{getGraphName(run.graph_id)}</div>
+                            </td>
+                            <td className="p-3 sm:p-4 align-top">
+                              <Badge variant="outline" className={getStatusColor(run.status)}>
+                                {getStatusIcon(run.status)}
+                                <span className="ml-1 capitalize">
+                                  {run.status.replace(/_/g, ' ')}
+                                </span>
+                              </Badge>
+                              <div className="text-xs text-muted-foreground mt-1">
+                                {run.succeeded_items}/{run.total_items} completed
+                              </div>
+                            </td>
+                            <td className="p-3 sm:p-4 text-muted-foreground align-top hidden sm:table-cell whitespace-nowrap">
+                              {formatDate(run.created_at, {
+                                dateStyle: 'medium',
+                                timeStyle: 'short',
+                              })}
+                            </td>
+                            <td className="p-3 sm:p-4 text-muted-foreground align-top hidden sm:table-cell whitespace-nowrap tabular-nums">
+                              <>
+                                {costFmt.display}
+                                {costFmt.incomplete ? (
+                                  <span
+                                    className="text-amber-700 dark:text-amber-400 ml-0.5"
+                                    title="Estimate may be incomplete"
+                                  >
+                                    *
+                                  </span>
+                                ) : null}
+                              </>
+                            </td>
+                            <td className="p-3 sm:p-4 text-muted-foreground align-top hidden md:table-cell whitespace-nowrap">
+                              {getDuration(run)}
+                            </td>
+                            <td className="p-3 sm:p-4 text-right align-top">
+                              <div className="flex items-center justify-end gap-2">
+                                {(run.status === 'pending' || run.status === 'running') && (
+                                  <Button
+                                    variant="outline"
+                                    size="sm"
+                                    onClick={(e) => void handleCancelRun(run.id, e)}
+                                    disabled={cancellingRuns.has(run.id)}
+                                    className="text-red-600 hover:text-red-700 hover:bg-red-50"
+                                  >
+                                    {cancellingRuns.has(run.id) ? (
+                                      <Loader2 className="h-4 w-4 animate-spin" />
+                                    ) : (
+                                      <StopCircle className="h-4 w-4" />
+                                    )}
+                                  </Button>
+                                )}
+                                <Button
+                                  variant="ghost"
+                                  size="sm"
+                                  onClick={(e) => {
+                                    e.stopPropagation()
+                                    navigate(`/runs/${run.id}`)
+                                  }}
+                                >
+                                  View
+                                  <ArrowRight className="ml-2 h-4 w-4" />
+                                </Button>
+                              </div>
+                            </td>
+                          </tr>
+                        )
+                      })}
+                    </tbody>
+                  </table>
+                </div>
+              </CardContent>
+            </Card>
+
+            {showPager ? (
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <p className="text-sm text-muted-foreground">
+                  Showing {offset + 1}–{offset + filteredRuns.length}
+                  {hasMore ? ' (more available)' : ''}
+                </p>
+                <div className="flex gap-2">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    disabled={!canPrev}
+                    onClick={() =>
+                      void loadPage(Math.max(0, offset - PAGE_SIZE), { spinner: true })
+                    }
+                  >
+                    Previous
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    disabled={!canNext}
+                    onClick={() => void loadPage(offset + PAGE_SIZE, { spinner: true })}
+                  >
+                    Next
+                  </Button>
+                </div>
+              </div>
+            ) : null}
+          </>
+        )}
       </div>
     )
-  }
-
-  return (
-    <div className="space-y-4 w-full min-w-0">
-      <p className="text-sm text-muted-foreground mb-1">
-        Runs for flows in this project.
-      </p>
-
-      <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap">
-        <div className="flex flex-col gap-1 min-w-0 sm:min-w-[10rem]">
-          <label className="text-sm font-medium">Flow</label>
-          <Select value={selectedFlow} onValueChange={setSelectedFlow}>
-            <SelectTrigger className="w-full sm:w-[200px]">
-              <SelectValue placeholder="All flows" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">All flows</SelectItem>
-              {projectGraphs.map((g) => (
-                <SelectItem key={g.id} value={g.id}>
-                  {g.name}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-        <div className="flex flex-col gap-1 min-w-0 sm:min-w-[10rem]">
-          <label className="text-sm font-medium">Status</label>
-          <Select value={selectedStatus} onValueChange={setSelectedStatus}>
-            <SelectTrigger className="w-full sm:w-[180px]">
-              <SelectValue placeholder="All statuses" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">All statuses</SelectItem>
-              <SelectItem value="pending">Pending</SelectItem>
-              <SelectItem value="running">Running</SelectItem>
-              <SelectItem value="completed">Completed</SelectItem>
-              <SelectItem value="completed_with_errors">Completed with errors</SelectItem>
-            </SelectContent>
-          </Select>
-        </div>
-      </div>
-
-      {filteredRuns.length === 0 ? (
-        <Card>
-          <CardContent className="py-12">
-            <p className="text-center text-muted-foreground">
-              {runs.length === 0
-                ? 'No runs yet for this project.'
-                : 'No runs match the current filters.'}
-            </p>
-          </CardContent>
-        </Card>
-      ) : (
-        <Card className="overflow-hidden">
-          <CardContent className="p-0">
-            <div className="w-full overflow-x-auto">
-              <table className="w-full min-w-[640px] text-sm">
-                <thead className="border-b bg-muted/50">
-                  <tr>
-                    <th className="text-left p-3 sm:p-4 font-medium">Flow</th>
-                    <th className="text-left p-3 sm:p-4 font-medium">Status</th>
-                    <th className="text-left p-3 sm:p-4 font-medium hidden sm:table-cell">Created</th>
-                    <th className="text-left p-3 sm:p-4 font-medium hidden sm:table-cell">
-                      Estimated cost
-                    </th>
-                    <th className="text-left p-3 sm:p-4 font-medium hidden md:table-cell">Duration</th>
-                    <th className="text-right p-3 sm:p-4 font-medium">Actions</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {filteredRuns.map((run) => {
-                    const costFmt = formatRunEstimatedAiCost(run)
-                    return (
-                    <tr
-                      key={run.id}
-                      className="border-b last:border-b-0 hover:bg-muted/[0.07] cursor-pointer transition-colors"
-                      onClick={() => navigate(`/runs/${run.id}`)}
-                    >
-                      <td className="p-3 sm:p-4 align-top">
-                        <div className="font-medium">{getGraphName(run.graph_id)}</div>
-                      </td>
-                      <td className="p-3 sm:p-4 align-top">
-                        <Badge variant="outline" className={getStatusColor(run.status)}>
-                          {getStatusIcon(run.status)}
-                          <span className="ml-1 capitalize">{run.status.replace(/_/g, ' ')}</span>
-                        </Badge>
-                        <div className="text-xs text-muted-foreground mt-1">
-                          {run.succeeded_items}/{run.total_items} completed
-                        </div>
-                      </td>
-                      <td className="p-3 sm:p-4 text-muted-foreground align-top hidden sm:table-cell whitespace-nowrap">
-                        {formatDate(run.created_at, { dateStyle: 'medium', timeStyle: 'short' })}
-                      </td>
-                      <td className="p-3 sm:p-4 text-muted-foreground align-top hidden sm:table-cell whitespace-nowrap tabular-nums">
-                        <>
-                          {costFmt.display}
-                          {costFmt.incomplete ? (
-                            <span
-                              className="text-amber-700 dark:text-amber-400 ml-0.5"
-                              title="Estimate may be incomplete"
-                            >
-                              *
-                            </span>
-                          ) : null}
-                        </>
-                      </td>
-                      <td className="p-3 sm:p-4 text-muted-foreground align-top hidden md:table-cell whitespace-nowrap">
-                        {getDuration(run)}
-                      </td>
-                      <td className="p-3 sm:p-4 text-right align-top">
-                        <div className="flex items-center justify-end gap-2">
-                          {(run.status === 'pending' || run.status === 'running') && (
-                            <Button
-                              variant="outline"
-                              size="sm"
-                              onClick={(e) => void handleCancelRun(run.id, e)}
-                              disabled={cancellingRuns.has(run.id)}
-                              className="text-red-600 hover:text-red-700 hover:bg-red-50"
-                            >
-                              {cancellingRuns.has(run.id) ? (
-                                <Loader2 className="h-4 w-4 animate-spin" />
-                              ) : (
-                                <StopCircle className="h-4 w-4" />
-                              )}
-                            </Button>
-                          )}
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            onClick={(e) => {
-                              e.stopPropagation()
-                              navigate(`/runs/${run.id}`)
-                            }}
-                          >
-                            View
-                            <ArrowRight className="ml-2 h-4 w-4" />
-                          </Button>
-                        </div>
-                      </td>
-                    </tr>
-                    )
-                  })}
-                </tbody>
-              </table>
-            </div>
-          </CardContent>
-        </Card>
-      )}
-    </div>
-  )
-},
+  },
 )
 
 export default ProjectDetailRunsTab

--- a/apps/agate-ui/src/lib/api.ts
+++ b/apps/agate-ui/src/lib/api.ts
@@ -94,6 +94,8 @@ export interface ProjectStats {
   slowest_flows?: SlowestFlowStat[]
   /** Mean tracked LLM spend per succeeded run. */
   avg_estimated_ai_cost_per_run?: string | number | null
+  /** Mean tracked LLM spend per terminal processed item on succeeded runs. */
+  avg_estimated_ai_cost_per_item?: string | number | null
   top_flows_by_cost?: TopFlowByCostStat[]
   avg_estimated_ai_cost_currency?: string | null
   avg_estimated_ai_cost_incomplete?: boolean

--- a/apps/agate-ui/src/lib/api.ts
+++ b/apps/agate-ui/src/lib/api.ts
@@ -910,6 +910,51 @@ export async function getProjectEstimatedAiCost(
   return fetchAPI(`/projects/${projectId}/estimated-ai-cost`) as Promise<ProjectEstimatedAiCost>
 }
 
+export interface ProjectProcessedItem {
+  id: number
+  run_id: string
+  flow_name: string
+  title: string
+  url: string | null
+  status: string
+  created_at: string
+  source_file: string | null
+}
+
+export interface ProjectProcessedItemsPage {
+  total: number
+  limit: number
+  offset: number
+  q: string | null
+  items: ProjectProcessedItem[]
+}
+
+export interface ListProjectProcessedItemsOptions {
+  q?: string | null
+  limit?: number
+  offset?: number
+}
+
+export async function listProjectProcessedItems(
+  projectId: number,
+  options: ListProjectProcessedItemsOptions = {},
+): Promise<ProjectProcessedItemsPage> {
+  const params = new URLSearchParams()
+  if (options.q != null && options.q.trim()) {
+    params.set('q', options.q.trim())
+  }
+  if (options.limit != null) {
+    params.set('limit', String(options.limit))
+  }
+  if (options.offset != null) {
+    params.set('offset', String(options.offset))
+  }
+  const query = params.toString()
+  return fetchAPI(
+    `/projects/${projectId}/processed-items${query ? `?${query}` : ''}`,
+  ) as Promise<ProjectProcessedItemsPage>
+}
+
 interface RawProcessedItemDetail {
   id: number
   run_id: string

--- a/apps/agate-ui/src/lib/api.ts
+++ b/apps/agate-ui/src/lib/api.ts
@@ -331,6 +331,7 @@ export interface ListGraphsOptions {
 
 export interface ListRunsOptions {
   projectId?: number
+  graphId?: string
   limit?: number
   offset?: number
   includeResult?: boolean
@@ -823,6 +824,9 @@ export async function listRuns(options: ListRunsOptions = {}): Promise<Run[]> {
   const params = new URLSearchParams()
   if (options.projectId != null) {
     params.set('project_id', String(options.projectId))
+  }
+  if (options.graphId) {
+    params.set('graph_id', options.graphId)
   }
   if (options.limit != null) {
     params.set('limit', String(options.limit))

--- a/apps/agate-ui/src/lib/projectWorkspaceTab.test.ts
+++ b/apps/agate-ui/src/lib/projectWorkspaceTab.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import {
+  defaultProjectWorkspaceTab,
+  isProjectWorkspaceTab,
+  parseProjectWorkspaceTab,
+  projectWorkspaceTabSearch,
+} from './projectWorkspaceTab'
+
+describe('projectWorkspaceTab', () => {
+  it('defaults to flows', () => {
+    expect(defaultProjectWorkspaceTab()).toBe('flows')
+    expect(parseProjectWorkspaceTab(null)).toBe('flows')
+    expect(parseProjectWorkspaceTab('nope')).toBe('flows')
+  })
+
+  it('accepts known tabs', () => {
+    expect(isProjectWorkspaceTab('articles')).toBe(true)
+    expect(parseProjectWorkspaceTab('articles')).toBe('articles')
+    expect(parseProjectWorkspaceTab('runs')).toBe('runs')
+  })
+
+  it('builds tab search strings', () => {
+    expect(projectWorkspaceTabSearch('articles')).toBe('?tab=articles')
+    expect(projectWorkspaceTabSearch('flows')).toBe('?tab=flows')
+  })
+})

--- a/apps/agate-ui/src/lib/projectWorkspaceTab.ts
+++ b/apps/agate-ui/src/lib/projectWorkspaceTab.ts
@@ -1,0 +1,36 @@
+/** Project detail workspace tabs (``ProjectDetailPage``). */
+
+export const PROJECT_WORKSPACE_TABS = [
+  'flows',
+  'runs',
+  'articles',
+  'models',
+  'integrations',
+  'keys',
+] as const
+
+export type ProjectWorkspaceTab = (typeof PROJECT_WORKSPACE_TABS)[number]
+
+export function defaultProjectWorkspaceTab(): ProjectWorkspaceTab {
+  return 'flows'
+}
+
+export function isProjectWorkspaceTab(value: string): value is ProjectWorkspaceTab {
+  return (PROJECT_WORKSPACE_TABS as readonly string[]).includes(value)
+}
+
+export function parseProjectWorkspaceTab(
+  raw: string | null | undefined,
+): ProjectWorkspaceTab {
+  if (raw && isProjectWorkspaceTab(raw)) {
+    return raw
+  }
+  return defaultProjectWorkspaceTab()
+}
+
+/** Build search string for a workspace tab permalink (includes leading ``?``). */
+export function projectWorkspaceTabSearch(tab: ProjectWorkspaceTab): string {
+  const params = new URLSearchParams()
+  params.set('tab', tab)
+  return `?${params.toString()}`
+}

--- a/apps/agate-ui/src/pages/ProjectDetailPage.tsx
+++ b/apps/agate-ui/src/pages/ProjectDetailPage.tsx
@@ -6,7 +6,7 @@ import {
   useState,
   type KeyboardEvent,
 } from 'react'
-import { useNavigate, useParams } from 'react-router-dom'
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { InlineNameEditor } from '@/components/InlineNameEditor'
@@ -17,6 +17,7 @@ import ProjectDetailFlowsTab from '@/components/project/ProjectDetailFlowsTab'
 import ProjectDetailRunsTab, {
   type ProjectDetailRunsTabHandle,
 } from '@/components/project/ProjectDetailRunsTab'
+import ProjectDetailArticlesTab from '@/components/project/ProjectDetailArticlesTab'
 import ProjectDetailModelsTab from '@/components/project/ProjectDetailModelsTab'
 import ProjectDetailIntegrationsTab from '@/components/project/ProjectDetailIntegrationsTab'
 import {
@@ -33,6 +34,10 @@ import { stylebookShellHref } from '@/lib/platformUrls'
 import { formatDurationMs } from '@/lib/formatDuration'
 import { useAuth } from '@/lib/auth'
 import { listMyWorkspaces, type WorkspaceWithProjects } from '@/lib/core-api'
+import {
+  parseProjectWorkspaceTab,
+  projectWorkspaceTabSearch,
+} from '@/lib/projectWorkspaceTab'
 import { Loader2, Plus, RefreshCw } from 'lucide-react'
 
 function formatCurrencySummary(
@@ -83,6 +88,7 @@ function StatMinMaxRange({
 
 export default function ProjectDetailPage() {
   const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
   const { organizationId, isOrgAdmin } = useAuth()
   const { projectSlug: projectSlugParam } = useParams<{ projectSlug: string }>()
   const slug = projectSlugParam ? decodeURIComponent(projectSlugParam) : ''
@@ -92,7 +98,7 @@ export default function ProjectDetailPage() {
   const [overviewLoading, setOverviewLoading] = useState(true)
   const [overviewError, setOverviewError] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
-  const [workspaceTab, setWorkspaceTab] = useState('flows')
+  const workspaceTab = parseProjectWorkspaceTab(searchParams.get('tab'))
   const runsTabRef = useRef<ProjectDetailRunsTabHandle>(null)
   const [runsRefreshBusy, setRunsRefreshBusy] = useState(false)
   const keysSettingsRef = useRef<ProjectSettingsHandle>(null)
@@ -190,9 +196,19 @@ export default function ProjectDetailPage() {
     }
   }, [])
 
-  const handleWorkspaceTabChange = useCallback((value: string) => {
-    setWorkspaceTab(value)
-  }, [])
+  const handleWorkspaceTabChange = useCallback(
+    (value: string) => {
+      const tab = parseProjectWorkspaceTab(value)
+      navigate(
+        {
+          pathname: window.location.pathname,
+          search: projectWorkspaceTabSearch(tab),
+        },
+        { replace: true },
+      )
+    },
+    [navigate],
+  )
 
   const handleWorkspaceTabsPointerDownCapture = useCallback(() => {
     captureWorkspaceScrollAnchor()
@@ -565,7 +581,7 @@ export default function ProjectDetailPage() {
           <div className="min-w-0 flex-1">
             <h2 className="text-lg font-semibold">Project workspace</h2>
             <p className="mt-1 text-sm text-muted-foreground">
-              Flows, runs, integrations and API keys for this project.
+              Flows, runs, articles, integrations and API keys for this project.
             </p>
           </div>
           <div className="flex flex-shrink-0 flex-wrap items-center gap-2 sm:justify-end">
@@ -622,12 +638,15 @@ export default function ProjectDetailPage() {
           onKeyDownCapture={handleWorkspaceTabsKeyDownCapture}
           className="w-full min-w-0"
         >
-          <TabsList className="grid w-full max-w-none grid-cols-2 gap-1 h-auto p-1 sm:grid-cols-3 lg:grid-cols-5">
+          <TabsList className="grid w-full max-w-none grid-cols-2 gap-1 h-auto p-1 sm:grid-cols-3 lg:grid-cols-6">
             <TabsTrigger value="flows" className="w-full">
               Flows
             </TabsTrigger>
             <TabsTrigger value="runs" className="w-full">
               Runs
+            </TabsTrigger>
+            <TabsTrigger value="articles" className="w-full">
+              Articles
             </TabsTrigger>
             <TabsTrigger value="models" className="w-full">
               Models
@@ -660,6 +679,9 @@ export default function ProjectDetailPage() {
                 projectId={project.id}
                 onDataChanged={() => void reload()}
               />
+            ) : null}
+            {workspaceTab === 'articles' ? (
+              <ProjectDetailArticlesTab projectId={project.id} />
             ) : null}
             {workspaceTab === 'models' ? (
               <div className="w-full min-w-0 space-y-10">

--- a/apps/agate-ui/src/pages/ProjectDetailPage.tsx
+++ b/apps/agate-ui/src/pages/ProjectDetailPage.tsx
@@ -498,18 +498,18 @@ export default function ProjectDetailPage() {
           <Card>
             <CardHeader className="pb-2">
               <CardTitle className="text-sm font-medium text-muted-foreground">
-                Average cost per run
+                Average cost per item
               </CardTitle>
             </CardHeader>
             <CardContent>
               {stats &&
               stats.runs_succeeded > 0 &&
-              stats.avg_estimated_ai_cost_per_run != null &&
+              stats.avg_estimated_ai_cost_per_item != null &&
               stats.avg_estimated_ai_cost_currency ? (
                 <>
                   <p className="text-3xl font-semibold tabular-nums">
                     {formatCurrencySummary(
-                      stats.avg_estimated_ai_cost_per_run,
+                      stats.avg_estimated_ai_cost_per_item,
                       stats.avg_estimated_ai_cost_currency || 'USD',
                     )}
                     {stats.avg_estimated_ai_cost_incomplete ? (
@@ -521,7 +521,9 @@ export default function ProjectDetailPage() {
                       </span>
                     ) : null}
                   </p>
-                  <p className="text-xs text-muted-foreground mt-1">Among completed runs</p>
+                  <p className="text-xs text-muted-foreground mt-1">
+                    Among items in completed runs
+                  </p>
                   {stats.top_flows_by_cost && stats.top_flows_by_cost.length > 0 ? (
                     <StatMinMaxRange
                       title="Flows"
@@ -551,15 +553,15 @@ export default function ProjectDetailPage() {
           <Card>
             <CardHeader className="pb-2">
               <CardTitle className="text-sm font-medium text-muted-foreground">
-                Average time per run
+                Average time per item
               </CardTitle>
             </CardHeader>
             <CardContent>
               <p className="text-3xl font-semibold tabular-nums">
-                {overviewPending ? '…' : formatDurationMs(stats?.avg_duration_ms_per_run)}
+                {overviewPending ? '…' : formatDurationMs(stats?.avg_duration_ms_per_item)}
               </p>
               <p className="text-xs text-muted-foreground mt-1">
-                Wall time per completed run
+                Processing time per completed item
               </p>
               {stats?.slowest_flows && stats.slowest_flows.length > 0 ? (
                 <StatMinMaxRange

--- a/docs/api/agate.md
+++ b/docs/api/agate.md
@@ -23,7 +23,7 @@ Core API's documented `/public/v1` routes.
 
 ### Projects
 
-`/projects` owns project creation, listing, detail, updates, deletion, statistics, tracked AI cost, and encrypted project secrets.
+`/projects` owns project creation, listing, detail, updates, deletion, statistics, tracked AI cost, encrypted project secrets, and project-scoped processed-item discovery.
 
 The trusted offline `backfield organization create` command is the only project-creation exception.
 It uses a shared database transaction because a starter project must be committed atomically with
@@ -58,6 +58,12 @@ HTTP endpoint and does not change Agate API ownership of interactive project lif
   that project. Shared Stylebook canonicals for the organization are kept. The reserved
   `general` project cannot be deleted. Unlike flow deletion, project deletion does **not**
   preserve durable article content.
+- `GET /projects/{project_id}/processed-items` lists processed items across flows in the
+  project (newest first) for Agate UI Articles discovery. Optional `q` matches headline and
+  URL (linked article or input fields) plus `source_file`; it does not search article body
+  text. Pagination uses `limit` / `offset` (limit 1–500). Each row includes `title`, `url`,
+  `status`, `created_at`, `flow_name`, and `run_id` so the client can open
+  `/runs/{run_id}/items/{id}` for review.
 
 ### Flows and templates
 
@@ -90,6 +96,10 @@ For active runs, poll `GET /runs/{run_id}/status` and page summaries through `GE
 `GET /runs/{run_id}/estimated-ai-cost` returns run totals and node-level attribution. Project statistics and project cost routes aggregate the same tracked call records at project scope.
 
 ### Processed items
+
+Project-scoped discovery (list/search without knowing a run) is
+`GET /projects/{project_id}/processed-items` — see **Projects** above. Review and mutation
+routes remain under `/runs/{run_id}/items/…`.
 
 Important item routes are:
 

--- a/docs/api/processed-item-review.md
+++ b/docs/api/processed-item-review.md
@@ -4,6 +4,11 @@ Processed-item review is an Agate API contract layered over immutable worker out
 
 Routes are under `/runs/{run_id}/items/{item_id}` and require access to the run's project.
 
+To find an item without knowing the run, Agate UI uses project-scoped discovery
+`GET /projects/{project_id}/processed-items` (Articles tab). That endpoint returns review
+targets only; overlay edits and entity lanes still go through the run-scoped item routes
+below.
+
 ## Item detail
 
 `GET /runs/{run_id}/items/{item_id}` returns:

--- a/docs/development/frontend/agate.md
+++ b/docs/development/frontend/agate.md
@@ -54,7 +54,8 @@ Node panels and synced node UI are documented in
 
 On the project detail page, the workspace strip uses `?tab=<id>` with values
 `flows`, `runs`, `articles`, `models`, `integrations`, and `keys`. Missing or invalid
-values resolve to `flows`. The **Articles** tab lists recent processed items for the
+values resolve to `flows`. The **Runs** tab pages project runs with `limit` / `offset`
+(Previous/Next). The **Articles** tab lists recent processed items for the
 project and supports headline/URL search via `GET /projects/{id}/processed-items`; each
 row opens `/runs/{runId}/items/{itemId}` for review.
 

--- a/docs/development/frontend/agate.md
+++ b/docs/development/frontend/agate.md
@@ -50,6 +50,16 @@ Node panels and synced node UI are documented in
 - While an S3 batch run is creating processed items, the run table shows
   **Preparing items ...** instead of the empty-run state.
 
+## Project workspace tabs
+
+On the project detail page, the workspace strip uses `?tab=<id>` with values
+`flows`, `runs`, `articles`, `models`, `integrations`, and `keys`. Missing or invalid
+values resolve to `flows`. The **Articles** tab lists recent processed items for the
+project and supports headline/URL search via `GET /projects/{id}/processed-items`; each
+row opens `/runs/{runId}/items/{itemId}` for review.
+
+Helpers live in `src/lib/projectWorkspaceTab.ts`.
+
 ## Processed-item deep links
 
 Processed-item detail tabs are:

--- a/tests/agate_api/test_project_processed_items.py
+++ b/tests/agate_api/test_project_processed_items.py
@@ -1,0 +1,257 @@
+"""Tests for project-scoped processed-item list and search."""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from api.deps import get_session
+from api.main import app
+from api.project_processed_items import resolve_project_item_title_and_url
+from backfield_db import (
+    AgateProcessedItem,
+    BackfieldOrganization,
+    SubstrateArticle,
+)
+from fastapi.testclient import TestClient
+from sqlmodel import Session, SQLModel, create_engine
+
+from tests.agate_api.test_agate_api import _insert_pending_run, _post_project
+from tests.integration_helpers import patch_test_engine
+
+
+@pytest.fixture
+def client_and_engine(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> Generator[tuple[TestClient, object], None, None]:
+    database_path = tmp_path / "agate-project-items.db"
+    engine = create_engine(
+        f"sqlite:///{database_path}",
+        connect_args={"check_same_thread": False},
+    )
+    SQLModel.metadata.create_all(engine)
+    patch_test_engine(monkeypatch, engine)
+
+    with Session(engine) as s:
+        s.add(BackfieldOrganization(name="Backfield", slug="default"))
+        s.commit()
+
+    def get_test_session() -> Generator[Session, None, None]:
+        with Session(engine) as session:
+            yield session
+
+    app.dependency_overrides[get_session] = get_test_session
+    try:
+        yield (
+            TestClient(
+                app,
+                headers={
+                    "Authorization": "Bearer backfield-dev",
+                    "X-Backfield-Organization-ID": "1",
+                },
+            ),
+            engine,
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_resolve_title_prefers_article_headline_over_generic() -> None:
+    title, url = resolve_project_item_title_and_url(
+        item_id=1,
+        source_file="batch/story.json",
+        input_json='{"headline":"From input","url":"https://example.com/from-input"}',
+        article_headline="City council votes",
+        article_url="https://example.com/council",
+    )
+    assert title == "City council votes"
+    assert url == "https://example.com/council"
+
+
+def test_resolve_title_skips_generic_article_headline() -> None:
+    title, url = resolve_project_item_title_and_url(
+        item_id=2,
+        source_file="path/to/file.json",
+        input_json='{"headline":"Real headline"}',
+        article_headline="article",
+        article_url=None,
+    )
+    assert title == "Real headline"
+    assert url is None
+
+
+def test_resolve_title_falls_back_to_source_file() -> None:
+    title, url = resolve_project_item_title_and_url(
+        item_id=3,
+        source_file="s3://bucket/path/story-abc.json",
+        input_json='{"text":"long body without a headline"}',
+        article_headline=None,
+        article_url=None,
+    )
+    assert title == "story-abc.json"
+    assert url is None
+
+
+def test_list_project_processed_items_recent_and_search(
+    client_and_engine: tuple[TestClient, object],
+) -> None:
+    client, engine = client_and_engine
+
+    project_a = _post_project(client, name="Articles A", slug="articles-a").json()
+    project_b = _post_project(client, name="Articles B", slug="articles-b").json()
+
+    graph_a = client.post(
+        "/graphs",
+        json={
+            "name": "Ingest flow",
+            "project_id": project_a["id"],
+            "spec": {"name": "ingest", "nodes": [], "edges": []},
+        },
+    ).json()
+    graph_b = client.post(
+        "/graphs",
+        json={
+            "name": "Other project flow",
+            "project_id": project_b["id"],
+            "spec": {"name": "other", "nodes": [], "edges": []},
+        },
+    ).json()
+
+    older = datetime.now(UTC) - timedelta(hours=2)
+    newer = datetime.now(UTC) - timedelta(minutes=5)
+
+    with Session(engine) as s:
+        run_a = _insert_pending_run(s, graph_a["id"])
+        run_b = _insert_pending_run(s, graph_b["id"])
+        run_a.status = "succeeded"
+        run_b.status = "succeeded"
+        s.add(run_a)
+        s.add(run_b)
+        s.flush()
+
+        article = SubstrateArticle(
+            project_id=project_a["id"],
+            headline="Council approves budget",
+            text="Body text that should never match search alone xyzuniquebody",
+            url="https://news.example.com/budget",
+        )
+        s.add(article)
+        s.flush()
+
+        linked = AgateProcessedItem(
+            run_id=run_a.id,
+            source_file="batch/budget.json",
+            input_json='{"text":"ignored body"}',
+            status="succeeded",
+            result_json="{}",
+            substrate_article_id=article.id,
+            created_at=newer,
+        )
+        orphan = AgateProcessedItem(
+            run_id=run_a.id,
+            source_file="feeds/orphan-story.json",
+            input_json='{"headline":"Orphan headline only","url":"https://news.example.com/orphan"}',
+            status="failed",
+            error_message="boom",
+            created_at=older,
+        )
+        other = AgateProcessedItem(
+            run_id=run_b.id,
+            source_file="other.json",
+            input_json='{"headline":"Council approves budget"}',
+            status="succeeded",
+            result_json="{}",
+            created_at=newer,
+        )
+        s.add(linked)
+        s.add(orphan)
+        s.add(other)
+        s.commit()
+        linked_id = linked.id
+        orphan_id = orphan.id
+        run_a_id = run_a.id
+
+    empty = client.get(f"/projects/{project_a['id']}/processed-items")
+    assert empty.status_code == 200
+    body = empty.json()
+    assert body["total"] == 2
+    assert body["q"] is None
+    assert len(body["items"]) == 2
+    assert body["items"][0]["id"] == linked_id
+    assert body["items"][0]["title"] == "Council approves budget"
+    assert body["items"][0]["url"] == "https://news.example.com/budget"
+    assert body["items"][0]["flow_name"] == "Ingest flow"
+    assert body["items"][0]["run_id"] == run_a_id
+    assert body["items"][1]["id"] == orphan_id
+    assert body["items"][1]["title"] == "Orphan headline only"
+
+    by_headline = client.get(
+        f"/projects/{project_a['id']}/processed-items",
+        params={"q": "Council approves"},
+    )
+    assert by_headline.status_code == 200
+    hits = by_headline.json()
+    assert hits["total"] == 1
+    assert hits["q"] == "Council approves"
+    assert hits["items"][0]["id"] == linked_id
+
+    by_url = client.get(
+        f"/projects/{project_a['id']}/processed-items",
+        params={"q": "news.example.com/budget"},
+    )
+    assert by_url.status_code == 200
+    assert by_url.json()["total"] == 1
+    assert by_url.json()["items"][0]["id"] == linked_id
+
+    by_source = client.get(
+        f"/projects/{project_a['id']}/processed-items",
+        params={"q": "orphan-story"},
+    )
+    assert by_source.status_code == 200
+    assert by_source.json()["total"] == 1
+    assert by_source.json()["items"][0]["id"] == orphan_id
+
+    # Body-only unique token must not match (headline/URL/source only).
+    by_body = client.get(
+        f"/projects/{project_a['id']}/processed-items",
+        params={"q": "xyzuniquebody"},
+    )
+    assert by_body.status_code == 200
+    assert by_body.json()["total"] == 0
+
+    page = client.get(
+        f"/projects/{project_a['id']}/processed-items",
+        params={"limit": 1, "offset": 1},
+    )
+    assert page.status_code == 200
+    page_body = page.json()
+    assert page_body["total"] == 2
+    assert page_body["limit"] == 1
+    assert page_body["offset"] == 1
+    assert len(page_body["items"]) == 1
+    assert page_body["items"][0]["id"] == orphan_id
+
+    # Other project's item is excluded even when headline matches.
+    other_list = client.get(f"/projects/{project_b['id']}/processed-items")
+    assert other_list.status_code == 200
+    assert other_list.json()["total"] == 1
+
+
+def test_list_project_processed_items_requires_access(
+    client_and_engine: tuple[TestClient, object],
+) -> None:
+    client, _engine = client_and_engine
+    project = _post_project(client, name="Locked", slug="locked-items").json()
+    resp = client.get(
+        f"/projects/{project['id']}/processed-items",
+        headers={"Authorization": "Bearer not-a-real-token"},
+    )
+    assert resp.status_code in (401, 403)
+
+
+def test_list_project_processed_items_404(
+    client_and_engine: tuple[TestClient, object],
+) -> None:
+    client, _engine = client_and_engine
+    assert client.get("/projects/999999/processed-items").status_code == 404

--- a/tests/agate_api/test_project_stats_means.py
+++ b/tests/agate_api/test_project_stats_means.py
@@ -80,3 +80,98 @@ def test_project_stats_and_ai_cost_with_succeeded_run() -> None:
         )
         assert avg == Decimal("0")
         assert incomplete is False
+
+
+def test_project_stats_avg_cost_per_item_with_two_items() -> None:
+    from datetime import UTC, datetime, timedelta
+
+    from api.routers.projects import _avg_ai_cost_stats_for_terminal_items
+    from backfield_db import AgateProcessedItem, BackfieldAiCallRecord
+
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as session:
+        org = BackfieldOrganization(name="Org", slug="org-items")
+        session.add(org)
+        session.commit()
+        session.refresh(org)
+        project = BackfieldProject(
+            **project_ownership_fields(session, org.id),
+            organization_id=org.id,
+            name="Items",
+            slug="items",
+        )
+        session.add(project)
+        session.commit()
+        session.refresh(project)
+        graph = AgateGraph(name="Flow", spec_json="{}", project_id=project.id)
+        session.add(graph)
+        session.commit()
+        session.refresh(graph)
+        run = AgateRun(graph_id=graph.id, status="succeeded")
+        session.add(run)
+        session.commit()
+        session.refresh(run)
+
+        started = datetime.now(UTC) - timedelta(seconds=20)
+        ended = datetime.now(UTC)
+        item_a = AgateProcessedItem(
+            run_id=run.id,
+            status="succeeded",
+            started_at=started,
+            created_at=started,
+            updated_at=ended,
+        )
+        item_b = AgateProcessedItem(
+            run_id=run.id,
+            status="succeeded",
+            started_at=started,
+            created_at=started,
+            updated_at=ended,
+        )
+        session.add(item_a)
+        session.add(item_b)
+        session.commit()
+        session.refresh(item_a)
+        session.refresh(item_b)
+
+        session.add(
+            BackfieldAiCallRecord(
+                project_id=project.id,
+                run_id=run.id,
+                processed_item_id=item_a.id,
+                provider="openai",
+                provider_model_id="gpt-test",
+                status="succeeded",
+                estimated_cost=Decimal("0.20"),
+                currency="USD",
+            )
+        )
+        session.add(
+            BackfieldAiCallRecord(
+                project_id=project.id,
+                run_id=run.id,
+                processed_item_id=item_b.id,
+                provider="openai",
+                provider_model_id="gpt-test",
+                status="succeeded",
+                estimated_cost=Decimal("0.40"),
+                currency="USD",
+            )
+        )
+        session.commit()
+
+        avg, incomplete, currency = _avg_ai_cost_stats_for_terminal_items(
+            session,
+            int(project.id),
+            [graph.id],
+        )
+        assert avg is not None
+        assert abs(avg - Decimal("0.3")) < Decimal("0.0001")
+        assert incomplete is False
+        assert currency == "USD"
+
+        stats = _project_stats(session, project)
+        assert stats.avg_estimated_ai_cost_per_item is not None
+        assert abs(stats.avg_estimated_ai_cost_per_item - Decimal("0.3")) < Decimal("0.0001")
+        assert stats.avg_duration_ms_per_item is not None


### PR DESCRIPTION
## Summary

Agate project UX upgrades so editors can find and reason about processed work without knowing a specific run:

- **Articles tab** (`?tab=articles`): project-scoped processed-item list/search by headline/URL (source fallback), deep-linking into review
- **Runs tab pagination**: Previous/Next beyond the old hard page cap for large projects
- **Project stats cards**: average AI cost and duration **per item** (flow breakdowns aligned), instead of per run

## Project scope check

- [x] This change targets local development / source inspection (production self-hosting is unsupported in this repo)
- [x] Docs under `docs/` updated if behavior, architecture, or operations changed
- [x] First-admin provisioning still uses `backfield init` / `backfield seed` only (no HTTP/env bootstrap paths)

## Test plan

- [x] `make lint`
- [x] `make test` (full suite for Articles work; targeted stats tests for per-item averages)
- [x] `make ui-typecheck ui-test` (if UI/TypeScript changed) — `npx tsc --noEmit` in `agate-ui` plus workspace-tab unit tests
- [ ] `make smoke-fast` (if live-stack behavior changed)
- [ ] `make smoke` (if golden-path / provider-dependent runtime changed; configure **Settings → AI models**)
- [ ] Manually: open a project with many runs → Articles search + deep link; Runs Next/Previous; confirm stats cards read “per item”

## Notes for reviewers

- New `GET /projects/{id}/processed-items` is item-centric discovery; review mutations stay under `/runs/.../items/...`
- Keyword search matches headline/URL/source — not article body
- Per-run average fields remain on the stats API for compatibility; the UI surfaces per-item fields

Made with [Cursor](https://cursor.com)