### PR TITLE
Fix BuiltRevenue recovery, GeoJSON geometry, person recall, and geocoder health

### DIFF
--- a/apps/agate-api/src/api/routers/runs.py
+++ b/apps/agate-api/src/api/routers/runs.py
@@ -141,6 +141,13 @@ class AiCostNodeBreakdown(BaseModel):
     estimated_total: Decimal
 
 
+class GeocoderProviderHealthOut(BaseModel):
+    provider: str
+    auth_error: int = 0
+    rate_limit: int = 0
+    http_error: int = 0
+
+
 class RunEstimatedAiCostOut(BaseModel):
     run_id: str
     currency: str
@@ -148,6 +155,8 @@ class RunEstimatedAiCostOut(BaseModel):
     incomplete_estimate: bool
     attempt_count: int
     node_breakdown: list[AiCostNodeBreakdown]
+    geocoder_provider_health: list[GeocoderProviderHealthOut] = []
+    geocoder_degraded: bool = False
 
 
 class RunCreate(BaseModel):
@@ -2813,6 +2822,82 @@ def get_run(
     return _serialize_run(session, r)
 
 
+def _merge_geocoder_health_maps(
+    into: dict[str, dict[str, int]],
+    raw: object,
+) -> None:
+    if not isinstance(raw, dict):
+        return
+    for provider, counts in raw.items():
+        if not isinstance(provider, str) or not isinstance(counts, dict):
+            continue
+        bucket = into.setdefault(
+            provider,
+            {"auth_error": 0, "rate_limit": 0, "http_error": 0},
+        )
+        for key in ("auth_error", "rate_limit", "http_error"):
+            try:
+                bucket[key] += int(counts.get(key) or 0)
+            except (TypeError, ValueError):
+                continue
+
+
+def _geocoder_health_from_node_outputs(node_outputs: object) -> dict[str, dict[str, int]]:
+    """Collect ``geocoder_provider_health`` from a run/item result_json dict."""
+    out: dict[str, dict[str, int]] = {}
+    if not isinstance(node_outputs, dict):
+        return out
+    # Run-level aggregate (optional) or GeocodeAgent contribution under any node id.
+    top = node_outputs.get("geocoder_provider_health")
+    _merge_geocoder_health_maps(out, top)
+    for value in node_outputs.values():
+        if not isinstance(value, dict):
+            continue
+        _merge_geocoder_health_maps(out, value.get("geocoder_provider_health"))
+    return out
+
+
+def _geocoder_provider_health_for_run(
+    session: Session,
+    run: AgateRun,
+) -> tuple[list[GeocoderProviderHealthOut], bool]:
+    merged: dict[str, dict[str, int]] = {}
+    payload = parse_run_result_payload(run.result_json)
+    _merge_geocoder_health_maps(merged, payload.get("geocoder_provider_health"))
+    # Single-item runs store executor output on result_json; scan node contributions.
+    for key, value in payload.items():
+        if key in ("items", "s3_batch", GRAPH_SPEC_JSON_KEY, "geocoder_provider_health"):
+            continue
+        if isinstance(value, dict):
+            _merge_geocoder_health_maps(merged, value.get("geocoder_provider_health"))
+
+    item_rows = session.exec(
+        select(AgateProcessedItem.result_json).where(AgateProcessedItem.run_id == run.id)
+    ).all()
+    for raw in item_rows:
+        if not raw:
+            continue
+        try:
+            parsed = json.loads(raw) if isinstance(raw, str) else raw
+        except (TypeError, json.JSONDecodeError):
+            continue
+        for provider, counts in _geocoder_health_from_node_outputs(parsed).items():
+            _merge_geocoder_health_maps(merged, {provider: counts})
+
+    rows = [
+        GeocoderProviderHealthOut(
+            provider=provider,
+            auth_error=int(counts.get("auth_error") or 0),
+            rate_limit=int(counts.get("rate_limit") or 0),
+            http_error=int(counts.get("http_error") or 0),
+        )
+        for provider, counts in sorted(merged.items())
+        if any(int(counts.get(k) or 0) > 0 for k in ("auth_error", "rate_limit", "http_error"))
+    ]
+    degraded = any(row.auth_error > 0 or row.rate_limit > 0 for row in rows)
+    return rows, degraded
+
+
 @router.get("/{run_id}/estimated-ai-cost", response_model=RunEstimatedAiCostOut)
 def get_run_estimated_ai_cost(
     run_id: str,
@@ -2852,6 +2937,8 @@ def get_run_estimated_ai_cost(
         )
     ]
 
+    health_rows, geocoder_degraded = _geocoder_provider_health_for_run(session, r)
+
     return RunEstimatedAiCostOut(
         run_id=run_id,
         currency=currency,
@@ -2859,4 +2946,6 @@ def get_run_estimated_ai_cost(
         incomplete_estimate=incomplete,
         attempt_count=len(rows),
         node_breakdown=breakdown,
+        geocoder_provider_health=health_rows,
+        geocoder_degraded=geocoder_degraded,
     )

--- a/apps/agate-ui/src/lib/api.ts
+++ b/apps/agate-ui/src/lib/api.ts
@@ -895,6 +895,13 @@ export interface RunEstimatedAiCost {
     node_type?: string | null
     estimated_total: string
   }>
+  geocoder_provider_health?: Array<{
+    provider: string
+    auth_error: number
+    rate_limit: number
+    http_error: number
+  }>
+  geocoder_degraded?: boolean
 }
 
 export async function getRunEstimatedAiCost(runId: string): Promise<RunEstimatedAiCost> {

--- a/apps/agate-ui/src/pages/RunDetail.tsx
+++ b/apps/agate-ui/src/pages/RunDetail.tsx
@@ -675,7 +675,7 @@ export default function RunDetail() {
         </CardContent>
       </Card>
 
-      {aiCost && aiCost.attempt_count > 0 ? (
+      {aiCost && (aiCost.attempt_count > 0 || aiCost.geocoder_degraded) ? (
         <Card>
           <CardHeader>
             <CardTitle>Estimated AI usage cost</CardTitle>
@@ -684,13 +684,59 @@ export default function RunDetail() {
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-3">
-            <div className="text-2xl font-semibold">
-              {formatCurrencySummary(Number(aiCost.estimated_total), aiCost.currency || 'USD')}
-            </div>
+            {aiCost.attempt_count > 0 ? (
+              <div className="text-2xl font-semibold">
+                {formatCurrencySummary(Number(aiCost.estimated_total), aiCost.currency || 'USD')}
+              </div>
+            ) : null}
             {aiCost.incomplete_estimate ? (
               <p className="text-sm text-amber-700 dark:text-amber-400">
                 Some usage data was missing, so this total may be incomplete.
               </p>
+            ) : null}
+            {aiCost.geocoder_degraded ? (
+              <div className="text-sm text-amber-700 dark:text-amber-400 space-y-1">
+                <p>
+                  Location lookup had trouble with a configured provider during this run.
+                  Results may have used a backup source.
+                </p>
+                {aiCost.geocoder_provider_health?.length ? (
+                  <ul className="list-disc pl-5 space-y-1">
+                    {aiCost.geocoder_provider_health.map((row) => {
+                      const parts: string[] = []
+                      if (row.auth_error > 0) {
+                        parts.push(
+                          `${row.auth_error} sign-in ${row.auth_error === 1 ? 'failure' : 'failures'}`,
+                        )
+                      }
+                      if (row.rate_limit > 0) {
+                        parts.push(
+                          `${row.rate_limit} rate-limit ${row.rate_limit === 1 ? 'hit' : 'hits'}`,
+                        )
+                      }
+                      if (row.http_error > 0) {
+                        parts.push(
+                          `${row.http_error} other ${row.http_error === 1 ? 'error' : 'errors'}`,
+                        )
+                      }
+                      if (!parts.length) return null
+                      const label =
+                        row.provider === 'pelias'
+                          ? 'Primary address search'
+                          : row.provider === 'geocodio'
+                            ? 'Backup address search'
+                            : row.provider === 'overpass'
+                              ? 'Map data lookup'
+                              : 'Location lookup'
+                      return (
+                        <li key={row.provider}>
+                          {label}: {parts.join(', ')}
+                        </li>
+                      )
+                    })}
+                  </ul>
+                ) : null}
+              </div>
             ) : null}
             {aiCost.node_breakdown?.length ? (
               <div className="text-sm text-muted-foreground">

--- a/apps/stylebook-api/src/stylebook_api/entities/location/candidates.py
+++ b/apps/stylebook-api/src/stylebook_api/entities/location/candidates.py
@@ -35,6 +35,7 @@ from backfield_entities.entities.linking.substrate_actions import (
 )
 from backfield_entities.entities.location.persist import refresh_aliases_for_linked_location
 from backfield_entities.entities.location.types import PLACE_EXTRACT_LOCATION_TYPES
+from backfield_entities.geo.geometry_bind import assign_geojson_geometry
 from backfield_events import record_canonical_created, record_canonical_evidence_changed
 from fastapi import APIRouter, Body, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
@@ -780,7 +781,8 @@ def accept_candidate(
         if not label:
             raise HTTPException(status_code=400, detail="name is required when create_new is true")
         # Review UI often omits geometry; inherit from substrate (parity with ingest materialize).
-        if isinstance(body.geometry_json, dict):
+        bind_body_geometry = isinstance(body.geometry_json, dict)
+        if bind_body_geometry:
             gj: dict[str, Any] | None = dict(body.geometry_json)
             canon_geometry: object | None = None
         else:
@@ -829,6 +831,10 @@ def accept_candidate(
         )
         session.add(canon)
         session.flush()
+        # Body-supplied GeoJSON must also populate PostGIS (same as create_standalone_canonical).
+        if bind_body_geometry and isinstance(gj, dict):
+            assign_geojson_geometry(session, canon, gj)
+            session.flush()
         loc.stylebook_location_canonical_id = str(canon.id)
     else:
         if body.stylebook_location_id is None:

--- a/apps/worker/src/worker/substrate/entities/organization/handler.py
+++ b/apps/worker/src/worker/substrate/entities/organization/handler.py
@@ -191,10 +191,33 @@ class OrganizationPersistHandler:
                 disposed_substrates=0,
             )
 
+        # Authoritative replace: clear prior machine associations before upsert so a
+        # partial prior persist cannot leave dirty ORM rows that collide with dispose.
+        pre_retired_mentions = 0
+        pre_disposed_substrates = 0
+        if policy == "replace" and ctx.article_id is not None:
+            pre_retired_mentions, retired_organization_ids, _pre_preserved = (
+                retire_stale_article_mentions_for_rerun(
+                    session,
+                    article_id=int(ctx.article_id),
+                    touched_organization_ids=set(),
+                )
+            )
+            if retired_organization_ids:
+                pre_disposed_substrates = dispose_orphan_substrates_after_retired_mentions(
+                    session,
+                    project_id=int(ctx.project_id),
+                    organization_ids=retired_organization_ids,
+                    provenance="agate_replace_preclear",
+                )
+            session.expire_all()
+
         touched_organization_ids: set[int] = set()
         added = 0
         updated = 0
         skipped = 0
+        # Editorial preservation is counted on the post-upsert retire pass so we
+        # do not double-count rows already seen during replace pre-clear.
         preserved = 0
         pending_variant_recall: list[_OrgCanonicalWork] = []
         pending_adjudication: list[_PendingOrgAdjudication] = []
@@ -520,6 +543,9 @@ class OrganizationPersistHandler:
                     retired_mentions,
                     substrates_disposed,
                 )
+
+        retired_mentions += pre_retired_mentions
+        substrates_disposed += pre_disposed_substrates
 
         return HandlerPersistResult(
             summary=DomainReconciliationSummary(

--- a/apps/worker/src/worker/substrate/entities/organization/mentions.py
+++ b/apps/worker/src/worker/substrate/entities/organization/mentions.py
@@ -249,7 +249,15 @@ def _dispose_orphan_substrate_without_requeue(
         organization_id=int(organization.id),
         project_id=int(organization.project_id),
     )
+    # Flush unlink UPDATEs before DELETE so ORM rowcount checks cannot race a
+    # vanished PK (StaleDataError on replace after partial persist).
+    session.flush()
     session.delete(organization)
+    session.flush()
+    try:
+        session.expunge(organization)
+    except Exception:
+        pass
 
 
 def _suppress_prior_system_occurrences_for_mention(

--- a/apps/worker/src/worker/substrate/entities/person/handler.py
+++ b/apps/worker/src/worker/substrate/entities/person/handler.py
@@ -137,10 +137,30 @@ class PersonPersistHandler:
                 disposed_substrates=0,
             )
 
+        pre_retired_mentions = 0
+        pre_disposed_substrates = 0
+        if policy == "replace" and ctx.article_id is not None:
+            pre_retired_mentions, retired_person_ids, _pre_preserved = (
+                retire_stale_article_mentions_for_rerun(
+                    session,
+                    article_id=int(ctx.article_id),
+                    touched_person_ids=set(),
+                )
+            )
+            if retired_person_ids:
+                pre_disposed_substrates = dispose_orphan_substrates_after_retired_mentions(
+                    session,
+                    project_id=int(ctx.project_id),
+                    person_ids=retired_person_ids,
+                    provenance="agate_replace_preclear",
+                )
+            session.expire_all()
+
         touched_person_ids: set[int] = set()
         added = 0
         updated = 0
         skipped = 0
+        # Editorial preservation is counted on the post-upsert retire pass.
         preserved = 0
         pending_adjudication: list[_PendingPersonAdjudication] = []
         adj_model = (ctx.settings.adjudication_model or "").strip() or "gpt-5-nano"
@@ -348,6 +368,9 @@ class PersonPersistHandler:
                     retired_mentions,
                     substrates_disposed,
                 )
+
+        retired_mentions += pre_retired_mentions
+        substrates_disposed += pre_disposed_substrates
 
         return HandlerPersistResult(
             summary=DomainReconciliationSummary(

--- a/apps/worker/src/worker/substrate/entities/person/mentions.py
+++ b/apps/worker/src/worker/substrate/entities/person/mentions.py
@@ -238,7 +238,15 @@ def _dispose_orphan_substrate_without_requeue(
         person_id=int(person.id),
         project_id=int(person.project_id),
     )
+    # Flush unlink UPDATEs before DELETE so ORM rowcount checks cannot race a
+    # vanished PK (StaleDataError on replace after partial persist).
+    session.flush()
     session.delete(person)
+    session.flush()
+    try:
+        session.expunge(person)
+    except Exception:
+        pass
 
 
 def _suppress_prior_system_occurrences_for_mention(

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -74,6 +74,10 @@ Webhook metrics never use project IDs, endpoint IDs, URLs, or error text as dime
 
 Never log: secrets, auth headers, raw DB/Redis URLs, passwords, or customer content (addresses, article text, geocoder queries/results, provider bodies).
 
+Pelias HTTP calls retry on 429/502/503/504 (honoring `Retry-After` when present) and never retry
+401/403. Auth and rate-limit counts for the geocode pass are attached to GeocodeAgent output as
+`geocoder_provider_health` and surfaced on the run estimated-cost panel when degraded.
+
 ## Collector (cloud handoff)
 
 - **Image:** production worker image.

--- a/docs/architecture/canonicalization.md
+++ b/docs/architecture/canonicalization.md
@@ -74,9 +74,13 @@ merge an address extraction with a named-place extraction.
 
 ## Person policy
 
-Person tier-one matching requires an exact normalized name or alias plus affiliation; title is
-used by stricter comparison and recall but not by that automatic-link identity. When recall
-returns no candidates, policy creates a canonical unless extraction review signals block
+Person tier-one matching requires an exact normalized name or trusted alias plus affiliation;
+title is used by stricter comparison and recall but not by that automatic-link identity. Name
+matching strips a multi-token ``Given Family, Title…`` suffix so CSV labels like
+``Christine Hines, County Clerk`` still exact-match the bare name ``Christine Hines``. Trusted
+alias hits do not also require label equality. Affiliation- or title-only scores cannot alone
+clear recall so unrelated peers who share an employer do not drown exact-name candidates. When
+recall returns no candidates, policy creates a canonical unless extraction review signals block
 materialization. Ambiguous recall, descriptive pseudonyms, first-name-only identities, children,
 animals, and non-person extractions defer according to their review metadata.
 
@@ -106,13 +110,15 @@ Canonicalization and article reconciliation are separate controls. Backfield Out
 `smart_merge`, and `replace` policies decide how newly produced domains affect prior
 machine-generated mentions. `replace` is authoritative for every emitted domain, including an empty
 array: omitted machine associations and their system-extraction occurrences are retired while
-editor-added, editor-modified, and non-extraction associations remain. Shared substrate identities
-remain available to other articles; true orphans are unlinked and removed. When the last linked
-substrate for an ingest-only location, person, or organization canonical is disposed or unlinked,
-that empty catalog shell is pruned (manual, CSV, bundle, and review-queue rows stay). Stylebook
-unlink responses report that prune as ``canonical_pruned`` so the catalog UI can leave the detail
-page instead of refetching a row that no longer exists. `smart_merge`
-and `add_only` retain their non-authoritative behavior.
+editor-added, editor-modified, and non-extraction associations remain. For places, machine geography
+is cleared before upsert; for people and organizations, machine associations are pre-cleared the
+same way so a partial prior persist can be recovered without wedging the article. Shared substrate
+identities remain available to other articles; true orphans are unlinked and removed. When the last
+linked substrate for an ingest-only location, person, or organization canonical is disposed or
+unlinked, that empty catalog shell is pruned (manual, CSV, bundle, and review-queue rows stay).
+Stylebook unlink responses report that prune as ``canonical_pruned`` so the catalog UI can leave the
+detail page instead of refetching a row that no longer exists. `smart_merge` and `add_only` retain
+their non-authoritative behavior.
 
 Occurrence offsets are optional evidence, not best-effort guesses. Ingest stores `start_char` and
 `end_char` only when normalized source text can be mapped back to an equivalent exact article

--- a/docs/development/entities/overview.md
+++ b/docs/development/entities/overview.md
@@ -102,10 +102,12 @@ commits from prose alone.
 
 Exact-alias lookups used for tier-1 / exact-identity autolink ignore
 `substrate_ingest` aliases (`trusted_alias_only=True`). Editorial provenances
-such as `stylebook_ui_accept` and `stylebook_ui_link` still count. Ingest aliases
-may still appear in fuzzy recall for LLM adjudication; autolink-tier fuzzy
-scores and the sync commit gate must not treat machine aliases as identity
-evidence alone.
+such as `stylebook_ui_accept`, `stylebook_ui_link`, and `stylebook_ui_import_csv`
+still count. Person name keys strip a multi-token ``Name, Title`` suffix so
+title-glued CSV labels still exact-match bare names. Ingest aliases may still
+appear in fuzzy recall for LLM adjudication; autolink-tier fuzzy scores and the
+sync commit gate must not treat machine aliases as identity evidence alone.
+Affiliation- or title-only bonuses cannot alone clear person recall.
 
 An exact location alias is a candidate set, not a first-row winner. Linking
 requires one active, compatible, self-consistent survivor; multiple survivors
@@ -167,7 +169,8 @@ that reference it. Existing orphans can be repaired with
 Canonicals can be created manually, imported, or transferred in an organization
 Stylebook bundle:
 
-- locations import from GeoJSON;
+- locations import from GeoJSON (standalone create writes both `geometry_json` and PostGIS
+  `geometry` so bbox / geo-search work);
 - people and organizations import from CSV;
 - bundle transfer includes location, person, and organization canonicals, aliases,
   project-scoped metadata, and connections whose endpoints are included.

--- a/packages/backfield-agate/src/agate_nodes/geocode_agent/node.py
+++ b/packages/backfield-agate/src/agate_nodes/geocode_agent/node.py
@@ -9,6 +9,10 @@ from pydantic import AliasChoices, BaseModel, Field, ConfigDict, model_validator
 
 from agate_runtime.context import AgateEnvContext
 from agate_runtime.upstream_input import flatten_upstream_inputs
+from agate_utils.geocoding.provider_health import (
+    begin_geocoder_health_tracking,
+    end_geocoder_health_tracking,
+)
 
 from .agent import run_advanced_geocoding_agent
 from .location_limits import location_needs_review_entry, split_locations_for_geocoding
@@ -170,6 +174,10 @@ class GeocodeAgentOutput(BaseModel):
     model_config = ConfigDict(extra='allow')
     
     places: Dict[str, Any] = Field(description="Consolidated places structure with areas, points, etc.")
+    geocoder_provider_health: Optional[Dict[str, Dict[str, int]]] = Field(
+        default=None,
+        description="Per-provider auth/rate-limit/http error counts for this geocode pass",
+    )
 
 
 def _places_have_terminal_output(places: object) -> bool:
@@ -194,9 +202,34 @@ async def run_geocode_agent_pipeline(
     log_label: str = "GeocodeAgent",
 ) -> GeocodeAgentOutput:
     """Geocode locations using the LangGraph pipeline (cache → route_strategy → external geocode → consolidate)."""
+    health_token = begin_geocoder_health_tracking()
+    try:
+        return await _run_geocode_agent_pipeline_tracked(
+            inp, params, ctx, log_label=log_label
+        )
+    finally:
+        # Snapshot is attached inside the tracked helper before return; reset context here.
+        end_geocoder_health_tracking(health_token)
+
+
+async def _run_geocode_agent_pipeline_tracked(
+    inp: GeocodeAgentInput,
+    params: GeocodeAgentParams,
+    ctx: AgateEnvContext,
+    *,
+    log_label: str = "GeocodeAgent",
+) -> GeocodeAgentOutput:
+    """Inner pipeline body; assumes geocoder health tracking is already active."""
+    from agate_utils.geocoding.provider_health import snapshot_geocoder_health
 
     def _pipe_log(msg: str, *args: object) -> None:
         logger.debug(msg, *args)
+
+    def _finalize(output_data: dict[str, Any]) -> GeocodeAgentOutput:
+        health = snapshot_geocoder_health()
+        if health:
+            output_data["geocoder_provider_health"] = health
+        return GeocodeAgentOutput(**output_data)
 
     # Get all state (namespaced by upstream node id from the Backfield executor)
     state_dict = inp.model_dump()
@@ -240,7 +273,7 @@ async def run_geocode_agent_pipeline(
         # Include text at root level if found
         if text:
             output_data["text"] = text
-        return GeocodeAgentOutput(**output_data)
+        return _finalize(output_data)
         
     # Handle empty locations list
     if not isinstance(locations_data, list) or len(locations_data) == 0:
@@ -263,7 +296,7 @@ async def run_geocode_agent_pipeline(
         # Include text at root level if found
         if text:
             output_data["text"] = text
-        return GeocodeAgentOutput(**output_data)
+        return _finalize(output_data)
         
     # Filter for supported types. Unsupported extractions receive an explicit terminal disposition.
     filtered_locations = [
@@ -605,7 +638,7 @@ async def run_geocode_agent_pipeline(
     if text:
         output_data["text"] = text
 
-    return GeocodeAgentOutput(**output_data)
+    return _finalize(output_data)
 
 
 ########## AGENT NODE ##########

--- a/packages/backfield-agate/src/agate_runtime/node_output_contract.py
+++ b/packages/backfield-agate/src/agate_runtime/node_output_contract.py
@@ -37,7 +37,7 @@ NODE_CONTRIBUTION_KEYS: dict[str, frozenset[str]] = {
     "PlaceExtract": frozenset({"locations", "extraction_diagnostics"}),
     "PersonExtract": frozenset({"people", "extraction_diagnostics"}),
     "OrganizationExtract": frozenset({"organizations", "extraction_diagnostics"}),
-    "GeocodeAgent": frozenset({"places"}),
+    "GeocodeAgent": frozenset({"places", "geocoder_provider_health"}),
     "Gather": frozenset({"gathered"}),
     "Output": frozenset({"consolidated"}),
     "S3Output": frozenset({"consolidated", "s3_bucket", "s3_key"}),

--- a/packages/backfield-agate/src/agate_utils/geocoding/pelias.py
+++ b/packages/backfield-agate/src/agate_utils/geocoding/pelias.py
@@ -3,7 +3,10 @@
 import asyncio
 import logging
 import re
+import time
+from email.utils import parsedate_to_datetime
 from typing import Any, Dict, List, Optional
+from datetime import UTC
 
 import httpx
 from agate_utils.geocoding.geocoding_types import (
@@ -14,12 +17,17 @@ from agate_utils.geocoding.geocoding_types import (
     GeometryPolygon,
     bbox_west_south_east_north_to_polygon_coordinates,
 )
+from agate_utils.geocoding.provider_health import record_geocoder_http_status
 
 logger = logging.getLogger(__name__)
 
 # Geocode.Earth can be slow; connect timeouts often mean edge/network congestion, not bad params.
 _PELIAS_HTTP_TIMEOUT = httpx.Timeout(60.0, connect=20.0)
 _PELIAS_API_KEY_IN_URL = re.compile(r"([?&])api_key=[^&]*", re.IGNORECASE)
+_RETRYABLE_HTTP_STATUSES: frozenset[int] = frozenset({429, 502, 503, 504})
+_MAX_HTTP_RETRIES = 4
+_MAX_RETRY_DELAY_S = 30.0
+_BASE_RETRY_DELAY_S = 0.75
 
 
 def _redact_pelias_url(url_str: str) -> str:
@@ -34,52 +42,112 @@ def _params_for_log(params: dict[str, Any]) -> dict[str, Any]:
     return out
 
 
+def _retry_delay_seconds(
+    *,
+    response: httpx.Response | None,
+    attempt: int,
+    rate_limited: bool,
+) -> float:
+    """Backoff for retryable HTTP statuses; honor Retry-After when present."""
+    if response is not None:
+        retry_after = response.headers.get("Retry-After", "").strip()
+        if retry_after:
+            if retry_after.isdigit():
+                return min(float(retry_after), _MAX_RETRY_DELAY_S)
+            try:
+                retry_at = parsedate_to_datetime(retry_after)
+                if retry_at.tzinfo is None:
+                    retry_at = retry_at.replace(tzinfo=UTC)
+                delta = retry_at.timestamp() - time.time()
+                if delta > 0:
+                    return min(delta, _MAX_RETRY_DELAY_S)
+            except (TypeError, ValueError, OverflowError):
+                pass
+    multiplier = 2 ** max(0, attempt - 1)
+    floor = 8.0 if rate_limited else _BASE_RETRY_DELAY_S
+    return min(floor * multiplier, _MAX_RETRY_DELAY_S)
+
+
 async def _pelias_get(
     client: httpx.AsyncClient, url: str, params: dict[str, Any]
 ) -> httpx.Response:
-    """GET with one retry on transient connect/read/pool timeouts."""
-    import time
+    """GET with retries on timeouts and retryable HTTP statuses (429/5xx).
 
+    Auth failures (401/403) are never retried; they are recorded for run-level
+    provider health surfacing.
+    """
     from backfield_observability.external import emit_external_request
 
     transient = (httpx.ConnectTimeout, httpx.ReadTimeout, httpx.PoolTimeout)
-    started = time.perf_counter()
-    try:
+    last_response: httpx.Response | None = None
+
+    for attempt in range(1, _MAX_HTTP_RETRIES + 1):
+        started = time.perf_counter()
         try:
-            response = await client.get(url, params=params)
-        except transient as first:
-            logger.warning("Pelias %s, retrying once", type(first).__name__)
+            try:
+                response = await client.get(url, params=params)
+            except transient as first:
+                logger.warning("Pelias %s, retrying once", type(first).__name__)
+                emit_external_request(
+                    operation="geocoding",
+                    duration_seconds=time.perf_counter() - started,
+                    failed=True,
+                    provider="pelias",
+                    error_type=type(first).__name__,
+                    outcome="retry",
+                )
+                await asyncio.sleep(_BASE_RETRY_DELAY_S)
+                started = time.perf_counter()
+                response = await client.get(url, params=params)
+
+            failed = response.status_code >= 400
+            emit_external_request(
+                operation="geocoding",
+                duration_seconds=time.perf_counter() - started,
+                failed=failed,
+                provider="pelias",
+                error_type=f"http_{response.status_code}" if failed else None,
+                outcome="failure" if failed else "success",
+            )
+            if failed:
+                record_geocoder_http_status("pelias", response.status_code)
+
+            last_response = response
+            if response.status_code < 400:
+                return response
+            # Never retry auth failures — the key is dead for the whole run.
+            if response.status_code in (401, 403):
+                return response
+            if response.status_code not in _RETRYABLE_HTTP_STATUSES:
+                return response
+            if attempt >= _MAX_HTTP_RETRIES:
+                return response
+
+            rate_limited = response.status_code == 429
+            delay = _retry_delay_seconds(
+                response=response, attempt=attempt, rate_limited=rate_limited
+            )
+            logger.warning(
+                "Pelias HTTP %s, retrying in %.1fs (attempt %s/%s)",
+                response.status_code,
+                delay,
+                attempt,
+                _MAX_HTTP_RETRIES,
+            )
+            await asyncio.sleep(delay)
+        except Exception as exc:
             emit_external_request(
                 operation="geocoding",
                 duration_seconds=time.perf_counter() - started,
                 failed=True,
                 provider="pelias",
-                error_type=type(first).__name__,
-                outcome="retry",
+                error_type=type(exc).__name__,
+                outcome="exception",
             )
-            await asyncio.sleep(0.75)
-            started = time.perf_counter()
-            response = await client.get(url, params=params)
-        failed = response.status_code >= 400
-        emit_external_request(
-            operation="geocoding",
-            duration_seconds=time.perf_counter() - started,
-            failed=failed,
-            provider="pelias",
-            error_type=f"http_{response.status_code}" if failed else None,
-            outcome="failure" if failed else "success",
-        )
-        return response
-    except Exception as exc:
-        emit_external_request(
-            operation="geocoding",
-            duration_seconds=time.perf_counter() - started,
-            failed=True,
-            provider="pelias",
-            error_type=type(exc).__name__,
-            outcome="exception",
-        )
-        raise
+            raise
+
+    assert last_response is not None
+    return last_response
 
 
 def _pelias_http_error_suffix(exc: Exception) -> str:

--- a/packages/backfield-agate/src/agate_utils/geocoding/provider_health.py
+++ b/packages/backfield-agate/src/agate_utils/geocoding/provider_health.py
@@ -1,0 +1,79 @@
+"""Run-scoped geocoder provider health counters (auth / rate-limit)."""
+
+from __future__ import annotations
+
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+
+
+@dataclass
+class GeocoderProviderHealthCounters:
+    """Mutable per-provider failure counters for the current geocode run."""
+
+    auth_error: int = 0
+    rate_limit: int = 0
+    http_error: int = 0
+
+
+@dataclass
+class GeocoderHealthState:
+    by_provider: dict[str, GeocoderProviderHealthCounters] = field(default_factory=dict)
+
+    def record(self, provider: str, kind: str) -> None:
+        key = (provider or "unknown").strip().lower() or "unknown"
+        bucket = self.by_provider.setdefault(key, GeocoderProviderHealthCounters())
+        if kind == "auth_error":
+            bucket.auth_error += 1
+        elif kind == "rate_limit":
+            bucket.rate_limit += 1
+        else:
+            bucket.http_error += 1
+
+    def snapshot(self) -> dict[str, dict[str, int]]:
+        out: dict[str, dict[str, int]] = {}
+        for provider, counters in sorted(self.by_provider.items()):
+            if counters.auth_error or counters.rate_limit or counters.http_error:
+                out[provider] = {
+                    "auth_error": counters.auth_error,
+                    "rate_limit": counters.rate_limit,
+                    "http_error": counters.http_error,
+                }
+        return out
+
+
+_CTX: ContextVar[GeocoderHealthState | None] = ContextVar(
+    "bf_geocoder_health_ctx", default=None
+)
+
+
+def begin_geocoder_health_tracking() -> object:
+    """Start a fresh counter bag; return a reset token for ``end_geocoder_health_tracking``."""
+    return _CTX.set(GeocoderHealthState())
+
+
+def end_geocoder_health_tracking(token: object) -> dict[str, dict[str, int]]:
+    """Snapshot counters and restore the previous context."""
+    state = _CTX.get()
+    snapshot = state.snapshot() if state is not None else {}
+    _CTX.reset(token)
+    return snapshot
+
+
+def record_geocoder_http_status(provider: str, status_code: int) -> None:
+    """Record a non-success HTTP status against the active health context (if any)."""
+    state = _CTX.get()
+    if state is None:
+        return
+    if status_code in (401, 403):
+        state.record(provider, "auth_error")
+    elif status_code == 429:
+        state.record(provider, "rate_limit")
+    elif status_code >= 400:
+        state.record(provider, "http_error")
+
+
+def snapshot_geocoder_health() -> dict[str, dict[str, int]]:
+    state = _CTX.get()
+    if state is None:
+        return {}
+    return state.snapshot()

--- a/packages/backfield-agate/tests/test_pelias_retry_health.py
+++ b/packages/backfield-agate/tests/test_pelias_retry_health.py
@@ -1,0 +1,92 @@
+"""Pelias HTTP retry and provider-health recording."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+from agate_utils.geocoding.pelias import _pelias_get, _retry_delay_seconds
+from agate_utils.geocoding.provider_health import (
+    begin_geocoder_health_tracking,
+    end_geocoder_health_tracking,
+    record_geocoder_http_status,
+    snapshot_geocoder_health,
+)
+
+
+def test_retry_delay_honors_retry_after_seconds() -> None:
+    response = MagicMock()
+    response.headers = {"Retry-After": "2"}
+    delay = _retry_delay_seconds(response=response, attempt=1, rate_limited=True)
+    assert delay == 2.0
+
+
+def test_provider_health_records_auth_and_rate_limit() -> None:
+    token = begin_geocoder_health_tracking()
+    try:
+        record_geocoder_http_status("pelias", 401)
+        record_geocoder_http_status("pelias", 401)
+        record_geocoder_http_status("pelias", 429)
+        snap = snapshot_geocoder_health()
+        assert snap["pelias"]["auth_error"] == 2
+        assert snap["pelias"]["rate_limit"] == 1
+    finally:
+        end_geocoder_health_tracking(token)
+
+
+def test_pelias_get_retries_429_then_succeeds() -> None:
+    async def _run() -> None:
+        token = begin_geocoder_health_tracking()
+        try:
+            limited = httpx.Response(
+                429, request=httpx.Request("GET", "https://example.test/v1/search")
+            )
+            limited.headers["Retry-After"] = "0"
+            ok = httpx.Response(
+                200,
+                json={"features": []},
+                request=httpx.Request("GET", "https://example.test/v1/search"),
+            )
+            client = AsyncMock()
+            client.get = AsyncMock(side_effect=[limited, ok])
+
+            with patch("agate_utils.geocoding.pelias.asyncio.sleep", new_callable=AsyncMock):
+                with patch("backfield_observability.external.emit_external_request"):
+                    response = await _pelias_get(
+                        client, "https://example.test/v1/search", {"text": "x"}
+                    )
+
+            assert response.status_code == 200
+            assert client.get.await_count == 2
+            snap = snapshot_geocoder_health()
+            assert snap["pelias"]["rate_limit"] == 1
+        finally:
+            end_geocoder_health_tracking(token)
+
+    asyncio.run(_run())
+
+
+def test_pelias_get_does_not_retry_401() -> None:
+    async def _run() -> None:
+        token = begin_geocoder_health_tracking()
+        try:
+            unauthorized = httpx.Response(
+                401, request=httpx.Request("GET", "https://example.test/v1/search")
+            )
+            client = AsyncMock()
+            client.get = AsyncMock(return_value=unauthorized)
+
+            with patch("backfield_observability.external.emit_external_request"):
+                response = await _pelias_get(
+                    client, "https://example.test/v1/search", {"text": "x"}
+                )
+
+            assert response.status_code == 401
+            assert client.get.await_count == 1
+            snap = snapshot_geocoder_health()
+            assert snap["pelias"]["auth_error"] == 1
+        finally:
+            end_geocoder_health_tracking(token)
+
+    asyncio.run(_run())

--- a/packages/backfield-entities/src/backfield_entities/entities/location/persist.py
+++ b/packages/backfield-entities/src/backfield_entities/entities/location/persist.py
@@ -45,6 +45,7 @@ from backfield_entities.entities.location.catalog_provenance import (
 from backfield_entities.entities.location.policy import plan_has_ambiguous_canonical_match
 from backfield_entities.entities.location.recall import location_alias_lookup_keys
 from backfield_entities.entities.location.types import is_address_like_location_type
+from backfield_entities.geo.geometry_bind import assign_geojson_geometry
 from backfield_entities.geo.h3_index import apply_h3_fields
 from backfield_entities.text.match_normalize import normalize_match_text
 
@@ -260,12 +261,10 @@ def create_standalone_canonical(
     if not clean:
         raise ValueError("label is required")
     gj = dict(geometry_json) if isinstance(geometry_json, dict) else None
-    gt_raw = gj.get("type") if isinstance(gj, dict) else None
-    geometry_type_str = str(gt_raw) if gt_raw is not None else None
     lt = (location_type or "").strip().lower() or None
     fa = (formatted_address or "").strip() or None
     def _build_row(slug: str) -> StylebookLocationCanonical:
-        return StylebookLocationCanonical(
+        row = StylebookLocationCanonical(
             stylebook_id=stylebook_id,
             label=clean,
             slug=slug,
@@ -273,11 +272,15 @@ def create_standalone_canonical(
             formatted_address=fa,
             primary_substrate_location_id=None,
             status="active",
-            geometry_json=gj,
-            geometry_type=geometry_type_str,
+            geometry_json=None,
+            geometry_type=None,
             geometry=None,
-            **_h3_field_kwargs(geometry_json=gj),
+            h3_cell=None,
+            h3_resolution=None,
         )
+        # Write GeoJSON + PostGIS + H3 together (geo-search/bbox require ``geometry``).
+        assign_geojson_geometry(session, row, gj)
+        return row
 
     canon = flush_new_canonical_with_slug_retry(
         session,

--- a/packages/backfield-entities/src/backfield_entities/entities/person/policy.py
+++ b/packages/backfield-entities/src/backfield_entities/entities/person/policy.py
@@ -130,6 +130,8 @@ def _strong_identity_canonical_ids(
     matches: list[str] = []
     seen: set[str] = set()
 
+    # Trusted exact-alias hits already prove name identity (docs: name or alias).
+    # Only affiliation must still match; label equality is not required.
     for cid in canonical_ids_from_person_name_keys(
         session,
         stylebook_id=stylebook_id,
@@ -139,7 +141,7 @@ def _strong_identity_canonical_ids(
         canon = session.get(StylebookPersonCanonical, cid)
         if canon is None or canon.id is None or canon.status != "active":
             continue
-        if person_strong_identity_matches_canonical(person, canon):
+        if person_affiliation_matches_canonical(person, canon):
             if cid not in seen:
                 seen.add(cid)
                 matches.append(cid)

--- a/packages/backfield-entities/src/backfield_entities/entities/person/recall.py
+++ b/packages/backfield-entities/src/backfield_entities/entities/person/recall.py
@@ -145,7 +145,12 @@ def _score_canonical_for_person(
     title_norm: str,
     aff_norm: str,
     canon: StylebookPersonCanonical,
-) -> int:
+) -> tuple[int, int]:
+    """Return ``(total_score, name_score)``.
+
+    Title/affiliation bonuses must not alone clear the recall floor — otherwise
+    unrelated peers who share an employer drown out exact-name candidates.
+    """
     cid = str(canon.id) if canon.id is not None else ""
     aliases = _alias_texts_for_canonical(session, canon_id=cid) if cid else []
     score = score_person_name_overlap(
@@ -161,11 +166,13 @@ def _score_canonical_for_person(
             or normalize_person_text(canon.label) in norm
         ):
             score = 40
-    if title_norm and normalize_person_text(canon.title) == title_norm:
-        score += 20
-    if aff_norm and normalize_person_text(canon.affiliation) == aff_norm:
-        score += 20
-    return score
+    name_score = score
+    if name_score > 0:
+        if title_norm and normalize_person_text(canon.title) == title_norm:
+            score += 20
+        if aff_norm and normalize_person_text(canon.affiliation) == aff_norm:
+            score += 20
+    return score, name_score
 
 
 def _canonical_ids_from_exact_alias(
@@ -267,7 +274,7 @@ def retrieve_person_canonical_candidates(
         canon = session.get(StylebookPersonCanonical, cid)
         if canon is None or canon.id is None or canon.status != "active":
             continue
-        score = _score_canonical_for_person(
+        score, name_score = _score_canonical_for_person(
             session,
             query_display=query_display,
             norm=norm,
@@ -275,7 +282,7 @@ def retrieve_person_canonical_candidates(
             aff_norm=aff_norm,
             canon=canon,
         )
-        if score > 0:
+        if score > 0 and (name_score > 0 or cid in exact_alias_ids):
             if cid in exact_alias_ids:
                 score = max(score, 100)
             scored[str(canon.id)] = (score, str(canon.label))
@@ -293,7 +300,7 @@ def retrieve_person_canonical_candidates(
         if canon.id is None:
             continue
         cid = str(canon.id)
-        score = _score_canonical_for_person(
+        score, name_score = _score_canonical_for_person(
             session,
             query_display=query_display,
             norm=norm,
@@ -301,6 +308,8 @@ def retrieve_person_canonical_candidates(
             aff_norm=aff_norm,
             canon=canon,
         )
+        if name_score < PERSON_RECALL_MIN_SCORE:
+            continue
         if score < PERSON_RECALL_MIN_SCORE:
             continue
         prev = scored.get(cid)

--- a/packages/backfield-entities/src/backfield_entities/entities/person/types.py
+++ b/packages/backfield-entities/src/backfield_entities/entities/person/types.py
@@ -68,13 +68,35 @@ def normalize_person_text(value: str | None) -> str:
     return normalize_match_text(value)
 
 
+def person_display_name_core(value: str | None) -> str:
+    """Return the name core used for identity matching.
+
+    CSV and editorial imports often jam a role into the label as
+    ``Given Family, Title…`` (e.g. ``Christine Hines, County Clerk``). Multi-token
+    text before the first comma is treated as the person name; single-token heads
+    (``Last, First``) are left unchanged.
+    """
+    raw = (value or "").strip()
+    if not raw or "," not in raw:
+        return raw
+    head, _sep, tail = raw.partition(",")
+    head = head.strip()
+    tail = tail.strip()
+    if not head or not tail:
+        return raw
+    if len(head.split()) >= 2:
+        return head
+    return raw
+
+
 def person_match_key(value: str | None) -> str:
     """Accent- and punctuation-insensitive key for person-name equality.
 
     Display text is unchanged elsewhere. Periods and other non-alphanumerics are
-    removed so ``C.J. Stroud`` and ``CJ Stroud`` share a key.
+    removed so ``C.J. Stroud`` and ``CJ Stroud`` share a key. Role suffixes after a
+    comma (``Name, Title``) are stripped when the head is a multi-token name.
     """
-    folded = match_fold_key(value)
+    folded = match_fold_key(person_display_name_core(value))
     if not folded:
         return ""
     stripped = _PERSON_KEY_PUNCT_RE.sub("", folded)
@@ -108,12 +130,22 @@ def person_alias_lookup_keys(value: str | None) -> tuple[str, ...]:
     """Stored ``normalized_alias`` variants for recall and exact alias lookup.
 
     Includes literal + accent-folded forms plus the punctuation-stripped
-    ``person_match_key`` so dotted initials hit both stored shapes.
+    ``person_match_key`` so dotted initials hit both stored shapes. When the
+    display string includes a ``, Title`` suffix, also seed keys for the name
+    core so ingest of the bare name can exact-match.
     """
     keys = list(alias_lookup_keys(value))
     folded = person_match_key(value)
     if folded and folded not in keys:
         keys.append(folded)
+    core = person_display_name_core(value)
+    if core and core != (value or "").strip():
+        for extra in alias_lookup_keys(core):
+            if extra not in keys:
+                keys.append(extra)
+        core_folded = person_match_key(core)
+        if core_folded and core_folded not in keys:
+            keys.append(core_folded)
     return tuple(keys)
 
 

--- a/tests/agate_api/test_geocoder_provider_health_cost.py
+++ b/tests/agate_api/test_geocoder_provider_health_cost.py
@@ -1,0 +1,33 @@
+"""Run estimated-cost helpers for geocoder provider health."""
+
+from __future__ import annotations
+
+from api.routers.runs import _geocoder_health_from_node_outputs, _merge_geocoder_health_maps
+
+
+def test_merge_geocoder_health_maps_sums_counts() -> None:
+    merged: dict[str, dict[str, int]] = {}
+    _merge_geocoder_health_maps(
+        merged,
+        {"pelias": {"auth_error": 3, "rate_limit": 0, "http_error": 0}},
+    )
+    _merge_geocoder_health_maps(
+        merged,
+        {"pelias": {"auth_error": 1, "rate_limit": 2, "http_error": 0}},
+    )
+    assert merged["pelias"]["auth_error"] == 4
+    assert merged["pelias"]["rate_limit"] == 2
+
+
+def test_geocoder_health_from_node_outputs_reads_geocode_agent_contribution() -> None:
+    from_outputs = _geocoder_health_from_node_outputs(
+        {
+            "geo": {
+                "places": {},
+                "geocoder_provider_health": {
+                    "pelias": {"auth_error": 5, "rate_limit": 0, "http_error": 0}
+                },
+            }
+        }
+    )
+    assert from_outputs["pelias"]["auth_error"] == 5

--- a/tests/entities/test_location_standalone_geometry.py
+++ b/tests/entities/test_location_standalone_geometry.py
@@ -1,0 +1,84 @@
+"""Standalone location create must write PostGIS ``geometry`` alongside GeoJSON."""
+
+from __future__ import annotations
+
+from backfield_db import BackfieldOrganization, Stylebook, StylebookLocationCanonical
+from backfield_entities.entities.location.persist import create_standalone_canonical
+from backfield_entities.geo.geometry_bind import geojson_to_wkt
+from sqlmodel import Session, SQLModel, create_engine, select
+
+
+def _seed_stylebook(session: Session) -> int:
+    org = BackfieldOrganization(name="Org", slug="org-loc-geom")
+    session.add(org)
+    session.commit()
+    session.refresh(org)
+    sb = Stylebook(
+        organization_id=int(org.id),  # type: ignore[arg-type]
+        slug="default",
+        name="Default",
+        is_default=True,
+    )
+    session.add(sb)
+    session.commit()
+    session.refresh(sb)
+    return int(sb.id)  # type: ignore[arg-type]
+
+
+def test_create_standalone_canonical_binds_postgis_geometry_from_geojson() -> None:
+    engine = create_engine("sqlite://", echo=False)
+    SQLModel.metadata.create_all(engine)
+    polygon = {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [-92.0, 45.0],
+                [-92.0, 45.1],
+                [-91.9, 45.1],
+                [-91.9, 45.0],
+                [-92.0, 45.0],
+            ]
+        ],
+    }
+    expected_wkt = geojson_to_wkt(polygon)
+    assert expected_wkt is not None
+
+    with Session(engine) as session:
+        sb_id = _seed_stylebook(session)
+        canon = create_standalone_canonical(
+            session,
+            stylebook_id=sb_id,
+            label="Town Boundary",
+            location_type="city",
+            geometry_json=polygon,
+            provenance="stylebook_ui_import_geojson",
+        )
+        session.commit()
+        cid = str(canon.id)
+
+    with Session(engine) as session:
+        row = session.get(StylebookLocationCanonical, cid)
+        assert row is not None
+        assert row.geometry_json == polygon
+        assert row.geometry_type == "Polygon"
+        assert row.geometry is not None
+        assert str(row.geometry) == expected_wkt
+        assert row.h3_cell is not None
+
+
+def test_create_standalone_canonical_without_geometry_leaves_postgis_null() -> None:
+    engine = create_engine("sqlite://", echo=False)
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as session:
+        sb_id = _seed_stylebook(session)
+        canon = create_standalone_canonical(
+            session,
+            stylebook_id=sb_id,
+            label="No Map",
+            provenance="stylebook_ui_manual",
+        )
+        session.commit()
+        assert canon.geometry is None
+        assert canon.geometry_json is None
+        rows = session.exec(select(StylebookLocationCanonical)).all()
+        assert len(rows) == 1

--- a/tests/entities/test_person_name_match.py
+++ b/tests/entities/test_person_name_match.py
@@ -36,6 +36,22 @@ def test_person_alias_lookup_keys_include_punctuation_stripped() -> None:
     assert "cj stroud" in keys
 
 
+def test_person_match_key_strips_title_after_comma() -> None:
+    assert person_match_key("Christine Hines, County Clerk") == person_match_key("Christine Hines")
+    assert person_names_match("Christine Hines", "Christine Hines, County Clerk")
+
+
+def test_person_match_key_preserves_last_first_comma_form() -> None:
+    # Single-token head is treated as Last, First — not a title suffix.
+    assert person_match_key("Smith, John") == "smith john"
+
+
+def test_person_alias_lookup_keys_include_name_core_without_title() -> None:
+    keys = person_alias_lookup_keys("Christine Hines, County Clerk")
+    assert "christine hines" in keys
+    assert person_match_key("Christine Hines") in keys
+
+
 def test_person_name_tokens_strips_middle_initial() -> None:
     given, family, tokens = person_name_tokens("Ronald L. Wyden")
     assert given == "ronald"

--- a/tests/entities/test_person_recall.py
+++ b/tests/entities/test_person_recall.py
@@ -10,7 +10,10 @@ from backfield_db import (
     SubstratePerson,
 )
 from backfield_entities.canonical.plan_types import CanonicalPersistDecision
-from backfield_entities.entities.person.persist import upsert_alias_for_canonical_text
+from backfield_entities.entities.person.persist import (
+    create_standalone_canonical,
+    upsert_alias_for_canonical_text,
+)
 from backfield_entities.entities.person.policy import (
     decide_person_canonical_persist_plan,
     find_existing_person_canonical_id_by_strong_identity,
@@ -252,6 +255,60 @@ def test_alias_hit_with_affiliation_mismatch_defers_not_links() -> None:
         session.refresh(person)
         plan = decide_person_canonical_persist_plan(session, stylebook_id=sb_id, person=person)
         assert plan.decision == CanonicalPersistDecision.DEFER
+
+
+def test_exact_alias_with_title_suffix_tier1_links_bare_name() -> None:
+    """CSV labels like ``Name, Title`` must still exact-alias match the bare name."""
+    engine = _engine()
+    with Session(engine) as session:
+        sb_id, pid = _seed(session)
+        canon = create_standalone_canonical(
+            session,
+            stylebook_id=sb_id,
+            label="Christine Hines, County Clerk",
+            title="County Clerk",
+            affiliation="St. Croix County",
+            provenance="stylebook_ui_import_csv",
+        )
+        session.commit()
+        # Affiliation-only peers that previously drowned recall.
+        for label, slug in (
+            ("Other Official", "other-official"),
+            ("Another Official", "another-official"),
+        ):
+            peer = StylebookPersonCanonical(
+                stylebook_id=sb_id,
+                label=label,
+                slug=slug,
+                affiliation="St. Croix County",
+                status="active",
+            )
+            session.add(peer)
+        session.commit()
+
+        person = SubstratePerson(
+            project_id=pid,
+            name="Christine Hines",
+            normalized_name="christine hines",
+            title="County Clerk",
+            affiliation="St. Croix County",
+        )
+        session.add(person)
+        session.commit()
+        session.refresh(person)
+
+        linked = find_existing_person_canonical_id_by_strong_identity(
+            session, stylebook_id=sb_id, person=person
+        )
+        assert linked == str(canon.id)
+
+        ranked = retrieve_person_canonical_candidates(
+            session, stylebook_id=sb_id, person=person, limit=10
+        )
+        recall_ids = [cid for cid, _label in ranked]
+        assert str(canon.id) in recall_ids
+        # Affiliation-only peers must not appear without name evidence.
+        assert all("Hines" in label or label.startswith("Christine") for _cid, label in ranked)
 
 
 def test_same_affiliation_different_name_does_not_tier1_link() -> None:

--- a/tests/worker/test_organization_replace_partial_recovery.py
+++ b/tests/worker/test_organization_replace_partial_recovery.py
@@ -1,0 +1,94 @@
+"""Replace after a partial org persist must not raise StaleDataError."""
+
+from __future__ import annotations
+
+from backfield_db import (
+    AgateRun,
+    SubstrateOrganization,
+    SubstrateOrganizationMention,
+)
+from sqlmodel import Session, SQLModel, col, create_engine, select
+from worker.substrate.orchestration import persist_from_consolidated
+
+from tests.worker.test_organization_substrate_persistence import (
+    _bootstrap_project,
+    _sample_organization_entry,
+)
+
+
+def test_organizations_replace_recovers_after_partial_machine_persist() -> None:
+    """Simulate durable org rows left behind (e.g. mid-LLM commit), then replace."""
+    engine = create_engine("sqlite://", echo=False)
+    SQLModel.metadata.create_all(engine)
+    url = "https://example.com/organizations-partial-replace"
+
+    with Session(engine) as session:
+        project_id = _bootstrap_project(
+            session,
+            org_slug="org-organization-partial",
+            project_slug="proj-organization-partial",
+        )
+        for run_id in ("run-org-p1", "run-org-p2"):
+            session.add(AgateRun(id=run_id, graph_id="graph-org-partial", status="pending"))
+        session.commit()
+
+        # First pass persists two orgs (as if places/people finished and orgs partially wrote).
+        persist_from_consolidated(
+            session,
+            project_id=project_id,
+            graph_id="graph-org-partial",
+            run_id="run-org-p1",
+            consolidated={
+                "text": "Alpha Org and Beta Org appeared.",
+                "url": url,
+                "organizations": [
+                    {**_sample_organization_entry(name="Alpha Org"), "type": "business"},
+                    {**_sample_organization_entry(name="Beta Org"), "type": "nonprofit"},
+                ],
+            },
+            db_output_params={"reconciliation_policy": "smart_merge"},
+        )
+        session.commit()
+
+        # Leave rows durable, then authoritative replace with a type refinement for Alpha
+        # (fingerprint change) and drop Beta — the recovery path that used to wedge.
+        result = persist_from_consolidated(
+            session,
+            project_id=project_id,
+            graph_id="graph-org-partial",
+            run_id="run-org-p2",
+            consolidated={
+                "text": "Only Alpha Org remains, now typed as government.",
+                "url": url,
+                "organizations": [
+                    {**_sample_organization_entry(name="Alpha Org"), "type": "government"},
+                ],
+            },
+            db_output_params={"reconciliation_policy": "replace"},
+        )
+        session.commit()
+
+        summary = next(item for item in result.domain_summaries if item.domain == "organizations")
+        assert summary.policy == "replace"
+        assert result.disposed_substrates >= 1
+
+    with Session(engine) as session:
+        names = {
+            organization.normalized_name
+            for organization in session.exec(select(SubstrateOrganization)).all()
+        }
+        assert "beta org" not in names
+        assert "alpha org" in names
+        alpha = session.exec(
+            select(SubstrateOrganization).where(
+                SubstrateOrganization.normalized_name == "alpha org"
+            )
+        ).one()
+        assert alpha.organization_type == "government"
+        active = session.exec(
+            select(SubstrateOrganizationMention).where(
+                SubstrateOrganizationMention.organization_id == int(alpha.id),
+                col(SubstrateOrganizationMention.deleted).is_(False),
+            )
+        ).all()
+        assert len(active) == 1

--- a/tests/worker/test_organization_substrate_persistence.py
+++ b/tests/worker/test_organization_substrate_persistence.py
@@ -559,11 +559,11 @@ def test_organizations_replace_reconciles_omissions_and_preserves_editorial_asso
         session.commit()
 
         summary = next(item for item in result.domain_summaries if item.domain == "organizations")
-        assert summary.removed == 2
+        assert summary.removed == 3
         assert summary.preserved == 3
-        assert summary.disposed == 1
-        assert result.retired_mentions == 2
-        assert result.disposed_substrates == 1
+        assert summary.disposed == 2
+        assert result.retired_mentions == 3
+        assert result.disposed_substrates == 2
 
     with Session(engine) as session:
         remaining_names = {

--- a/tests/worker/test_person_substrate_persistence.py
+++ b/tests/worker/test_person_substrate_persistence.py
@@ -438,11 +438,11 @@ def test_people_replace_reconciles_omissions_and_preserves_editorial_association
         session.commit()
 
         summary = next(item for item in result.domain_summaries if item.domain == "people")
-        assert summary.removed == 2
+        assert summary.removed == 3
         assert summary.preserved == 3
-        assert summary.disposed == 1
-        assert result.retired_mentions == 2
-        assert result.disposed_substrates == 1
+        assert summary.disposed == 2
+        assert result.retired_mentions == 3
+        assert result.disposed_substrates == 2
 
     with Session(engine) as session:
         remaining_names = {


### PR DESCRIPTION
## Summary

Fixes four production issues reported from a BuiltRevenue instance:

- **Replace after partial persist:** people/orgs pre-clear machine associations under `replace` and dispose flushes/expunges before delete, so a mid-run failure no longer wedges articles with `StaleDataError` on `substrate_organization`.
- **GeoJSON import geometry:** standalone location create (and candidate create-with-geometry) write PostGIS `geometry` alongside `geometry_json` so bbox/geo-search work.
- **Person exact-alias recall:** strip multi-token `Name, Title…` suffixes for match keys; tier-1 trusts editorial alias + affiliation without requiring label equality; affiliation-only peers no longer fill recall.
- **Dead primary geocoder visibility:** Pelias retries 429/5xx, records auth/rate-limit counts, and surfaces degraded location-lookup health on the run cost panel.

Docs under `docs/architecture/canonicalization.md`, `docs/development/entities/overview.md`, and `docs/OBSERVABILITY.md` updated.

## Project scope check

- [x] This change targets local development / source inspection (production self-hosting is unsupported in this repo)
- [x] Docs under `docs/` updated if behavior, architecture, or operations changed
- [x] First-admin provisioning still uses `backfield init` / `backfield seed` only (no HTTP/env bootstrap paths)

## Test plan

- [x] `make lint`
- [x] `make test`
- [ ] `make ui-typecheck ui-test` (if UI/TypeScript changed)
- [ ] `make smoke-fast` (if live-stack behavior changed)
- [ ] `make smoke` (if golden-path / provider-dependent runtime changed; configure **Settings → AI models**)

## Notes for reviewers

- Existing Stylebook rows that already have `geometry_json` but null `geometry` still need a one-shot PostGIS backfill (`ST_GeomFromGeoJSON`); this PR fixes the write path only.
- Replace pre-clear changes removed/disposed counts for people/orgs under `replace` (tests updated); editorial associations remain preserved.
- Geocoder health appears on the estimated-cost card when auth/rate-limit counts are present, even if there were no AI call rows.

Made with [Cursor](https://cursor.com)