### PR TITLE
Gate ECR CRITICALs with a reviewed CVE allowlist; drop sid OpenSSL pin

### DIFF
--- a/apps/agate-api/Dockerfile
+++ b/apps/agate-api/Dockerfile
@@ -51,19 +51,15 @@ ENV APP_VERSION=${APP_VERSION} \
     GIT_SHA=${GIT_SHA} \
     BUILD_TIME=${BUILD_TIME}
 
-# CVE-2026-75803: NVD/ECR treat OpenSSL <3.5.8 / <3.6.4 as CRITICAL even though
-# Debian marks trixie-security 3.5.7-1~deb13u2 fixed. Install upstream-fixed
-# openssl 3.6.4-1 from sid (pinned so only these packages come from unstable),
-# then remove perl-base (CRITICAL on the slim base). No package management after.
-RUN echo "deb http://deb.debian.org/debian sid main" > /etc/apt/sources.list.d/sid.list \
-    && printf "Package: *\nPin: release a=unstable\nPin-Priority: 100\n" \
-        > /etc/apt/preferences.d/sid \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends -t sid \
+# Pin OpenSSL to trixie-security (≥ 3.5.7-1~deb13u2) for CVE-2026-75803 before
+# any further package removals. bookworm has no fixed openssl package yet.
+# The final Python service does not invoke Perl; remove perl-base after that.
+# No package management runs after this point.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
         openssl \
         libssl3t64 \
         openssl-provider-legacy \
-    && rm -f /etc/apt/sources.list.d/sid.list /etc/apt/preferences.d/sid \
     && rm -rf /var/lib/apt/lists/* \
     && dpkg --purge --force-depends --force-remove-essential perl-base \
     && useradd --create-home --uid 10001 --shell /usr/sbin/nologin appuser

--- a/apps/core-api/Dockerfile
+++ b/apps/core-api/Dockerfile
@@ -44,19 +44,15 @@ ENV APP_VERSION=${APP_VERSION} \
     GIT_SHA=${GIT_SHA} \
     BUILD_TIME=${BUILD_TIME}
 
-# CVE-2026-75803: NVD/ECR treat OpenSSL <3.5.8 / <3.6.4 as CRITICAL even though
-# Debian marks trixie-security 3.5.7-1~deb13u2 fixed. Install upstream-fixed
-# openssl 3.6.4-1 from sid (pinned so only these packages come from unstable),
-# then remove perl-base (CRITICAL on the slim base). No package management after.
-RUN echo "deb http://deb.debian.org/debian sid main" > /etc/apt/sources.list.d/sid.list \
-    && printf "Package: *\nPin: release a=unstable\nPin-Priority: 100\n" \
-        > /etc/apt/preferences.d/sid \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends -t sid \
+# Pin OpenSSL to trixie-security (≥ 3.5.7-1~deb13u2) for CVE-2026-75803 before
+# any further package removals. bookworm has no fixed openssl package yet.
+# The final Python service does not invoke Perl; remove perl-base after that.
+# No package management runs after this point.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
         openssl \
         libssl3t64 \
         openssl-provider-legacy \
-    && rm -f /etc/apt/sources.list.d/sid.list /etc/apt/preferences.d/sid \
     && rm -rf /var/lib/apt/lists/* \
     && dpkg --purge --force-depends --force-remove-essential perl-base \
     && useradd --create-home --uid 10001 --shell /usr/sbin/nologin appuser

--- a/apps/stylebook-api/Dockerfile
+++ b/apps/stylebook-api/Dockerfile
@@ -42,19 +42,15 @@ ENV APP_VERSION=${APP_VERSION} \
     GIT_SHA=${GIT_SHA} \
     BUILD_TIME=${BUILD_TIME}
 
-# CVE-2026-75803: NVD/ECR treat OpenSSL <3.5.8 / <3.6.4 as CRITICAL even though
-# Debian marks trixie-security 3.5.7-1~deb13u2 fixed. Install upstream-fixed
-# openssl 3.6.4-1 from sid (pinned so only these packages come from unstable),
-# then remove perl-base (CRITICAL on the slim base). No package management after.
-RUN echo "deb http://deb.debian.org/debian sid main" > /etc/apt/sources.list.d/sid.list \
-    && printf "Package: *\nPin: release a=unstable\nPin-Priority: 100\n" \
-        > /etc/apt/preferences.d/sid \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends -t sid \
+# Pin OpenSSL to trixie-security (≥ 3.5.7-1~deb13u2) for CVE-2026-75803 before
+# any further package removals. bookworm has no fixed openssl package yet.
+# The final Python service does not invoke Perl; remove perl-base after that.
+# No package management runs after this point.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
         openssl \
         libssl3t64 \
         openssl-provider-legacy \
-    && rm -f /etc/apt/sources.list.d/sid.list /etc/apt/preferences.d/sid \
     && rm -rf /var/lib/apt/lists/* \
     && dpkg --purge --force-depends --force-remove-essential perl-base \
     && useradd --create-home --uid 10001 --shell /usr/sbin/nologin appuser

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -48,19 +48,15 @@ ENV APP_VERSION=${APP_VERSION} \
     GIT_SHA=${GIT_SHA} \
     BUILD_TIME=${BUILD_TIME}
 
-# CVE-2026-75803: NVD/ECR treat OpenSSL <3.5.8 / <3.6.4 as CRITICAL even though
-# Debian marks trixie-security 3.5.7-1~deb13u2 fixed. Install upstream-fixed
-# openssl 3.6.4-1 from sid (pinned so only these packages come from unstable),
-# then remove perl-base (CRITICAL on the slim base). No package management after.
-RUN echo "deb http://deb.debian.org/debian sid main" > /etc/apt/sources.list.d/sid.list \
-    && printf "Package: *\nPin: release a=unstable\nPin-Priority: 100\n" \
-        > /etc/apt/preferences.d/sid \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends -t sid \
+# Pin OpenSSL to trixie-security (≥ 3.5.7-1~deb13u2) for CVE-2026-75803 before
+# any further package removals. bookworm has no fixed openssl package yet.
+# The final Python service does not invoke Perl; remove perl-base after that.
+# No package management runs after this point.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
         openssl \
         libssl3t64 \
         openssl-provider-legacy \
-    && rm -f /etc/apt/sources.list.d/sid.list /etc/apt/preferences.d/sid \
     && rm -rf /var/lib/apt/lists/* \
     && dpkg --purge --force-depends --force-remove-essential perl-base \
     && useradd --create-home --uid 10001 --shell /usr/sbin/nologin appuser

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -46,11 +46,10 @@ make docker-build-prod-worker \
 The Bake targets are `agate-api`, `core-api`, `stylebook-api`, and `worker`. They use the repository
 root as build context, target each Dockerfile's `prod` stage, and build for `linux/amd64`.
 
-Production (and shared `base`) stages use `python:3.11-slim-trixie`. The prod stage then
-installs OpenSSL `3.6.4-1` from Debian sid (pinned so only those packages come from unstable)
-before removing `perl-base`. That satisfies NVD/ECR for CVE-2026-75803 (fixed upstream in
-3.5.8 / 3.6.4); Debian's own trixie-security `3.5.7-1~deb13u2` is marked fixed in the Debian
-tracker but ECR still treats `<3.5.8` as CRITICAL. bookworm still has no fixed openssl package.
+Production (and shared `base`) stages use `python:3.11-slim-trixie` and explicitly install
+`openssl` / `libssl3t64` from trixie-security (≥ `3.5.7-1~deb13u2`) before removing `perl-base`.
+Prod images use only Debian stable packages; do not pull packages from sid/unstable to satisfy
+scanners.
 
 The production API stages install non-editable packages and start Uvicorn without reload as a
 non-root `appuser`. The worker starts Celery through `apps/worker/scripts/entrypoint.sh` (also
@@ -104,7 +103,7 @@ After lint, tests, and required smoke pass on `main` in the canonical
 
 1. derive the immutable version `main-<first-12-sha>-amd64`
 2. build and push any missing image targets to ECR with SBOM and supply-chain attestations
-3. wait for ECR scanning and block publication on critical findings
+3. wait for ECR scanning and block publication on critical findings (see below)
 4. build all three UIs and create deterministic gzip archives
 5. upload UI archives under `versions/<version>/ui/`
 6. upload `manifests/<version>.json` last as the ready-to-deploy marker
@@ -119,6 +118,18 @@ than synthesizing paths from the SemVer alias.
 
 Publishing is retry-safe: CI skips image tags already present, and the manifest is written only after
 every required artifact is available and verified. Fork workflows do not publish artifacts.
+
+### ECR scan gate and the CVE allowlist
+
+The publish gate blocks on any CRITICAL ECR finding **unless** the CVE is listed in
+`SCAN_FINDING_ALLOWLIST` in `scripts/release_manifest.py`. ECR basic scanning matches NVD records
+against upstream version numbers, so it regularly flags Debian stable packages that are already
+patched via backport, or that Debian has triaged as minor with no stable fix planned. Do not chase
+those findings by pulling packages from sid/unstable; instead, verify the finding against the
+[Debian security tracker](https://security-tracker.debian.org/) and, if it is a version-matching
+false positive or a Debian `no-dsa` minor issue, add an allowlist entry with the evidence and an
+expiry date. Expired entries block publication again, which forces a re-review. Gate failures print
+the CVE and package for every blocking finding.
 
 ## Release aliases
 

--- a/scripts/release_manifest.py
+++ b/scripts/release_manifest.py
@@ -14,6 +14,8 @@ import json
 import re
 import tarfile
 import time
+from dataclasses import dataclass
+from datetime import date
 from pathlib import Path
 from typing import Any
 
@@ -30,6 +32,38 @@ UI_NAMES_V1 = ("agate-ui", "stylebook-ui")
 UI_NAMES_V2 = ("agate-ui", "stylebook-ui", "api-playground")
 CURRENT_SCHEMA_VERSION = 2
 SEMVER_RE = re.compile(r"^v(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$")
+
+
+@dataclass(frozen=True)
+class ScanFindingAllowlistEntry:
+    """A reviewed ECR CRITICAL finding the publish gate may ignore until expiry."""
+
+    reason: str
+    expires: date
+
+
+# ECR basic scanning matches NVD records against upstream version numbers, so it
+# flags Debian stable packages that are already patched via backport or that
+# Debian has triaged as minor with no stable fix planned. Every entry here must
+# cite that evidence and carry an expiry so it gets re-reviewed instead of
+# rotting. Non-listed CRITICAL findings still block publication.
+SCAN_FINDING_ALLOWLIST: dict[str, ScanFindingAllowlistEntry] = {
+    "CVE-2026-75803": ScanFindingAllowlistEntry(
+        reason=(
+            "openssl: Debian trixie-security 3.5.7-1~deb13u2 backports the upstream "
+            "fix (Debian tracker marks trixie fixed); NVD matches <3.5.8 by version."
+        ),
+        expires=date(2026, 12, 31),
+    ),
+    "CVE-2026-5450": ScanFindingAllowlistEntry(
+        reason=(
+            "glibc scanf %mc heap overflow: Debian tracker marks trixie/bookworm "
+            "no-dsa (minor issue) with no stable fix planned; our Python services "
+            "do not call scanf."
+        ),
+        expires=date(2026, 12, 31),
+    ),
+}
 
 
 def required_ui_names(schema_version: int) -> tuple[str, ...]:
@@ -228,40 +262,59 @@ def _wait_for_scan(ecr: Any, repository: str, tag: str) -> dict[str, int]:
     raise RuntimeError(f"ECR scan timed out for {repository}:{tag} ({image_id})")
 
 
-def _critical_finding_summaries(
-    ecr: Any, repository: str, tag: str, *, limit: int = 8
-) -> list[str]:
-    """Best-effort package/CVE labels for CRITICAL findings (for gate error text)."""
+def _critical_findings(ecr: Any, repository: str, tag: str) -> list[dict[str, str]]:
+    """All CRITICAL findings for an image as {name, label} records (paginated)."""
     image_id = _scan_image_id(ecr, repository, tag)
-    try:
-        response = ecr.describe_image_scan_findings(
-            repositoryName=repository,
-            imageId=image_id,
-        )
-    except ClientError:
-        return []
-    findings = response.get("imageScanFindings", {}).get("findings") or []
-    summaries: list[str] = []
-    for finding in findings:
-        if str(finding.get("severity") or "").upper() != "CRITICAL":
-            continue
-        name = str(finding.get("name") or "unknown")
-        attrs = {
-            str(item.get("key")): str(item.get("value"))
-            for item in (finding.get("attributes") or [])
-            if isinstance(item, dict)
-        }
-        package = attrs.get("package_name") or attrs.get("packageName") or ""
-        version = attrs.get("package_version") or attrs.get("packageVersion") or ""
-        if package and version:
-            summaries.append(f"{name} ({package} {version})")
-        elif package:
-            summaries.append(f"{name} ({package})")
-        else:
-            summaries.append(name)
-        if len(summaries) >= limit:
+    findings: list[dict[str, str]] = []
+    next_token: str | None = None
+    while True:
+        kwargs: dict[str, Any] = {"repositoryName": repository, "imageId": image_id}
+        if next_token:
+            kwargs["nextToken"] = next_token
+        response = ecr.describe_image_scan_findings(**kwargs)
+        for finding in response.get("imageScanFindings", {}).get("findings") or []:
+            if str(finding.get("severity") or "").upper() != "CRITICAL":
+                continue
+            name = str(finding.get("name") or "unknown")
+            attrs = {
+                str(item.get("key")): str(item.get("value"))
+                for item in (finding.get("attributes") or [])
+                if isinstance(item, dict)
+            }
+            package = attrs.get("package_name") or attrs.get("packageName") or ""
+            version = attrs.get("package_version") or attrs.get("packageVersion") or ""
+            label = name
+            if package and version:
+                label = f"{name} ({package} {version})"
+            elif package:
+                label = f"{name} ({package})"
+            findings.append({"name": name, "label": label})
+        next_token = response.get("nextToken")
+        if not next_token:
             break
-    return summaries
+    return findings
+
+
+def _partition_critical_findings(
+    findings: list[dict[str, str]],
+    *,
+    today: date,
+    allowlist: dict[str, ScanFindingAllowlistEntry],
+) -> tuple[list[str], list[str]]:
+    """Split CRITICAL findings into blocking labels and allowlisted notes."""
+    blocking: list[str] = []
+    allowed: list[str] = []
+    for finding in findings:
+        entry = allowlist.get(finding["name"])
+        if entry is None:
+            blocking.append(finding["label"])
+        elif today > entry.expires:
+            blocking.append(
+                f"{finding['label']} (allowlist expired {entry.expires.isoformat()})"
+            )
+        else:
+            allowed.append(f"{finding['label']}: {entry.reason}")
+    return blocking, allowed
 
 
 def build_manifest(
@@ -296,10 +349,22 @@ def build_manifest(
         detail = _image_detail(ecr, repository, version)
         repo = ecr.describe_repositories(repositoryNames=[repository])["repositories"][0]
         scans = _wait_for_scan(ecr, repository, version) if enforce_scans else {}
-        if scans.get("CRITICAL", 0):
-            detail_bits = _critical_finding_summaries(ecr, repository, version)
-            suffix = f" [{'; '.join(detail_bits)}]" if detail_bits else ""
-            critical.append(f"{repository}: {scans['CRITICAL']} CRITICAL{suffix}")
+        critical_count = scans.get("CRITICAL", 0)
+        if critical_count:
+            findings = _critical_findings(ecr, repository, version)
+            blocking, allowed = _partition_critical_findings(
+                findings, today=date.today(), allowlist=SCAN_FINDING_ALLOWLIST
+            )
+            if len(findings) < critical_count:
+                # Fail closed if the findings list does not account for every
+                # CRITICAL the severity counts reported.
+                blocking.append(
+                    f"{critical_count - len(findings)} unresolved CRITICAL finding(s)"
+                )
+            for note in allowed:
+                print(f"allowlisted CRITICAL for {repository}: {note}")
+            if blocking:
+                critical.append(f"{repository}: {'; '.join(blocking)}")
         images[repository] = {
             "tag": version,
             "digest": detail["imageDigest"],

--- a/tests/test_release_manifest.py
+++ b/tests/test_release_manifest.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import hashlib
 import importlib.util
 import json
+import sys
 import tarfile
+from datetime import date
 from pathlib import Path
 from typing import Any
 
@@ -14,6 +16,8 @@ _SCRIPT = Path(__file__).parents[1] / "scripts" / "release_manifest.py"
 _SPEC = importlib.util.spec_from_file_location("release_manifest", _SCRIPT)
 assert _SPEC is not None and _SPEC.loader is not None
 release_manifest = importlib.util.module_from_spec(_SPEC)
+# Register before exec so decorators like @dataclass can resolve the module.
+sys.modules["release_manifest"] = release_manifest
 _SPEC.loader.exec_module(release_manifest)
 
 alias_ecr_image = release_manifest.alias_ecr_image
@@ -26,6 +30,8 @@ validate_manifest_inventory = release_manifest.validate_manifest_inventory
 validate_release_version = release_manifest.validate_release_version
 scan_image_id = release_manifest._scan_image_id
 publish_manifest = release_manifest.publish_manifest
+partition_critical_findings = release_manifest._partition_critical_findings
+ScanFindingAllowlistEntry = release_manifest.ScanFindingAllowlistEntry
 CURRENT_SCHEMA_VERSION = release_manifest.CURRENT_SCHEMA_VERSION
 REPOSITORIES = release_manifest.REPOSITORIES
 UI_NAMES_V1 = release_manifest.UI_NAMES_V1
@@ -360,7 +366,7 @@ def test_build_manifest_requires_api_playground_and_emits_schema_v2(tmp_path: Pa
         )
 
 
-def test_build_manifest_critical_gate_includes_finding_labels(tmp_path: Path) -> None:
+def _scan_gate_archives(tmp_path: Path) -> dict[str, Path]:
     archives = {
         "agate-ui": tmp_path / "agate-ui.tar.gz",
         "stylebook-ui": tmp_path / "stylebook-ui.tar.gz",
@@ -368,29 +374,34 @@ def test_build_manifest_critical_gate_includes_finding_labels(tmp_path: Path) ->
     }
     for path in archives.values():
         path.write_bytes(b"archive")
+    return archives
 
+
+def _critical_finding(name: str, package: str, version: str) -> dict[str, Any]:
+    return {
+        "name": name,
+        "severity": "CRITICAL",
+        "attributes": [
+            {"key": "package_name", "value": package},
+            {"key": "package_version", "value": version},
+        ],
+    }
+
+
+def test_build_manifest_blocks_unlisted_critical_with_labels(tmp_path: Path) -> None:
+    archives = _scan_gate_archives(tmp_path)
     source_sha = "0123456789abcdef0123456789abcdef01234567"
     version = canonical_version(source_sha)
     ecr = FakeScanGateEcr(
         critical_counts={"backfield-agate-api": 1},
         findings_by_repo={
             "backfield-agate-api": [
-                {
-                    "name": "CVE-2026-75803",
-                    "severity": "CRITICAL",
-                    "attributes": [
-                        {"key": "package_name", "value": "libssl3t64"},
-                        {"key": "package_version", "value": "3.5.7-1~deb13u2"},
-                    ],
-                }
+                _critical_finding("CVE-2099-0001", "somepkg", "1.0-1")
             ]
         },
     )
 
-    expected = (
-        r"backfield-agate-api: 1 CRITICAL "
-        r"\[CVE-2026-75803 \(libssl3t64 3\.5\.7-1~deb13u2\)\]"
-    )
+    expected = r"backfield-agate-api: CVE-2099-0001 \(somepkg 1\.0-1\)"
     with pytest.raises(RuntimeError, match=expected):
         build_manifest(
             version=version,
@@ -402,6 +413,86 @@ def test_build_manifest_critical_gate_includes_finding_labels(tmp_path: Path) ->
             s3=FakePublishS3(),
             enforce_scans=True,
         )
+
+
+def test_build_manifest_allows_allowlisted_critical(tmp_path: Path) -> None:
+    archives = _scan_gate_archives(tmp_path)
+    source_sha = "0123456789abcdef0123456789abcdef01234567"
+    version = canonical_version(source_sha)
+    # Mirrors the trixie prod images: glibc CVE-2026-5450 (Debian no-dsa) and
+    # openssl CVE-2026-75803 (fixed via Debian backport, flagged by version).
+    findings = {
+        repo: [
+            _critical_finding("CVE-2026-5450", "glibc", "2.41-12+deb13u3"),
+            _critical_finding("CVE-2026-75803", "libssl3t64", "3.5.7-1~deb13u2"),
+        ]
+        for repo in REPOSITORIES
+    }
+    ecr = FakeScanGateEcr(
+        critical_counts={repo: 2 for repo in REPOSITORIES},
+        findings_by_repo=findings,
+    )
+
+    manifest = build_manifest(
+        version=version,
+        source_sha=source_sha,
+        build_time="2026-01-01T00:00:00Z",
+        artifact_bucket="artifacts",
+        ui_archives=archives,
+        ecr=ecr,
+        s3=FakePublishS3(),
+        enforce_scans=True,
+    )
+    assert manifest["images"]["backfield-worker"]["scan_findings"] == {"CRITICAL": 2}
+
+
+def test_build_manifest_fails_closed_on_unresolved_critical_count(
+    tmp_path: Path,
+) -> None:
+    archives = _scan_gate_archives(tmp_path)
+    source_sha = "0123456789abcdef0123456789abcdef01234567"
+    version = canonical_version(source_sha)
+    # Severity counts report a CRITICAL but the findings list is empty.
+    ecr = FakeScanGateEcr(critical_counts={"backfield-core-api": 1})
+
+    with pytest.raises(RuntimeError, match=r"1 unresolved CRITICAL finding"):
+        build_manifest(
+            version=version,
+            source_sha=source_sha,
+            build_time="2026-01-01T00:00:00Z",
+            artifact_bucket="artifacts",
+            ui_archives=archives,
+            ecr=ecr,
+            s3=FakePublishS3(),
+            enforce_scans=True,
+        )
+
+
+def test_partition_critical_findings_expires_allowlist_entries() -> None:
+    allowlist = {
+        "CVE-1111-1": ScanFindingAllowlistEntry(
+            reason="reviewed", expires=date(2026, 6, 30)
+        ),
+    }
+    findings = [
+        {"name": "CVE-1111-1", "label": "CVE-1111-1 (pkg 1.0)"},
+        {"name": "CVE-2222-2", "label": "CVE-2222-2 (other 2.0)"},
+    ]
+
+    blocking, allowed = partition_critical_findings(
+        findings, today=date(2026, 6, 1), allowlist=allowlist
+    )
+    assert blocking == ["CVE-2222-2 (other 2.0)"]
+    assert allowed == ["CVE-1111-1 (pkg 1.0): reviewed"]
+
+    blocking, allowed = partition_critical_findings(
+        findings, today=date(2026, 7, 1), allowlist=allowlist
+    )
+    assert blocking == [
+        "CVE-1111-1 (pkg 1.0) (allowlist expired 2026-06-30)",
+        "CVE-2222-2 (other 2.0)",
+    ]
+    assert allowed == []
 
 
 def test_release_alias_preserves_ui_object_keys_for_schema_v1_and_v2() -> None:


### PR DESCRIPTION
## Summary

Publishing kept failing on new ECR CRITICAL findings even though nothing in the repo changed: ECR basic scanning matches NVD records by upstream version number, so it flags Debian stable packages that are already backport-patched (openssl `CVE-2026-75803`, fixed in trixie-security `3.5.7-1~deb13u2`) or that Debian has triaged as `no-dsa` minor with no stable fix planned (glibc `CVE-2026-5450`, see the [Debian tracker](https://security-tracker.debian.org/tracker/CVE-2026-5450) and failing [run 33966657403](https://github.com/localangle/backfield/actions/runs/33966657403)).

Instead of chasing each finding with sid/unstable packages:

- Revert the sid OpenSSL pin from #167: prod Dockerfiles return to pure trixie + trixie-security OpenSSL. No unstable packages in prod images.
- Add `SCAN_FINDING_ALLOWLIST` to `scripts/release_manifest.py`: CRITICAL findings still block publication unless the CVE is explicitly listed with written evidence and an expiry date. Expired entries block again (forced re-review), severity counts that cannot be attributed to named findings fail closed, and the findings fetch is paginated.
- Allowlist `CVE-2026-75803` (openssl, Debian backport-fixed) and `CVE-2026-5450` (glibc, Debian no-dsa minor; our services do not call `scanf`), both expiring 2026-12-31.

## Project scope check

- [x] This change targets local development / source inspection (production self-hosting is unsupported in this repo)
- [x] Docs under `docs/` updated if behavior, architecture, or operations changed (`docs/operations/deployment.md` documents the gate policy and the no-sid rule)
- [x] First-admin provisioning still uses `backfield init` / `backfield seed` only (no HTTP/env bootstrap paths)

## Test plan

- [x] `make lint`
- [x] `make test` (2204 passed; includes new gate tests: allowlisted CVEs pass, unlisted CVEs block with CVE/package labels, unattributed counts fail closed, expired entries re-block)
- [ ] `make ui-typecheck ui-test` (if UI/TypeScript changed) — n/a
- [ ] `make smoke-fast` (if live-stack behavior changed) — n/a (publish gate + prod image packaging only)
- [ ] `make smoke` (if golden-path / provider-dependent runtime changed) — n/a

## Notes for reviewers

- Validated against real ECR data: ran the new gate logic with the `backfield` AWS profile against the existing `main-e5180aad7ca7-amd64` scans — each image shows exactly one CRITICAL (`CVE-2026-5450`, glibc), the allowlist covers it, and the gate would pass.
- Those scanned images still carry sid OpenSSL 3.6.4, so they don't exercise the openssl allowlist entry; after merge, rebuilt trixie images will re-flag `CVE-2026-75803`, which is covered by unit tests replaying both CVEs per image.
- Local rebuild of the reverted prod image confirms OpenSSL `3.5.7-1~deb13u2` and Python linking against it.
- Follow-up expectation: when a new NVD CRITICAL trips the gate, the error names the CVE and package; verify against the Debian tracker and either fix or add a reviewed allowlist entry — do not pull packages from sid.