### PR TITLE
Fix MultiPolygon PostGIS binds so geometry reassignment stays geo-searchable

### DIFF
--- a/apps/stylebook-api/src/stylebook_api/entities/location/candidates.py
+++ b/apps/stylebook-api/src/stylebook_api/entities/location/candidates.py
@@ -35,7 +35,7 @@ from backfield_entities.entities.linking.substrate_actions import (
 )
 from backfield_entities.entities.location.persist import refresh_aliases_for_linked_location
 from backfield_entities.entities.location.types import PLACE_EXTRACT_LOCATION_TYPES
-from backfield_entities.geo.geometry_bind import assign_geojson_geometry
+from backfield_entities.geo.geometry_bind import GeometryBindError, assign_geojson_geometry
 from backfield_events import record_canonical_created, record_canonical_evidence_changed
 from fastapi import APIRouter, Body, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
@@ -833,7 +833,10 @@ def accept_candidate(
         session.flush()
         # Body-supplied GeoJSON must also populate PostGIS (same as create_standalone_canonical).
         if bind_body_geometry and isinstance(gj, dict):
-            assign_geojson_geometry(session, canon, gj)
+            try:
+                assign_geojson_geometry(session, canon, gj)
+            except GeometryBindError as exc:
+                raise HTTPException(status_code=400, detail=str(exc)) from exc
             session.flush()
         loc.stylebook_location_canonical_id = str(canon.id)
     else:

--- a/apps/stylebook-api/src/stylebook_api/entities/location/locations.py
+++ b/apps/stylebook-api/src/stylebook_api/entities/location/locations.py
@@ -24,7 +24,7 @@ from backfield_entities.entities.linking.substrate_actions import (
     unlink_substrate_from_canonical,
 )
 from backfield_entities.entities.location.types import PLACE_EXTRACT_LOCATION_TYPES
-from backfield_entities.geo.geometry_bind import assign_geojson_geometry
+from backfield_entities.geo.geometry_bind import GeometryBindError, assign_geojson_geometry
 from backfield_entities.ingest.semantic_indexing.reindex import (
     location_patch_affects_semantic_index,
 )
@@ -653,7 +653,10 @@ def patch_location_geometry(
     loc = session.get(SubstrateLocation, location_id)
     if loc is None or int(loc.project_id) != int(proj.id):
         raise HTTPException(status_code=404, detail="Location not found")
-    assign_geojson_geometry(session, loc, body.geometry_json)
+    try:
+        assign_geojson_geometry(session, loc, body.geometry_json)
+    except GeometryBindError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     loc.updated_at = datetime.now(UTC)
     session.add(loc)
     session.commit()

--- a/apps/stylebook-api/src/stylebook_api/routers/stylebook_canonicals.py
+++ b/apps/stylebook-api/src/stylebook_api/routers/stylebook_canonicals.py
@@ -25,7 +25,7 @@ from backfield_entities.entities.location.geometry_apply import (
     suggest_substrate_for_geometry_apply,
 )
 from backfield_entities.entities.location.persist import create_standalone_canonical
-from backfield_entities.geo.geometry_bind import assign_geojson_geometry
+from backfield_entities.geo.geometry_bind import GeometryBindError, assign_geojson_geometry
 from backfield_events import record_canonical_updated
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
@@ -610,7 +610,10 @@ def patch_canonical_location_geometry(
     canon = session.get(StylebookLocationCanonical, canonical_id)
     if canon is None or int(canon.stylebook_id) != int(sb.id):
         raise HTTPException(status_code=404, detail="Canonical location not found")
-    assign_geojson_geometry(session, canon, body.geometry_json)
+    try:
+        assign_geojson_geometry(session, canon, body.geometry_json)
+    except GeometryBindError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     canon.updated_at = datetime.now(UTC)
     log_stylebook_activity_safe(
         session,
@@ -667,12 +670,15 @@ def apply_canonical_location_geometry_to_substrates(
         project_slug=project,
         organization_id=int(sb.organization_id),
     )
-    result = apply_canonical_geometry_to_substrates(
-        session,
-        canon=canon,
-        substrate_ids=body.substrate_location_ids,
-        visible_project_ids=project_ids,
-    )
+    try:
+        result = apply_canonical_geometry_to_substrates(
+            session,
+            canon=canon,
+            substrate_ids=body.substrate_location_ids,
+            visible_project_ids=project_ids,
+        )
+    except GeometryBindError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     log_stylebook_activity_safe(
         session,
         stylebook_id=int(sb.id),

--- a/docs/api/stylebook.md
+++ b/docs/api/stylebook.md
@@ -39,7 +39,7 @@ Stylebook-scoped families under `/v1/stylebooks/{stylebook_slug}` provide list/s
 
 Canonical identifiers are UUID strings. Catalog responses expose immutable slugs for stable links. Project filters narrow mention and evidence counts without changing catalog ownership.
 
-Location geometry uses GeoJSON `Point`, `Polygon`, or `MultiPolygon` with longitude-latitude coordinate order. Canonical and saved-place geometry PATCH routes write GeoJSON together with PostGIS `geometry`, `geometry_type`, and H3. Editors can copy a canonical location’s current geography onto selected linked saved places with `POST /v1/stylebooks/{stylebook_slug}/canonical-locations/{id}/geometry/apply-to-substrates`. That write marks those saved places so later ingest does not replace the editorial shape, and it deletes matching project geocode-cache rows.
+Location geometry uses GeoJSON `Point`, `Polygon`, or `MultiPolygon` with longitude-latitude coordinate order. Canonical and saved-place geometry PATCH routes write GeoJSON together with PostGIS `geometry`, `geometry_type`, and H3 (article geo-search requires PostGIS; a write that cannot bind PostGIS is rejected rather than leaving GeoJSON/H3 updated alone). Editors can copy a canonical location’s current geography onto selected linked saved places with `POST /v1/stylebooks/{stylebook_slug}/canonical-locations/{id}/geometry/apply-to-substrates`. That write marks those saved places so later ingest does not replace the editorial shape, and it deletes matching project geocode-cache rows.
 
 Canonical metadata is Stylebook-wide editorial data: one typed scalar attribute per
 `meta_type` slug on a canonical (`text`, `number`, or `boolean`). Rows retain a project

--- a/docs/development/entities/overview.md
+++ b/docs/development/entities/overview.md
@@ -137,7 +137,10 @@ Location catalog geography can be copied onto selected linked saved places from 
 That override stays on the saved-place row (including PostGIS and H3) so article geo-search
 follows the catalog shape. The next ingest of the same geocode finds the existing row by
 identity fingerprint and keeps the editorial geometry unless an authoritative geocode
-rejection clears it.
+rejection clears it. Rows left with GeoJSON/H3 but null PostGIS (historical MultiPolygon
+bind bug) can be repaired with
+`uv run python scripts/rebind_location_postgis_geometry.py` (dry-run by default; `--apply`
+to commit). That script is intentionally not a `backfield` CLI subcommand.
 
 Occurrence offsets are written only for a normalization-equivalent article slice.
 When whitespace or encoding artifacts cannot be mapped back exactly, the evidence

--- a/packages/backfield-entities/src/backfield_entities/geo/geometry_bind.py
+++ b/packages/backfield-entities/src/backfield_entities/geo/geometry_bind.py
@@ -7,6 +7,16 @@ from typing import Any, Protocol
 from backfield_entities.geo.h3_index import apply_h3_fields
 from sqlmodel import Session
 
+# ``str.title()`` mangles camelCase GeoJSON types (``MultiPolygon`` → ``Multipolygon``).
+_GEOJSON_TYPE_BY_KEY: dict[str, str] = {
+    "point": "Point",
+    "multipoint": "MultiPoint",
+    "linestring": "LineString",
+    "multilinestring": "MultiLineString",
+    "polygon": "Polygon",
+    "multipolygon": "MultiPolygon",
+}
+
 
 class HasLocationGeometry(Protocol):
     geometry: object | None
@@ -14,6 +24,18 @@ class HasLocationGeometry(Protocol):
     geometry_type: str | None
     h3_cell: str | None
     h3_resolution: int | None
+
+
+class GeometryBindError(ValueError):
+    """GeoJSON was provided but could not be converted to a PostGIS bind value."""
+
+
+def normalize_geojson_type(raw: object | None) -> str | None:
+    """Return the canonical GeoJSON geometry type, or ``None`` when unrecognized."""
+    if not isinstance(raw, str):
+        return None
+    key = raw.strip().lower().replace("_", "").replace(" ", "")
+    return _GEOJSON_TYPE_BY_KEY.get(key)
 
 
 def _coord_pair_wkt(pair: Any) -> str | None:
@@ -41,7 +63,9 @@ def _ring_coords_wkt(ring: Any) -> str | None:
 
 def geojson_to_wkt(geometry_json: dict[str, Any]) -> str | None:
     """Return WKT for a GeoJSON geometry, or ``None`` when the shape is invalid."""
-    gtype = str(geometry_json.get("type") or "").title()
+    gtype = normalize_geojson_type(geometry_json.get("type"))
+    if gtype is None:
+        return None
     coords = geometry_json.get("coordinates")
 
     try:
@@ -72,6 +96,22 @@ def geojson_to_wkt(geometry_json: dict[str, Any]) -> str | None:
                     return None
                 pts.append(wkt_pair)
             return "LINESTRING (" + ", ".join(pts) + ")"
+
+        if gtype == "MultiLineString":
+            if not isinstance(coords, list) or not coords:
+                return None
+            lines: list[str] = []
+            for line in coords:
+                if not isinstance(line, list) or len(line) < 2:
+                    return None
+                pts = []
+                for pair in line:
+                    wkt_pair = _coord_pair_wkt(pair)
+                    if not wkt_pair:
+                        return None
+                    pts.append(wkt_pair)
+                lines.append("(" + ", ".join(pts) + ")")
+            return "MULTILINESTRING (" + ", ".join(lines) + ")"
 
         if gtype == "Polygon":
             if not isinstance(coords, list) or not coords:
@@ -129,7 +169,12 @@ def assign_geojson_geometry(
     row: HasLocationGeometry,
     geometry_json: dict[str, Any] | None,
 ) -> None:
-    """Write GeoJSON, PostGIS, type, and H3 onto a canonical or saved-place row."""
+    """Write GeoJSON, PostGIS, type, and H3 onto a canonical or saved-place row.
+
+    When ``geometry_json`` is provided it must convert to a PostGIS bind value; otherwise
+    this raises :class:`GeometryBindError` so callers never leave GeoJSON/H3 updated while
+    ``geometry`` is cleared (article geo-search keys off PostGIS).
+    """
     if geometry_json is None:
         row.geometry_json = None
         row.geometry = None
@@ -139,10 +184,16 @@ def assign_geojson_geometry(
         return
 
     copied = dict(geometry_json)
+    bind = geometry_bind_value(session, copied)
+    if bind is None:
+        raise GeometryBindError(
+            f"Could not convert GeoJSON to PostGIS geometry (type={copied.get('type')!r})."
+        )
+
     row.geometry_json = copied
-    gt = copied.get("type")
+    gt = normalize_geojson_type(copied.get("type")) or copied.get("type")
     row.geometry_type = str(gt) if gt else None
-    row.geometry = geometry_bind_value(session, copied)
+    row.geometry = bind
     cell, resolution = apply_h3_fields(geometry_json=copied)
     row.h3_cell = cell
     row.h3_resolution = resolution

--- a/packages/backfield-entities/src/backfield_entities/geo/rebind_postgis.py
+++ b/packages/backfield-entities/src/backfield_entities/geo/rebind_postgis.py
@@ -1,0 +1,184 @@
+"""Rebind PostGIS ``geometry`` from stored GeoJSON for half-updated location rows.
+
+Editorial MultiPolygon / LineString writes used to clear PostGIS while leaving
+``geometry_json`` and H3 intact (``str.title()`` mangled camelCase GeoJSON types).
+Article geo-search keys off PostGIS, so those mentions matched nowhere.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from backfield_db import StylebookLocationCanonical, SubstrateLocation
+from backfield_entities.geo.geometry_bind import (
+    GeometryBindError,
+    assign_geojson_geometry,
+    geojson_to_wkt,
+)
+from sqlalchemy import ColumnElement
+from sqlmodel import Session, col, select
+
+
+@dataclass(frozen=True)
+class GeometryRebindSkip:
+    table: str
+    id: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class GeometryRebindResult:
+    inspected_count: int
+    rebound_count: int
+    skipped: tuple[GeometryRebindSkip, ...]
+    substrate_ids: tuple[int, ...]
+    canonical_ids: tuple[str, ...]
+
+
+def _geometry_is_missing(row: StylebookLocationCanonical | SubstrateLocation) -> bool:
+    return row.geometry is None
+
+
+def _needs_postgis_rebind(row: StylebookLocationCanonical | SubstrateLocation) -> bool:
+    """True when GeoJSON is present and convertible but PostGIS is missing."""
+    gj = row.geometry_json
+    if not isinstance(gj, dict):
+        return False
+    if not _geometry_is_missing(row):
+        return False
+    return geojson_to_wkt(gj) is not None
+
+
+def rebind_missing_location_postgis_geometry(
+    session: Session,
+    *,
+    stylebook_id: int | None = None,
+    project_id: int | None = None,
+    dry_run: bool = True,
+    limit: int | None = None,
+) -> GeometryRebindResult:
+    """Recompute PostGIS from ``geometry_json`` where geo-search would otherwise miss.
+
+    Scans canonical catalog rows and linked saved places. Does not invent geometry:
+    only rows with convertible GeoJSON and a null PostGIS column are rebound.
+    """
+    skipped: list[GeometryRebindSkip] = []
+    substrate_ids: list[int] = []
+    canonical_ids: list[str] = []
+    inspected = 0
+    remaining = limit
+
+    canon_filters: list[ColumnElement[bool]] = [
+        col(StylebookLocationCanonical.geometry_json).is_not(None),
+        col(StylebookLocationCanonical.geometry).is_(None),
+    ]
+    if stylebook_id is not None:
+        canon_filters.append(StylebookLocationCanonical.stylebook_id == int(stylebook_id))
+
+    canon_stmt = select(StylebookLocationCanonical).where(*canon_filters)
+    if remaining is not None:
+        canon_stmt = canon_stmt.limit(remaining)
+
+    for canon in session.exec(canon_stmt).all():
+        inspected += 1
+        cid = str(canon.id)
+        if not _needs_postgis_rebind(canon):
+            skipped.append(
+                GeometryRebindSkip(
+                    table="stylebook_location_canonical",
+                    id=cid,
+                    reason="geometry_json_not_convertible",
+                )
+            )
+            continue
+        if not dry_run:
+            try:
+                assign_geojson_geometry(
+                    session,
+                    canon,
+                    dict(canon.geometry_json) if isinstance(canon.geometry_json, dict) else None,
+                )
+            except GeometryBindError as exc:
+                skipped.append(
+                    GeometryRebindSkip(
+                        table="stylebook_location_canonical",
+                        id=cid,
+                        reason=str(exc),
+                    )
+                )
+                continue
+            canon.updated_at = datetime.now(UTC)
+            session.add(canon)
+        canonical_ids.append(cid)
+        if remaining is not None:
+            remaining -= 1
+            if remaining <= 0:
+                return GeometryRebindResult(
+                    inspected_count=inspected,
+                    rebound_count=len(substrate_ids) + len(canonical_ids),
+                    skipped=tuple(skipped),
+                    substrate_ids=tuple(substrate_ids),
+                    canonical_ids=tuple(canonical_ids),
+                )
+
+    substrate_filters: list[ColumnElement[bool]] = [
+        col(SubstrateLocation.geometry_json).is_not(None),
+        col(SubstrateLocation.geometry).is_(None),
+    ]
+    if project_id is not None:
+        substrate_filters.append(SubstrateLocation.project_id == int(project_id))
+    if stylebook_id is not None:
+        # Limit to saved places linked into the given Stylebook catalog.
+        linked_ids = select(StylebookLocationCanonical.id).where(
+            StylebookLocationCanonical.stylebook_id == int(stylebook_id)
+        )
+        substrate_filters.append(
+            col(SubstrateLocation.stylebook_location_canonical_id).in_(linked_ids)
+        )
+
+    substrate_stmt = select(SubstrateLocation).where(*substrate_filters)
+    if remaining is not None:
+        substrate_stmt = substrate_stmt.limit(remaining)
+
+    for loc in session.exec(substrate_stmt).all():
+        inspected += 1
+        if loc.id is None:
+            continue
+        sid = int(loc.id)
+        if not _needs_postgis_rebind(loc):
+            skipped.append(
+                GeometryRebindSkip(
+                    table="substrate_location",
+                    id=str(sid),
+                    reason="geometry_json_not_convertible",
+                )
+            )
+            continue
+        if not dry_run:
+            try:
+                assign_geojson_geometry(
+                    session,
+                    loc,
+                    dict(loc.geometry_json) if isinstance(loc.geometry_json, dict) else None,
+                )
+            except GeometryBindError as exc:
+                skipped.append(
+                    GeometryRebindSkip(
+                        table="substrate_location",
+                        id=str(sid),
+                        reason=str(exc),
+                    )
+                )
+                continue
+            loc.updated_at = datetime.now(UTC)
+            session.add(loc)
+        substrate_ids.append(sid)
+
+    return GeometryRebindResult(
+        inspected_count=inspected,
+        rebound_count=len(substrate_ids) + len(canonical_ids),
+        skipped=tuple(skipped),
+        substrate_ids=tuple(substrate_ids),
+        canonical_ids=tuple(canonical_ids),
+    )

--- a/scripts/rebind_location_postgis_geometry.py
+++ b/scripts/rebind_location_postgis_geometry.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""One-off: rebind PostGIS geometry from geometry_json for half-updated locations.
+
+Not registered on the ``backfield`` CLI menu. Run from the repo root:
+
+  uv run python scripts/rebind_location_postgis_geometry.py
+  uv run python scripts/rebind_location_postgis_geometry.py --apply
+  uv run python scripts/rebind_location_postgis_geometry.py --stylebook-id 1 --apply
+
+Dry-run by default. Targets catalog and saved-place rows where ``geometry_json`` is
+present and convertible but PostGIS ``geometry`` is null (the MultiPolygon title() bug
+state). Article geo-search requires PostGIS.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from backfield_db.session import get_engine
+from backfield_entities.geo.rebind_postgis import rebind_missing_location_postgis_geometry
+from sqlmodel import Session
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Rebind PostGIS geometry from stored GeoJSON where geometry is null "
+            "(dry-run by default; not a backfield CLI subcommand)."
+        )
+    )
+    parser.add_argument(
+        "--stylebook-id",
+        type=int,
+        default=None,
+        help="Limit to one Stylebook catalog and its linked saved places",
+    )
+    parser.add_argument(
+        "--project-id",
+        type=int,
+        default=None,
+        help="Limit saved-place scan to one project id",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Maximum rows to inspect across catalog + saved places",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Commit PostGIS rebinds (default is dry-run)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print the report as JSON",
+    )
+    args = parser.parse_args(argv)
+
+    dry_run = not bool(args.apply)
+    with Session(get_engine()) as session:
+        result = rebind_missing_location_postgis_geometry(
+            session,
+            stylebook_id=args.stylebook_id,
+            project_id=args.project_id,
+            dry_run=dry_run,
+            limit=args.limit,
+        )
+        if args.apply:
+            session.commit()
+
+    payload = {
+        "mode": "apply" if args.apply else "dry-run",
+        "stylebook_id": args.stylebook_id,
+        "project_id": args.project_id,
+        "inspected_count": result.inspected_count,
+        "rebound_count": result.rebound_count,
+        "canonical_ids": list(result.canonical_ids),
+        "substrate_ids": list(result.substrate_ids),
+        "skipped": [
+            {"table": item.table, "id": item.id, "reason": item.reason} for item in result.skipped
+        ],
+    }
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 0
+
+    label = "Rebound" if args.apply else "Would rebind"
+    print(f"PostGIS geometry rebind ({payload['mode']})")
+    if args.stylebook_id is not None:
+        print(f"  stylebook_id: {args.stylebook_id}")
+    if args.project_id is not None:
+        print(f"  project_id: {args.project_id}")
+    print(f"  inspected: {result.inspected_count}")
+    print(f"  {label.lower()}: {result.rebound_count}")
+    print(f"  skipped: {len(result.skipped)}")
+    if result.canonical_ids:
+        print(
+            f"  canonical_ids ({len(result.canonical_ids)}): {', '.join(result.canonical_ids[:20])}"
+        )
+        if len(result.canonical_ids) > 20:
+            print(f"    … and {len(result.canonical_ids) - 20} more")
+    if result.substrate_ids:
+        shown = ", ".join(str(sid) for sid in result.substrate_ids[:20])
+        print(f"  substrate_ids ({len(result.substrate_ids)}): {shown}")
+        if len(result.substrate_ids) > 20:
+            print(f"    … and {len(result.substrate_ids) - 20} more")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/entities/test_geometry_bind_multipolygon.py
+++ b/tests/entities/test_geometry_bind_multipolygon.py
@@ -1,0 +1,223 @@
+"""GeoJSON → WKT / PostGIS bind helpers."""
+
+from __future__ import annotations
+
+import pytest
+from backfield_db import (
+    BackfieldOrganization,
+    BackfieldProject,
+    BackfieldWorkspace,
+    Stylebook,
+    StylebookLocationCanonical,
+    SubstrateLocation,
+)
+from backfield_entities.geo.geometry_bind import (
+    GeometryBindError,
+    assign_geojson_geometry,
+    geojson_to_wkt,
+    normalize_geojson_type,
+)
+from backfield_entities.geo.rebind_postgis import rebind_missing_location_postgis_geometry
+from sqlmodel import Session, SQLModel, create_engine
+
+ROUTE_W_MULTIPOLYGON: dict = {
+    "type": "MultiPolygon",
+    "coordinates": [
+        [
+            [
+                [-92.1805, 38.5943],
+                [-92.1708, 38.5943],
+                [-92.1708, 38.5977],
+                [-92.1805, 38.5977],
+                [-92.1805, 38.5943],
+            ]
+        ]
+    ],
+}
+
+
+def _seed_project(session: Session, *, slug_suffix: str) -> tuple[int, int]:
+    org = BackfieldOrganization(name="Org", slug=f"org-{slug_suffix}")
+    session.add(org)
+    session.commit()
+    session.refresh(org)
+    org_id = int(org.id)  # type: ignore[arg-type]
+    sb = Stylebook(
+        organization_id=org_id,
+        slug="default",
+        name="Default",
+        is_default=True,
+    )
+    session.add(sb)
+    session.commit()
+    session.refresh(sb)
+    sb_id = int(sb.id)  # type: ignore[arg-type]
+    ws = BackfieldWorkspace(
+        organization_id=org_id,
+        stylebook_id=sb_id,
+        name="WS",
+        slug="ws",
+    )
+    session.add(ws)
+    session.commit()
+    session.refresh(ws)
+    proj = BackfieldProject(
+        organization_id=org_id,
+        workspace_id=int(ws.id),  # type: ignore[arg-type]
+        stylebook_id=sb_id,
+        name="P",
+        slug="p",
+    )
+    session.add(proj)
+    session.commit()
+    session.refresh(proj)
+    return sb_id, int(proj.id)  # type: ignore[arg-type]
+
+
+def test_normalize_geojson_type_preserves_multipolygon() -> None:
+    # ``str.title()`` turns MultiPolygon into Multipolygon — that must never gate WKT.
+    assert normalize_geojson_type("MultiPolygon") == "MultiPolygon"
+    assert normalize_geojson_type("multipolygon") == "MultiPolygon"
+    assert normalize_geojson_type("LineString") == "LineString"
+    assert normalize_geojson_type("linestring") == "LineString"
+
+
+def test_geojson_to_wkt_multipolygon() -> None:
+    wkt = geojson_to_wkt(ROUTE_W_MULTIPOLYGON)
+    assert wkt is not None
+    assert wkt.startswith("MULTIPOLYGON ((")
+    assert "-92.1805 38.5943" in wkt
+
+
+def test_geojson_to_wkt_linestring() -> None:
+    wkt = geojson_to_wkt(
+        {
+            "type": "LineString",
+            "coordinates": [[-92.18, 38.59], [-92.17, 38.60]],
+        }
+    )
+    assert wkt is not None
+    assert wkt.startswith("LINESTRING (")
+    assert "-92.18 38.59" in wkt
+    assert "-92.17 38.6" in wkt
+
+
+def test_assign_geojson_geometry_writes_postgis_for_multipolygon() -> None:
+    engine = create_engine("sqlite://", echo=False)
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as session:
+        _sb_id, project_id = _seed_project(session, slug_suffix="mp")
+        loc = SubstrateLocation(
+            project_id=project_id,
+            name="Route W",
+            normalized_name="route w",
+            location_type="street_road",
+            identity_fingerprint="fp-route-w",
+            geometry_json={"type": "Point", "coordinates": [-92.0, 38.0]},
+            geometry="POINT (-92.0 38.0)",
+            geometry_type="Point",
+        )
+        session.add(loc)
+        session.commit()
+        session.refresh(loc)
+
+        assign_geojson_geometry(session, loc, ROUTE_W_MULTIPOLYGON)
+        session.add(loc)
+        session.commit()
+        session.refresh(loc)
+
+        assert loc.geometry_json == ROUTE_W_MULTIPOLYGON
+        assert loc.geometry_type == "MultiPolygon"
+        assert loc.geometry is not None
+        assert str(loc.geometry).startswith("MULTIPOLYGON")
+        assert loc.h3_cell is not None
+        assert loc.h3_resolution == 8
+
+
+def test_assign_geojson_geometry_rejects_unconvertible_shape() -> None:
+    engine = create_engine("sqlite://", echo=False)
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as session:
+        sb_id, _project_id = _seed_project(session, slug_suffix="bad")
+        row = StylebookLocationCanonical(
+            stylebook_id=sb_id,
+            label="Bad",
+            slug="bad",
+            location_type="street_road",
+            primary_substrate_location_id=None,
+            status="active",
+            geometry="POINT (0 0)",
+            geometry_json={"type": "Point", "coordinates": [0, 0]},
+            geometry_type="Point",
+        )
+        session.add(row)
+        session.commit()
+        with pytest.raises(GeometryBindError):
+            assign_geojson_geometry(
+                session,
+                row,
+                {"type": "MultiPolygon", "coordinates": []},
+            )
+        # Prior PostGIS must remain — never half-update GeoJSON while clearing geometry.
+        session.refresh(row)
+        assert row.geometry is not None
+        assert row.geometry_json == {"type": "Point", "coordinates": [0, 0]}
+
+
+def test_rebind_missing_postgis_from_geometry_json() -> None:
+    engine = create_engine("sqlite://", echo=False)
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as session:
+        sb_id, project_id = _seed_project(session, slug_suffix="rebind")
+        canon = StylebookLocationCanonical(
+            stylebook_id=sb_id,
+            label="Route W",
+            slug="route-w",
+            location_type="street_road",
+            primary_substrate_location_id=None,
+            status="active",
+            geometry_json=ROUTE_W_MULTIPOLYGON,
+            geometry_type="MultiPolygon",
+            geometry=None,
+            h3_cell="8826550d37fffff",
+            h3_resolution=8,
+        )
+        session.add(canon)
+        session.commit()
+        session.refresh(canon)
+
+        loc = SubstrateLocation(
+            project_id=project_id,
+            name="Route W",
+            normalized_name="route w",
+            location_type="street_road",
+            identity_fingerprint="fp-route-w-rebind",
+            stylebook_location_canonical_id=str(canon.id),
+            geometry_json=ROUTE_W_MULTIPOLYGON,
+            geometry_type="MultiPolygon",
+            geometry=None,
+            h3_cell="8826550d37fffff",
+            h3_resolution=8,
+        )
+        session.add(loc)
+        session.commit()
+        session.refresh(loc)
+        sid = int(loc.id)  # type: ignore[arg-type]
+        cid = str(canon.id)
+
+        dry = rebind_missing_location_postgis_geometry(session, dry_run=True)
+        assert dry.rebound_count == 2
+        assert cid in dry.canonical_ids
+        assert sid in dry.substrate_ids
+        session.refresh(loc)
+        assert loc.geometry is None
+
+        applied = rebind_missing_location_postgis_geometry(session, dry_run=False)
+        session.commit()
+        assert applied.rebound_count == 2
+        session.refresh(loc)
+        session.refresh(canon)
+        assert loc.geometry is not None
+        assert str(loc.geometry).startswith("MULTIPOLYGON")
+        assert canon.geometry is not None
+        assert str(canon.geometry).startswith("MULTIPOLYGON")


### PR DESCRIPTION
## Summary

- Fix `geojson_to_wkt` type normalization: `str.title()` turned `MultiPolygon`/`LineString` into non-matching names, so editorial geometry reassignment wrote GeoJSON/H3 but cleared PostGIS — article geo-search then matched nowhere.
- Reject unconvertible GeoJSON before mutating the row (`GeometryBindError` → HTTP 400) so writes never leave half-updated locations.
- Add a hidden one-off rebind script (`uv run python scripts/rebind_location_postgis_geometry.py`, dry-run by default; `--apply` to commit) for rows already stuck with GeoJSON but null PostGIS. Not registered on the `backfield` CLI menu.

## Project scope check

- [x] This change targets local development / source inspection (production self-hosting is unsupported in this repo)
- [x] Docs under `docs/` updated if behavior, architecture, or operations changed
- [x] First-admin provisioning still uses `backfield init` / `backfield seed` only (no HTTP/env bootstrap paths)

## Test plan

- [x] `make lint`
- [x] `make test`
- [ ] `make ui-typecheck ui-test` (if UI/TypeScript changed)
- [ ] `make smoke-fast` (if live-stack behavior changed)
- [ ] `make smoke` (if golden-path / provider-dependent runtime changed; configure **Settings → AI models**)
- [ ] After deploy/backfill: `GET /public/v1/projects/general/articles/geo-search?bbox=-92.20,38.57,-92.15,38.62&location_type=street_road&pub_date_from=2026-08-25` returns article 2539 with Route W in `matching_locations`
- [ ] Same article no longer matches Route W in bboxes outside the corrected footprint
- [ ] Re-edit a canonical MultiPolygon geometry, apply to linked saved places, and confirm immediate geo-search hit

## Notes for reviewers

- Concrete bug: Stylebook MultiPolygon reassignment (e.g. Route W, Callaway County) updated the mention read model but left PostGIS null, so `/articles/geo-search` dropped the mention entirely.
- Backfill: `uv run python scripts/rebind_location_postgis_geometry.py --json` then `--apply` against the affected DB (optionally `--stylebook-id`).

Made with [Cursor](https://cursor.com)