### PR TITLE
Install OpenSSL 3.6.4 from sid for ECR CVE-2026-75803

### DIFF
--- a/apps/agate-api/Dockerfile
+++ b/apps/agate-api/Dockerfile
@@ -51,15 +51,19 @@ ENV APP_VERSION=${APP_VERSION} \
     GIT_SHA=${GIT_SHA} \
     BUILD_TIME=${BUILD_TIME}
 
-# Pin OpenSSL to trixie-security (≥ 3.5.7-1~deb13u2) for CVE-2026-75803 before
-# any further package removals. bookworm has no fixed openssl package yet.
-# The final Python service does not invoke Perl; remove perl-base after that.
-# No package management runs after this point.
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
+# CVE-2026-75803: NVD/ECR treat OpenSSL <3.5.8 / <3.6.4 as CRITICAL even though
+# Debian marks trixie-security 3.5.7-1~deb13u2 fixed. Install upstream-fixed
+# openssl 3.6.4-1 from sid (pinned so only these packages come from unstable),
+# then remove perl-base (CRITICAL on the slim base). No package management after.
+RUN echo "deb http://deb.debian.org/debian sid main" > /etc/apt/sources.list.d/sid.list \
+    && printf "Package: *\nPin: release a=unstable\nPin-Priority: 100\n" \
+        > /etc/apt/preferences.d/sid \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends -t sid \
         openssl \
         libssl3t64 \
         openssl-provider-legacy \
+    && rm -f /etc/apt/sources.list.d/sid.list /etc/apt/preferences.d/sid \
     && rm -rf /var/lib/apt/lists/* \
     && dpkg --purge --force-depends --force-remove-essential perl-base \
     && useradd --create-home --uid 10001 --shell /usr/sbin/nologin appuser

--- a/apps/core-api/Dockerfile
+++ b/apps/core-api/Dockerfile
@@ -44,15 +44,19 @@ ENV APP_VERSION=${APP_VERSION} \
     GIT_SHA=${GIT_SHA} \
     BUILD_TIME=${BUILD_TIME}
 
-# Pin OpenSSL to trixie-security (≥ 3.5.7-1~deb13u2) for CVE-2026-75803 before
-# any further package removals. bookworm has no fixed openssl package yet.
-# The final Python service does not invoke Perl; remove perl-base after that.
-# No package management runs after this point.
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
+# CVE-2026-75803: NVD/ECR treat OpenSSL <3.5.8 / <3.6.4 as CRITICAL even though
+# Debian marks trixie-security 3.5.7-1~deb13u2 fixed. Install upstream-fixed
+# openssl 3.6.4-1 from sid (pinned so only these packages come from unstable),
+# then remove perl-base (CRITICAL on the slim base). No package management after.
+RUN echo "deb http://deb.debian.org/debian sid main" > /etc/apt/sources.list.d/sid.list \
+    && printf "Package: *\nPin: release a=unstable\nPin-Priority: 100\n" \
+        > /etc/apt/preferences.d/sid \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends -t sid \
         openssl \
         libssl3t64 \
         openssl-provider-legacy \
+    && rm -f /etc/apt/sources.list.d/sid.list /etc/apt/preferences.d/sid \
     && rm -rf /var/lib/apt/lists/* \
     && dpkg --purge --force-depends --force-remove-essential perl-base \
     && useradd --create-home --uid 10001 --shell /usr/sbin/nologin appuser

--- a/apps/stylebook-api/Dockerfile
+++ b/apps/stylebook-api/Dockerfile
@@ -42,15 +42,19 @@ ENV APP_VERSION=${APP_VERSION} \
     GIT_SHA=${GIT_SHA} \
     BUILD_TIME=${BUILD_TIME}
 
-# Pin OpenSSL to trixie-security (≥ 3.5.7-1~deb13u2) for CVE-2026-75803 before
-# any further package removals. bookworm has no fixed openssl package yet.
-# The final Python service does not invoke Perl; remove perl-base after that.
-# No package management runs after this point.
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
+# CVE-2026-75803: NVD/ECR treat OpenSSL <3.5.8 / <3.6.4 as CRITICAL even though
+# Debian marks trixie-security 3.5.7-1~deb13u2 fixed. Install upstream-fixed
+# openssl 3.6.4-1 from sid (pinned so only these packages come from unstable),
+# then remove perl-base (CRITICAL on the slim base). No package management after.
+RUN echo "deb http://deb.debian.org/debian sid main" > /etc/apt/sources.list.d/sid.list \
+    && printf "Package: *\nPin: release a=unstable\nPin-Priority: 100\n" \
+        > /etc/apt/preferences.d/sid \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends -t sid \
         openssl \
         libssl3t64 \
         openssl-provider-legacy \
+    && rm -f /etc/apt/sources.list.d/sid.list /etc/apt/preferences.d/sid \
     && rm -rf /var/lib/apt/lists/* \
     && dpkg --purge --force-depends --force-remove-essential perl-base \
     && useradd --create-home --uid 10001 --shell /usr/sbin/nologin appuser

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -48,15 +48,19 @@ ENV APP_VERSION=${APP_VERSION} \
     GIT_SHA=${GIT_SHA} \
     BUILD_TIME=${BUILD_TIME}
 
-# Pin OpenSSL to trixie-security (≥ 3.5.7-1~deb13u2) for CVE-2026-75803 before
-# any further package removals. bookworm has no fixed openssl package yet.
-# The final Python service does not invoke Perl; remove perl-base after that.
-# No package management runs after this point.
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
+# CVE-2026-75803: NVD/ECR treat OpenSSL <3.5.8 / <3.6.4 as CRITICAL even though
+# Debian marks trixie-security 3.5.7-1~deb13u2 fixed. Install upstream-fixed
+# openssl 3.6.4-1 from sid (pinned so only these packages come from unstable),
+# then remove perl-base (CRITICAL on the slim base). No package management after.
+RUN echo "deb http://deb.debian.org/debian sid main" > /etc/apt/sources.list.d/sid.list \
+    && printf "Package: *\nPin: release a=unstable\nPin-Priority: 100\n" \
+        > /etc/apt/preferences.d/sid \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends -t sid \
         openssl \
         libssl3t64 \
         openssl-provider-legacy \
+    && rm -f /etc/apt/sources.list.d/sid.list /etc/apt/preferences.d/sid \
     && rm -rf /var/lib/apt/lists/* \
     && dpkg --purge --force-depends --force-remove-essential perl-base \
     && useradd --create-home --uid 10001 --shell /usr/sbin/nologin appuser

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -46,10 +46,11 @@ make docker-build-prod-worker \
 The Bake targets are `agate-api`, `core-api`, `stylebook-api`, and `worker`. They use the repository
 root as build context, target each Dockerfile's `prod` stage, and build for `linux/amd64`.
 
-Production (and shared `base`) stages use `python:3.11-slim-trixie` and explicitly install
-`openssl` / `libssl3t64` from trixie-security (≥ `3.5.7-1~deb13u2`) before removing `perl-base`.
-That clears ECR CRITICAL `CVE-2026-75803`; Debian bookworm still has no fixed openssl package, so
-staying on `slim-bookworm` cannot pass the publish scan gate until a bookworm DSA ships.
+Production (and shared `base`) stages use `python:3.11-slim-trixie`. The prod stage then
+installs OpenSSL `3.6.4-1` from Debian sid (pinned so only those packages come from unstable)
+before removing `perl-base`. That satisfies NVD/ECR for CVE-2026-75803 (fixed upstream in
+3.5.8 / 3.6.4); Debian's own trixie-security `3.5.7-1~deb13u2` is marked fixed in the Debian
+tracker but ECR still treats `<3.5.8` as CRITICAL. bookworm still has no fixed openssl package.
 
 The production API stages install non-editable packages and start Uvicorn without reload as a
 non-root `appuser`. The worker starts Celery through `apps/worker/scripts/entrypoint.sh` (also

--- a/scripts/release_manifest.py
+++ b/scripts/release_manifest.py
@@ -228,6 +228,42 @@ def _wait_for_scan(ecr: Any, repository: str, tag: str) -> dict[str, int]:
     raise RuntimeError(f"ECR scan timed out for {repository}:{tag} ({image_id})")
 
 
+def _critical_finding_summaries(
+    ecr: Any, repository: str, tag: str, *, limit: int = 8
+) -> list[str]:
+    """Best-effort package/CVE labels for CRITICAL findings (for gate error text)."""
+    image_id = _scan_image_id(ecr, repository, tag)
+    try:
+        response = ecr.describe_image_scan_findings(
+            repositoryName=repository,
+            imageId=image_id,
+        )
+    except ClientError:
+        return []
+    findings = response.get("imageScanFindings", {}).get("findings") or []
+    summaries: list[str] = []
+    for finding in findings:
+        if str(finding.get("severity") or "").upper() != "CRITICAL":
+            continue
+        name = str(finding.get("name") or "unknown")
+        attrs = {
+            str(item.get("key")): str(item.get("value"))
+            for item in (finding.get("attributes") or [])
+            if isinstance(item, dict)
+        }
+        package = attrs.get("package_name") or attrs.get("packageName") or ""
+        version = attrs.get("package_version") or attrs.get("packageVersion") or ""
+        if package and version:
+            summaries.append(f"{name} ({package} {version})")
+        elif package:
+            summaries.append(f"{name} ({package})")
+        else:
+            summaries.append(name)
+        if len(summaries) >= limit:
+            break
+    return summaries
+
+
 def build_manifest(
     *,
     version: str,
@@ -261,7 +297,9 @@ def build_manifest(
         repo = ecr.describe_repositories(repositoryNames=[repository])["repositories"][0]
         scans = _wait_for_scan(ecr, repository, version) if enforce_scans else {}
         if scans.get("CRITICAL", 0):
-            critical.append(f"{repository}: {scans['CRITICAL']} CRITICAL")
+            detail_bits = _critical_finding_summaries(ecr, repository, version)
+            suffix = f" [{'; '.join(detail_bits)}]" if detail_bits else ""
+            critical.append(f"{repository}: {scans['CRITICAL']} CRITICAL{suffix}")
         images[repository] = {
             "tag": version,
             "digest": detail["imageDigest"],

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -244,12 +244,51 @@ class FakePublishEcr:
     def describe_images(self, **kwargs: Any) -> dict[str, Any]:
         return {"imageDetails": [{"imageDigest": "sha256:canonical"}]}
 
+    def batch_get_image(self, **kwargs: Any) -> dict[str, Any]:
+        # Single-arch manifest (no OCI index children) so scans key off imageTag.
+        return {
+            "images": [
+                {
+                    "imageManifest": json.dumps(
+                        {"schemaVersion": 2, "config": {}, "layers": []}
+                    )
+                }
+            ]
+        }
+
     def describe_repositories(self, **kwargs: Any) -> dict[str, Any]:
         name = kwargs["repositoryNames"][0]
         return {
             "repositories": [
                 {"repositoryUri": f"123.dkr.ecr.us-east-1.amazonaws.com/{name}"}
             ]
+        }
+
+
+class FakeScanGateEcr(FakePublishEcr):
+    """ECR stub that reports COMPLETE scans with optional CRITICAL findings."""
+
+    def __init__(
+        self,
+        *,
+        critical_counts: dict[str, int] | None = None,
+        findings_by_repo: dict[str, list[dict[str, Any]]] | None = None,
+    ) -> None:
+        self.critical_counts = critical_counts or {}
+        self.findings_by_repo = findings_by_repo or {}
+
+    def describe_image_scan_findings(self, **kwargs: Any) -> dict[str, Any]:
+        repository = kwargs["repositoryName"]
+        critical = int(self.critical_counts.get(repository, 0))
+        counts: dict[str, int] = {}
+        if critical:
+            counts["CRITICAL"] = critical
+        return {
+            "imageScanStatus": {"status": "COMPLETE"},
+            "imageScanFindings": {
+                "findingSeverityCounts": counts,
+                "findings": list(self.findings_by_repo.get(repository, [])),
+            },
         }
 
 
@@ -318,6 +357,50 @@ def test_build_manifest_requires_api_playground_and_emits_schema_v2(tmp_path: Pa
             ecr=FakePublishEcr(),
             s3=FakePublishS3(),
             enforce_scans=False,
+        )
+
+
+def test_build_manifest_critical_gate_includes_finding_labels(tmp_path: Path) -> None:
+    archives = {
+        "agate-ui": tmp_path / "agate-ui.tar.gz",
+        "stylebook-ui": tmp_path / "stylebook-ui.tar.gz",
+        "api-playground": tmp_path / "api-playground.tar.gz",
+    }
+    for path in archives.values():
+        path.write_bytes(b"archive")
+
+    source_sha = "0123456789abcdef0123456789abcdef01234567"
+    version = canonical_version(source_sha)
+    ecr = FakeScanGateEcr(
+        critical_counts={"backfield-agate-api": 1},
+        findings_by_repo={
+            "backfield-agate-api": [
+                {
+                    "name": "CVE-2026-75803",
+                    "severity": "CRITICAL",
+                    "attributes": [
+                        {"key": "package_name", "value": "libssl3t64"},
+                        {"key": "package_version", "value": "3.5.7-1~deb13u2"},
+                    ],
+                }
+            ]
+        },
+    )
+
+    expected = (
+        r"backfield-agate-api: 1 CRITICAL "
+        r"\[CVE-2026-75803 \(libssl3t64 3\.5\.7-1~deb13u2\)\]"
+    )
+    with pytest.raises(RuntimeError, match=expected):
+        build_manifest(
+            version=version,
+            source_sha=source_sha,
+            build_time="2026-01-01T00:00:00Z",
+            artifact_bucket="artifacts",
+            ui_archives=archives,
+            ecr=ecr,
+            s3=FakePublishS3(),
+            enforce_scans=True,
         )
 
 


### PR DESCRIPTION
## Summary
- Trixie-security OpenSSL `3.5.7-1~deb13u2` still fails the ECR CRITICAL gate because NVD treats OpenSSL `<3.5.8` / `<3.6.4` as vulnerable (see [run 33962899996](https://github.com/localangle/backfield/actions/runs/33962899996)).
- Prod Dockerfiles now pin-install `openssl` / `libssl3t64` / `openssl-provider-legacy` `3.6.4-1` from Debian sid (low pin priority; sid sources removed after install), then purge `perl-base` as before.
- Scan-gate failures now include CRITICAL CVE/package labels; deployment docs updated.

## Risk notes
- Same `libssl.so.3` ABI family; Python `_ssl` already links the system OpenSSL. Local check: `ssl.OPENSSL_VERSION` reports 3.6.4 and outbound HTTPS to pypi succeeds.
- Only those three packages are pulled from unstable; apt pin priority is 100 and sid lists are deleted in the same layer.
- Main runtime impact is **outbound TLS** from APIs/worker (inbound TLS stays at the load balancer). Revisit once Debian ships an NVD-satisfying trixie package and drop the sid pin.

## Test plan
- [x] Local amd64 prod image build shows OpenSSL `3.6.4-1`
- [x] `make lint` / `make test`
- [ ] CI publish-artifacts: ECR CRITICAL counts are 0 for all four repos
- [ ] After promote: smoke login + one Agate run that hits external HTTPS (LLM / geocode / S3 as applicable)


Made with [Cursor](https://cursor.com)