### PR TITLE
Move prod Python images to slim-trixie for OpenSSL CVE-2026-75803

### DIFF
--- a/apps/agate-api/Dockerfile
+++ b/apps/agate-api/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM python:3.11-slim-bookworm AS base
+FROM python:3.11-slim-trixie AS base
 
 WORKDIR /app
 ENV PYTHONDONTWRITEBYTECODE=1 \
@@ -37,7 +37,7 @@ RUN uv pip install --system /app/packages/backfield-db \
     && uv pip install --system --no-deps --no-sources /app/packages/backfield-cli \
     && uv pip install --system /app/apps/agate-api
 
-FROM python:3.11-slim-bookworm AS prod
+FROM python:3.11-slim-trixie AS prod
 
 WORKDIR /app
 ENV PYTHONDONTWRITEBYTECODE=1 \
@@ -51,10 +51,17 @@ ENV APP_VERSION=${APP_VERSION} \
     GIT_SHA=${GIT_SHA} \
     BUILD_TIME=${BUILD_TIME}
 
-# The final Python service does not invoke Perl. Remove the unpatched Debian
-# runtime package (builders retain normal tooling); no package management runs
-# after this point.
-RUN dpkg --purge --force-depends --force-remove-essential perl-base \
+# Pin OpenSSL to trixie-security (≥ 3.5.7-1~deb13u2) for CVE-2026-75803 before
+# any further package removals. bookworm has no fixed openssl package yet.
+# The final Python service does not invoke Perl; remove perl-base after that.
+# No package management runs after this point.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        openssl \
+        libssl3t64 \
+        openssl-provider-legacy \
+    && rm -rf /var/lib/apt/lists/* \
+    && dpkg --purge --force-depends --force-remove-essential perl-base \
     && useradd --create-home --uid 10001 --shell /usr/sbin/nologin appuser
 
 COPY --from=builder /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages

--- a/apps/core-api/Dockerfile
+++ b/apps/core-api/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM python:3.11-slim-bookworm AS base
+FROM python:3.11-slim-trixie AS base
 
 WORKDIR /app
 ENV PYTHONDONTWRITEBYTECODE=1 \
@@ -31,7 +31,7 @@ RUN uv pip install --system /app/packages/backfield-db \
     && uv pip install --system /app/packages/backfield-auth \
     && uv pip install --system /app/apps/core-api
 
-FROM python:3.11-slim-bookworm AS prod
+FROM python:3.11-slim-trixie AS prod
 
 WORKDIR /app
 ENV PYTHONDONTWRITEBYTECODE=1 \
@@ -44,9 +44,17 @@ ENV APP_VERSION=${APP_VERSION} \
     GIT_SHA=${GIT_SHA} \
     BUILD_TIME=${BUILD_TIME}
 
-# The final Python service does not invoke Perl. Remove the unpatched Debian
-# runtime package; no package management runs after this point.
-RUN dpkg --purge --force-depends --force-remove-essential perl-base \
+# Pin OpenSSL to trixie-security (≥ 3.5.7-1~deb13u2) for CVE-2026-75803 before
+# any further package removals. bookworm has no fixed openssl package yet.
+# The final Python service does not invoke Perl; remove perl-base after that.
+# No package management runs after this point.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        openssl \
+        libssl3t64 \
+        openssl-provider-legacy \
+    && rm -rf /var/lib/apt/lists/* \
+    && dpkg --purge --force-depends --force-remove-essential perl-base \
     && useradd --create-home --uid 10001 --shell /usr/sbin/nologin appuser
 
 COPY --from=builder /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages

--- a/apps/stylebook-api/Dockerfile
+++ b/apps/stylebook-api/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM python:3.11-slim-bookworm AS base
+FROM python:3.11-slim-trixie AS base
 
 WORKDIR /app
 ENV PYTHONDONTWRITEBYTECODE=1 \
@@ -29,7 +29,7 @@ RUN uv pip install --system /app/packages/backfield-db \
     && uv pip install --system /app/packages/backfield-auth \
     && uv pip install --system /app/apps/stylebook-api
 
-FROM python:3.11-slim-bookworm AS prod
+FROM python:3.11-slim-trixie AS prod
 
 WORKDIR /app
 ENV PYTHONDONTWRITEBYTECODE=1 \
@@ -42,9 +42,17 @@ ENV APP_VERSION=${APP_VERSION} \
     GIT_SHA=${GIT_SHA} \
     BUILD_TIME=${BUILD_TIME}
 
-# The final Python service does not invoke Perl. Remove the unpatched Debian
-# runtime package; no package management runs after this point.
-RUN dpkg --purge --force-depends --force-remove-essential perl-base \
+# Pin OpenSSL to trixie-security (≥ 3.5.7-1~deb13u2) for CVE-2026-75803 before
+# any further package removals. bookworm has no fixed openssl package yet.
+# The final Python service does not invoke Perl; remove perl-base after that.
+# No package management runs after this point.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        openssl \
+        libssl3t64 \
+        openssl-provider-legacy \
+    && rm -rf /var/lib/apt/lists/* \
+    && dpkg --purge --force-depends --force-remove-essential perl-base \
     && useradd --create-home --uid 10001 --shell /usr/sbin/nologin appuser
 
 COPY --from=builder /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM python:3.11-slim-bookworm AS base
+FROM python:3.11-slim-trixie AS base
 
 WORKDIR /app
 ENV PYTHONDONTWRITEBYTECODE=1 \
@@ -34,7 +34,7 @@ RUN uv pip install --system /app/packages/backfield-db \
     && uv pip install --system /app/packages/backfield-agate \
     && uv pip install --system /app/apps/worker
 
-FROM python:3.11-slim-bookworm AS prod
+FROM python:3.11-slim-trixie AS prod
 
 WORKDIR /app
 ENV PYTHONDONTWRITEBYTECODE=1 \
@@ -48,9 +48,17 @@ ENV APP_VERSION=${APP_VERSION} \
     GIT_SHA=${GIT_SHA} \
     BUILD_TIME=${BUILD_TIME}
 
-# The final Python service does not invoke Perl. Remove the unpatched Debian
-# runtime package; no package management runs after this point.
-RUN dpkg --purge --force-depends --force-remove-essential perl-base \
+# Pin OpenSSL to trixie-security (≥ 3.5.7-1~deb13u2) for CVE-2026-75803 before
+# any further package removals. bookworm has no fixed openssl package yet.
+# The final Python service does not invoke Perl; remove perl-base after that.
+# No package management runs after this point.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        openssl \
+        libssl3t64 \
+        openssl-provider-legacy \
+    && rm -rf /var/lib/apt/lists/* \
+    && dpkg --purge --force-depends --force-remove-essential perl-base \
     && useradd --create-home --uid 10001 --shell /usr/sbin/nologin appuser
 
 COPY --from=builder /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -46,6 +46,11 @@ make docker-build-prod-worker \
 The Bake targets are `agate-api`, `core-api`, `stylebook-api`, and `worker`. They use the repository
 root as build context, target each Dockerfile's `prod` stage, and build for `linux/amd64`.
 
+Production (and shared `base`) stages use `python:3.11-slim-trixie` and explicitly install
+`openssl` / `libssl3t64` from trixie-security (≥ `3.5.7-1~deb13u2`) before removing `perl-base`.
+That clears ECR CRITICAL `CVE-2026-75803`; Debian bookworm still has no fixed openssl package, so
+staying on `slim-bookworm` cannot pass the publish scan gate until a bookworm DSA ships.
+
 The production API stages install non-editable packages and start Uvicorn without reload as a
 non-root `appuser`. The worker starts Celery through `apps/worker/scripts/entrypoint.sh` (also
 non-root in prod). Every image receives `APP_VERSION`, `GIT_SHA`, `BUILD_TIME`, and `LICENSE.md`.


### PR DESCRIPTION
## Summary

Unblocks GitHub Actions publish after ECR CRITICAL findings on all four service images (`agate-api`, `core-api`, `stylebook-api`, `worker`).

Root cause was Debian `openssl` `3.0.20-1~deb12u2` from `python:3.11-slim-bookworm` (CVE-2026-75803). bookworm still has no fixed package; trixie-security is fixed at `3.5.7-1~deb13u2`.

- Move shared `base` and `prod` stages to `python:3.11-slim-trixie`
- Explicitly install `openssl` / `libssl3t64` / `openssl-provider-legacy` before the `perl-base` purge
- Document the base-image choice in `docs/operations/deployment.md`

Does not use `--skip-scan-gate`.

## Project scope check

- [x] This change targets local development / source inspection (production self-hosting is unsupported in this repo)
- [x] Docs under `docs/` updated if behavior, architecture, or operations changed
- [x] First-admin provisioning still uses `backfield init` / `backfield seed` only (no HTTP/env bootstrap paths)

## Test plan

- [x] `make lint`
- [ ] `make test`
- [ ] `make ui-typecheck ui-test` (if UI/TypeScript changed)
- [ ] `make smoke-fast` (if live-stack behavior changed)
- [ ] `make smoke` (if golden-path / provider-dependent runtime changed; configure **Settings → AI models**)
- [x] Local amd64 `prod` builds for all four images report `openssl`/`libssl3t64` `3.5.7-1~deb13u2`
- [ ] CI publish: ECR `findingSeverityCounts.CRITICAL == 0` for amd64 children of all four repos, then `release_manifest.py` publish succeeds

## Notes for reviewers

- Shared base-image issue, not app code in the failing main commit.
- Local Compose `dev` targets also inherit `slim-trixie` via the shared `base` stage.
- Full ECR CRITICAL clearance is confirmed only after CI rebuild/push; staying on bookworm cannot pass until Debian ships a bookworm DSA.

Made with [Cursor](https://cursor.com)