### PR TITLE
Stop Celery claim-collision requeue storms after SIGKILL/OOM

### DIFF
--- a/apps/worker/src/worker/processed_item_claims.py
+++ b/apps/worker/src/worker/processed_item_claims.py
@@ -66,8 +66,17 @@ def should_reconcile_orphan_running_items(
     *,
     run_id: str,
     concurrency: int = _WORKER_CONCURRENCY,
+    active_count: int | None = None,
 ) -> bool:
-    if running_count <= concurrency:
+    """Return True when orphan reconcile should run (interval-throttled).
+
+    Reconcile when running claims exceed configured concurrency, or when
+    ``active_count`` is provided and running claims exceed live Celery
+    executions for this pool (SIGKILL/OOM can leave claims without workers).
+    """
+    over_concurrency = running_count > concurrency
+    over_active = active_count is not None and running_count > active_count
+    if not (over_concurrency or over_active):
         return False
     now = time.monotonic()
     last = _orphan_reconcile_last_by_run.get(run_id, 0.0)

--- a/apps/worker/src/worker/tasks.py
+++ b/apps/worker/src/worker/tasks.py
@@ -92,8 +92,7 @@ from backfield_observability.lifecycle import (
     emit_worker_lost,
     worker_identity,
 )
-from celery import Celery, chord, group
-from celery.exceptions import Reject
+from celery import Celery, Task, chord, group
 from sqlalchemy import delete, func, update
 from sqlalchemy.engine import Engine
 from sqlmodel import Session, col, select
@@ -102,6 +101,7 @@ from worker.flags.replace_geography import clear_replace_article_geography_flags
 from worker.nodes.db_output import run_db_output
 from worker.processed_item_claims import (
     active_execute_processed_item_ids,
+    is_orphan_running_item,
     release_orphan_running_items_for_run,
     release_running_claim,
     should_reconcile_orphan_running_items,
@@ -155,6 +155,9 @@ _TASK_HARD_TIME_LIMIT = int(os.getenv("TASK_HARD_TIME_LIMIT", "4200"))
 _STALE_RUNNING_GRACE_S = int(os.getenv("TASK_STALE_RUNNING_GRACE_S", "300"))
 _STALE_RUNNING_AFTER_S = _TASK_HARD_TIME_LIMIT + _STALE_RUNNING_GRACE_S
 _STALE_RUNNING_MESSAGE = "Processing interrupted (worker lost or exceeded time limit)"
+# Backoff when a redelivered task cannot claim a still-running row (avoids Reject requeue storms).
+_CLAIM_COLLISION_RETRY_BASE_S = 5
+_CLAIM_COLLISION_RETRY_MAX_S = 60
 
 _current_processed_item_id: contextvars.ContextVar[int | None] = contextvars.ContextVar(
     "current_processed_item_id",
@@ -174,6 +177,24 @@ def _is_stale_running_item(item: AgateProcessedItem, *, now: datetime | None = N
     if touch.tzinfo is None:
         touch = touch.replace(tzinfo=UTC)
     return (now - touch).total_seconds() > _STALE_RUNNING_AFTER_S
+
+
+def _claim_collision_countdown(retries: int) -> int:
+    """Exponential countdown seconds for claim-collision retries (capped)."""
+    return min(
+        _CLAIM_COLLISION_RETRY_MAX_S,
+        _CLAIM_COLLISION_RETRY_BASE_S * (2 ** max(0, retries)),
+    )
+
+
+def _retry_after_claim_collision(task: Task, item_id: int) -> None:
+    countdown = _claim_collision_countdown(int(getattr(task.request, "retries", 0) or 0))
+    logger.info(
+        "Claim collision for processed_item id=%s; retrying in %ss",
+        item_id,
+        countdown,
+    )
+    raise task.retry(countdown=countdown)
 
 
 def _reap_stale_running_items_for_run(
@@ -1451,21 +1472,27 @@ def execute_run_replay_setup(source_run_id: str, new_run_id: str) -> None:
 
 
 @celery_app.task(
+    bind=True,
     name="worker.tasks.execute_processed_item",
     soft_time_limit=_TASK_SOFT_TIME_LIMIT,
     time_limit=_TASK_HARD_TIME_LIMIT,
     acks_late=True,
     reject_on_worker_lost=True,
+    max_retries=None,
 )
-def execute_processed_item(item_id: int, spec_json: str | None = None) -> None:
+def execute_processed_item(self: Task, item_id: int, spec_json: str | None = None) -> None:
     token = _current_processed_item_id.set(int(item_id))
     try:
-        _execute_processed_item_impl(item_id, spec_json=spec_json)
+        _execute_processed_item_impl(self, item_id, spec_json=spec_json)
     finally:
         _current_processed_item_id.reset(token)
 
 
-def _execute_processed_item_impl(item_id: int, spec_json: str | None = None) -> None:
+def _execute_processed_item_impl(
+    task: Task,
+    item_id: int,
+    spec_json: str | None = None,
+) -> None:
     engine = get_engine()
     claimed_at: datetime
     with Session(engine) as session:
@@ -1484,13 +1511,20 @@ def _execute_processed_item_impl(item_id: int, spec_json: str | None = None) -> 
             )
             or 0
         )
+        active_ids = active_execute_processed_item_ids(celery_app)
+        # Include this task so batch orphan reconcile does not release the row we
+        # are about to claim. Claim-miss orphan checks use ``active_ids`` alone.
+        reconcile_active_ids = active_ids | {int(item_id)}
         released = 0
-        if should_reconcile_orphan_running_items(running_count, run_id=item.run_id):
-            active_ids = active_execute_processed_item_ids(celery_app) | {int(item_id)}
+        if should_reconcile_orphan_running_items(
+            running_count,
+            run_id=item.run_id,
+            active_count=len(reconcile_active_ids),
+        ):
             released = release_orphan_running_items_for_run(
                 session,
                 item.run_id,
-                active_item_ids=active_ids,
+                active_item_ids=reconcile_active_ids,
             )
         if reaped or released:
             logger.info(
@@ -1501,11 +1535,23 @@ def _execute_processed_item_impl(item_id: int, spec_json: str | None = None) -> 
                 released,
             )
             session.commit()
-        if not _try_claim_processed_item(session, item):
-            if item.status == "running":
-                # Another worker holds a fresh claim; requeue until the lease goes stale
-                # or orphan reconcile returns the row to pending.
-                raise Reject(requeue=True)
+        claimed = _try_claim_processed_item(session, item)
+        if not claimed and item.status == "running":
+            # SIGKILL/OOM can leave a running claim with no live worker. Prefer
+            # releasing an orphan and reclaiming; otherwise delay instead of
+            # Reject(requeue=True), which storms Redis/CPU with immediate redeliveries.
+            if is_orphan_running_item(item, active_item_ids=active_ids):
+                if release_running_claim(
+                    session,
+                    int(item.id),
+                    observed_started_at=item.started_at,
+                ):
+                    session.refresh(item)
+                    claimed = _try_claim_processed_item(session, item)
+            if not claimed:
+                session.commit()
+                _retry_after_claim_collision(task, item_id)
+        if not claimed:
             return
         if item.started_at is None:
             session.rollback()

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -47,7 +47,7 @@ Check:
 3. that producer and worker use the same `CELERY_QUEUE` (`agate` by default)
 4. that the worker has the graph's provider credentials
 
-For a batch with many UI items marked Running but few active Celery tasks, old claims may remain after child crashes. The worker reconciles inactive claims using `BATCH_ORPHAN_RUNNING_AFTER_S` and `BATCH_ORPHAN_RECONCILE_INTERVAL_S`. After reconciliation, retry failed items from Agate UI.
+For a batch with many UI items marked Running but few active Celery tasks, old claims may remain after child crashes. The worker reconciles inactive claims when running rows exceed concurrency **or** exceed the inspected active Celery task count, throttled by `BATCH_ORPHAN_RECONCILE_INTERVAL_S` and aged by `BATCH_ORPHAN_RUNNING_AFTER_S`. After reconciliation, retry failed items from Agate UI.
 
 ## APIs slow down during a large run
 
@@ -69,6 +69,8 @@ If Backfield Output repeatedly reports deadlocks, workers may be updating the sa
 Signal 9 without a Celery time-limit message usually indicates an out-of-memory kill. Total memory grows with `CELERY_WORKER_CONCURRENCY` because each prefork child has an import baseline plus the current article's working set.
 
 Lower concurrency or increase the container/Docker VM memory allocation. `CELERY_MAX_MEMORY_PER_CHILD_KB` replaces a child only after a task completes; it cannot prevent a single task from exceeding container memory.
+
+After SIGKILL/OOM, `acks_late` redelivers tasks while DB claims may still be `running`. The worker releases aged orphan claims (or retries claim collisions with countdown backoff) instead of `Reject(requeue=True)`, which previously pegged CPU with immediate requeue storms. Look for `Claim collision for processed_item` and orphan-release log lines; if storms recur, confirm orphan reconcile is firing (`running` count above live active tasks) and that `BATCH_ORPHAN_RUNNING_AFTER_S` is not far longer than your crash-recovery window.
 
 ## Worker timeouts
 

--- a/tests/worker/test_processed_item_claims.py
+++ b/tests/worker/test_processed_item_claims.py
@@ -2,12 +2,26 @@
 
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 
-from backfield_db import AgateProcessedItem
+import pytest
+from backfield_db import (
+    AgateGraph,
+    AgateProcessedItem,
+    AgateRun,
+    BackfieldOrganization,
+    BackfieldProject,
+)
+from celery.exceptions import Retry
 from sqlalchemy import event, update
 from sqlmodel import Session, SQLModel, create_engine
 from worker import processed_item_claims as claims
+from worker import tasks as worker_tasks
+
+from tests.project_helpers import project_ownership_fields
 
 
 def test_is_orphan_running_item_when_not_active_and_old_enough() -> None:
@@ -30,6 +44,51 @@ def test_is_not_orphan_when_item_is_actively_executing() -> None:
         started_at=now - timedelta(seconds=claims._ORPHAN_RUNNING_AFTER_S + 60),
     )
     assert not claims.is_orphan_running_item(item, active_item_ids={9}, now=now)
+
+
+def test_should_reconcile_when_running_exceeds_concurrency() -> None:
+    claims._orphan_reconcile_last_by_run.clear()
+    assert claims.should_reconcile_orphan_running_items(
+        17,
+        run_id="gate-concurrency",
+        concurrency=16,
+    )
+
+
+def test_should_reconcile_when_running_exceeds_active_count() -> None:
+    claims._orphan_reconcile_last_by_run.clear()
+    assert claims.should_reconcile_orphan_running_items(
+        5,
+        run_id="gate-active",
+        concurrency=16,
+        active_count=2,
+    )
+
+
+def test_should_not_reconcile_when_within_concurrency_and_active() -> None:
+    claims._orphan_reconcile_last_by_run.clear()
+    assert not claims.should_reconcile_orphan_running_items(
+        5,
+        run_id="gate-ok",
+        concurrency=16,
+        active_count=5,
+    )
+
+
+def test_should_reconcile_keeps_interval_throttle() -> None:
+    claims._orphan_reconcile_last_by_run.clear()
+    assert claims.should_reconcile_orphan_running_items(
+        20,
+        run_id="gate-throttle",
+        concurrency=16,
+        active_count=1,
+    )
+    assert not claims.should_reconcile_orphan_running_items(
+        20,
+        run_id="gate-throttle",
+        concurrency=16,
+        active_count=1,
+    )
 
 
 def test_release_orphan_running_items_for_run() -> None:
@@ -154,3 +213,164 @@ def test_orphan_reconciliation_selects_only_claim_columns() -> None:
         "reviewed_output_json",
     ):
         assert forbidden not in item_selects[0]
+
+
+def _text_flow_spec() -> str:
+    return json.dumps(
+        {
+            "name": "claim_collision",
+            "nodes": [
+                {"id": "t", "type": "TextInput", "params": {"text": "Hello."}},
+                {"id": "out", "type": "Output", "params": {}},
+            ],
+            "edges": [
+                {"source": "t", "target": "out", "sourceHandle": "text", "targetHandle": "data"},
+            ],
+        }
+    )
+
+
+@pytest.fixture
+def claim_collision_engine(tmp_path, monkeypatch):
+    url = f"sqlite:///{tmp_path}/claim_collision.db"
+    monkeypatch.setenv("BACKFIELD_DATABASE_URL", url)
+    import backfield_db.session as db_session
+
+    db_session._engine = None
+    engine = create_engine(url, connect_args={"check_same_thread": False})
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as session:
+        org = BackfieldOrganization(name="Backfield", slug="default")
+        session.add(org)
+        session.commit()
+        session.refresh(org)
+        ensure_default = __import__(
+            "backfield_entities.catalog.bootstrap",
+            fromlist=["ensure_default_stylebook_for_organization"],
+        ).ensure_default_stylebook_for_organization
+        ensure_default(session, organization_id=int(org.id))
+        project = BackfieldProject(
+            **project_ownership_fields(session, int(org.id)),
+            organization_id=int(org.id),
+            name="Claims",
+            slug="claim-collision",
+        )
+        session.add(project)
+        session.commit()
+        session.refresh(project)
+        graph = AgateGraph(
+            project_id=int(project.id),
+            name="flow",
+            spec_json=_text_flow_spec(),
+        )
+        session.add(graph)
+        session.commit()
+        session.refresh(graph)
+        run = AgateRun(graph_id=graph.id, status="running")
+        session.add(run)
+        session.commit()
+        session.refresh(run)
+        item = AgateProcessedItem(
+            run_id=run.id,
+            source_file="inline:text",
+            input_json=json.dumps({"text": "Hello."}),
+            status="pending",
+        )
+        session.add(item)
+        session.commit()
+        session.refresh(item)
+        yield engine, int(item.id), run.id
+    db_session._engine = None
+
+
+def _mock_task(*, retries: int = 0) -> MagicMock:
+    task = MagicMock()
+    task.request = SimpleNamespace(retries=retries, called_directly=False, is_eager=False)
+
+    def _retry(*, countdown: float, **_kwargs: object) -> Retry:
+        raise Retry("retry", None, when=countdown)
+
+    task.retry.side_effect = _retry
+    return task
+
+
+def test_claim_miss_releases_orphan_and_reclaims(claim_collision_engine, monkeypatch) -> None:
+    engine, item_id, _run_id = claim_collision_engine
+    orphan_started = datetime.now(UTC) - timedelta(seconds=claims._ORPHAN_RUNNING_AFTER_S + 30)
+    with Session(engine) as session:
+        item = session.get(AgateProcessedItem, item_id)
+        assert item is not None
+        item.status = "running"
+        item.started_at = orphan_started
+        session.add(item)
+        session.commit()
+
+    monkeypatch.setattr(worker_tasks, "active_execute_processed_item_ids", lambda _app: set())
+    monkeypatch.setattr(
+        worker_tasks,
+        "should_reconcile_orphan_running_items",
+        lambda *_a, **_k: False,
+    )
+    monkeypatch.setattr(worker_tasks, "_reap_stale_running_items_for_run", lambda *_a, **_k: 0)
+    monkeypatch.setattr(
+        worker_tasks,
+        "merge_project_and_org_llm_api_keys",
+        lambda *_a, **_k: {},
+    )
+
+    task = _mock_task()
+    worker_tasks._execute_processed_item_impl(task, item_id)
+
+    task.retry.assert_not_called()
+    with Session(engine) as session:
+        item = session.get(AgateProcessedItem, item_id)
+        assert item is not None
+        assert item.status == "succeeded"
+        assert item.started_at is not None
+        assert item.started_at.replace(tzinfo=UTC) > orphan_started
+
+
+def test_claim_miss_retries_with_countdown_when_not_orphan(
+    claim_collision_engine, monkeypatch
+) -> None:
+    engine, item_id, _run_id = claim_collision_engine
+    with Session(engine) as session:
+        item = session.get(AgateProcessedItem, item_id)
+        assert item is not None
+        item.status = "running"
+        item.started_at = datetime.now(UTC) - timedelta(seconds=30)
+        session.add(item)
+        session.commit()
+
+    monkeypatch.setattr(
+        worker_tasks,
+        "active_execute_processed_item_ids",
+        lambda _app: {item_id},
+    )
+    monkeypatch.setattr(
+        worker_tasks,
+        "should_reconcile_orphan_running_items",
+        lambda *_a, **_k: False,
+    )
+    monkeypatch.setattr(worker_tasks, "_reap_stale_running_items_for_run", lambda *_a, **_k: 0)
+
+    task = _mock_task(retries=1)
+    with pytest.raises(Retry) as raised:
+        worker_tasks._execute_processed_item_impl(task, item_id)
+
+    expected = worker_tasks._claim_collision_countdown(1)
+    assert raised.value.when == expected
+    task.retry.assert_called_once()
+    assert task.retry.call_args.kwargs["countdown"] == expected
+
+    with Session(engine) as session:
+        item = session.get(AgateProcessedItem, item_id)
+        assert item is not None
+        assert item.status == "running"
+
+
+def test_claim_collision_countdown_caps() -> None:
+    assert worker_tasks._claim_collision_countdown(0) == 5
+    assert worker_tasks._claim_collision_countdown(1) == 10
+    assert worker_tasks._claim_collision_countdown(2) == 20
+    assert worker_tasks._claim_collision_countdown(10) == 60


### PR DESCRIPTION
## Summary

After worker children die via SIGKILL/OOM, `acks_late` redelivers tasks while DB claims can stay `running`. Those redeliveries previously hit `Reject(requeue=True)` with no backoff, and orphan reconcile often did not run because it required `running_count > CELERY_WORKER_CONCURRENCY` even when claims already exceeded live Celery tasks—producing CPU-pegging requeue storms.

- Reconcile orphan running claims when `running_count > concurrency` **or** `running_count > active_count` (still interval-throttled).
- On claim miss for a running item: release+reclaim if orphan; otherwise `task.retry` with capped exponential countdown instead of immediate requeue.
- Document the SIGKILL/OOM storm failure mode in `docs/operations/troubleshooting.md`.

## Project scope check

- [x] This change targets local development / source inspection (production self-hosting is unsupported in this repo)
- [x] Docs under `docs/` updated if behavior, architecture, or operations changed
- [x] First-admin provisioning still uses `backfield init` / `backfield seed` only (no HTTP/env bootstrap paths)

## Test plan

- [x] `make lint` (ruff on touched worker/test files)
- [ ] `make test`
- [ ] `make ui-typecheck ui-test` (if UI/TypeScript changed)
- [ ] `make smoke-fast` (if live-stack behavior changed)
- [ ] `make smoke` (if golden-path / provider-dependent runtime changed; configure **Settings → AI models**)
- [x] Targeted: `uv run pytest tests/worker/test_processed_item_claims.py tests/worker/test_stale_running_items.py tests/worker/test_cancel_race.py tests/worker/test_single_item_worker.py`

## Notes for reviewers

- `execute_processed_item` is now `bind=True` with `max_retries=None` so claim-collision backoff can retry indefinitely with countdown.
- Claim-miss orphan checks use the Celery inspect snapshot **without** unioning the current `item_id` (reconcile still includes self so it does not release the row about to be claimed).
- No backfield-cloud changes.

Made with [Cursor](https://cursor.com)