### PR TITLE
Mark failed batch-setup runs instead of deadlocking on the worker's single connection

### DIFF
--- a/apps/worker/src/worker/tasks.py
+++ b/apps/worker/src/worker/tasks.py
@@ -1011,7 +1011,12 @@ def execute_json_input_batch_setup(run_id: str) -> None:
             chord(header, finalize_s3_parent_run.s(run_id)).apply_async(queue=_queue)
         except Exception as e:
             logger.exception("JSON Input batch setup failed for run %s", run_id)
-            with Session(engine) as session3:
+            # Unpooled Session: the enclosing `with Session(engine)` above is still
+            # held here, and the worker runs pool_size=1 / max_overflow=0, so asking
+            # the pool for a second connection blocks until it times out and this
+            # handler never marks the run failed. Same rule as
+            # _fail_stylebook_bundle_job below.
+            with null_pool_session() as session3:
                 run_fail = session3.exec(
                     select(AgateRun)
                     .where(AgateRun.id == run_id)
@@ -1356,7 +1361,12 @@ def execute_s3_batch_setup(run_id: str) -> None:
             chord(header, finalize_s3_parent_run.s(run_id)).apply_async(queue=_queue)
         except Exception as e:
             logger.exception("S3 batch setup failed for run %s", run_id)
-            with Session(engine) as session3:
+            # Unpooled Session: the enclosing `with Session(engine)` above is still
+            # held here, and the worker runs pool_size=1 / max_overflow=0, so asking
+            # the pool for a second connection blocks until it times out and this
+            # handler never marks the run failed. Same rule as
+            # _fail_stylebook_bundle_job below.
+            with null_pool_session() as session3:
                 run_fail = session3.exec(
                     select(AgateRun)
                     .where(AgateRun.id == run_id)

--- a/tests/worker/test_no_nested_pooled_sessions.py
+++ b/tests/worker/test_no_nested_pooled_sessions.py
@@ -1,0 +1,128 @@
+"""The worker must never open a pooled Session while it already holds one.
+
+The worker runs with ``pool_size=1`` and ``max_overflow=0``
+(``infra/docker-compose.yml``), so a second ``Session(engine)`` opened while an
+outer one is still held can never be served: it blocks for the pool timeout and
+raises ``TimeoutError``.
+
+That is not a theoretical hazard. It silently broke run failure reporting. When
+``execute_s3_batch_setup`` raised, the ``except`` block that marks the run
+``failed`` opened a nested ``Session(engine)``, timed out, and the run stayed
+``running`` forever with ``error_message`` NULL -- so the original error survived
+only in the worker log and ``status == "running"`` stopped meaning "still
+working".
+
+``null_pool_session()`` exists for exactly this case and says so in its
+docstring. This test enforces the rule across the whole module rather than
+pinning the two handlers that were wrong, so a future nested session anywhere in
+``tasks.py`` fails here instead of in production.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+TASKS = (
+    pathlib.Path(__file__).resolve().parents[2]
+    / "apps"
+    / "worker"
+    / "src"
+    / "worker"
+    / "tasks.py"
+)
+
+
+def _opens_pooled_session(node: ast.With) -> bool:
+    """True when this ``with`` opens ``Session(engine)`` from the process pool."""
+    for item in node.items:
+        call = item.context_expr
+        if not isinstance(call, ast.Call):
+            continue
+        func = call.func
+        name = func.id if isinstance(func, ast.Name) else getattr(func, "attr", None)
+        if name != "Session":
+            continue
+        # ``Session(engine)`` uses the shared pool; ``Session(some_other_engine)``
+        # does not necessarily, so only flag the pooled one.
+        for arg in call.args:
+            if isinstance(arg, ast.Name) and arg.id == "engine":
+                return True
+    return False
+
+
+def _nested_pooled_sessions(tree: ast.AST) -> list[tuple[str, int, int]]:
+    """Every (function, outer line, inner line) where a pooled Session nests."""
+    found: list[tuple[str, int, int]] = []
+
+    for func in ast.walk(tree):
+        if not isinstance(func, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+
+        def visit(node: ast.AST, outer_line: int | None) -> None:
+            for child in ast.iter_child_nodes(node):
+                # Do not descend into a nested function: it runs with its own
+                # call stack and may legitimately open its own session.
+                if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    continue
+                if isinstance(child, ast.With) and _opens_pooled_session(child):
+                    if outer_line is not None:
+                        found.append((func.name, outer_line, child.lineno))
+                    visit(child, child.lineno)
+                else:
+                    visit(child, outer_line)
+
+        visit(func, None)
+
+    return found
+
+
+def test_tasks_module_is_parseable() -> None:
+    """Guards the guard: a parse failure must not read as 'no violations'."""
+    assert TASKS.is_file(), f"{TASKS} not found"
+    tree = ast.parse(TASKS.read_text())
+    functions = [n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef)]
+    assert len(functions) > 20, "parsed far fewer functions than expected"
+
+
+def test_no_pooled_session_is_opened_inside_another() -> None:
+    tree = ast.parse(TASKS.read_text())
+    violations = _nested_pooled_sessions(tree)
+    assert not violations, (
+        "a pooled Session(engine) is opened while another is still held; on the "
+        "worker (pool_size=1, max_overflow=0) that cannot be served and will time "
+        "out. Use null_pool_session() for the inner one. Offenders "
+        "(function, outer line, inner line): " + repr(violations)
+    )
+
+
+def test_the_detector_finds_a_known_nested_case() -> None:
+    """Proves the check above is not vacuous by giving it a violation to find."""
+    source = """
+def handler():
+    with Session(engine) as outer:
+        try:
+            work(outer)
+        except Exception:
+            with Session(engine) as inner:
+                mark_failed(inner)
+"""
+    violations = _nested_pooled_sessions(ast.parse(source))
+    assert [v[0] for v in violations] == ["handler"]
+
+    fixed = source.replace(
+        "with Session(engine) as inner:", "with null_pool_session() as inner:"
+    )
+    assert _nested_pooled_sessions(ast.parse(fixed)) == []
+
+
+def test_the_detector_allows_sequential_pooled_sessions() -> None:
+    """Opening one after another closes is fine and must not be flagged."""
+    source = """
+def handler():
+    with Session(engine) as first:
+        work(first)
+    with Session(engine) as second:
+        work(second)
+"""
+    assert _nested_pooled_sessions(ast.parse(source)) == []


### PR DESCRIPTION
## Summary

`execute_s3_batch_setup` and `execute_json_input_batch_setup` hold a pooled `Session` for the whole of their body. When either raises, the `except` block that marks the run `failed` opened a **second** pooled `Session`. The worker runs `pool_size=1, max_overflow=0`, so that checkout cannot be served while the outer session holds the only connection — it blocks for the full 30s and raises `TimeoutError` from inside the handler.

The run is therefore never marked failed. It stays `running` with `error_message` NULL, and the original error survives only in the worker log — so `status == "running"` stops meaning "still working".

We hit this on an `S3Input` run whose listing failed on a stale credential of ours. The triggering error was our fault; the handler failing on top of it left the run stuck for hours:

```
ClientError: SignatureDoesNotMatch ... calling the ListObjectsV2 operation
  tasks.py, in execute_s3_batch_setup

During handling of the above exception, another exception occurred:
TimeoutError('QueuePool limit of size 1 overflow 0 reached,
              connection timed out, timeout 30.00')
```

Both handlers now use `null_pool_session()`, which exists for exactly this case and says so in its docstring:

> Use when a long-held pooled Session (worker `pool_size=1`) must not block a nested progress/status write.

It was already imported in this module and already used correctly by `_fail_stylebook_bundle_job` — the same "mark it failed" operation — so this reads as two missed call sites rather than a design change.

**When it bites, precisely**, since it is not every failure: the outer session commits partway through, and after a commit its connection returns to the pool, so a failure *after* that point finds one free. The S3 listing runs *before* the first commit, with the outer transaction already open. So the most likely failure in this task is also the one guaranteed to deadlock its own handler.

## Project scope check

- [x] This change targets local development / source inspection (production self-hosting is unsupported in this repo)
- [x] Docs under `docs/` updated if behavior, architecture, or operations changed — no doc change needed; this restores documented behaviour rather than altering it
- [x] First-admin provisioning still uses `backfield init` / `backfield seed` only (no HTTP/env bootstrap paths)

Reproduces on the default local Compose stack, which ships the worker at `pool_size=1, max_overflow=0`.

## Test plan

- [x] `make lint` — clean
- [x] `make test` — 2217 passed, 14 skipped
- [ ] `make ui-typecheck ui-test` — not applicable, no UI/TypeScript change
- [ ] `make smoke-fast` — not run; see note below
- [ ] `make smoke` — not run; see note below

The new test, `tests/worker/test_no_nested_pooled_sessions.py`, enforces the rule across the whole module rather than pinning the two handlers that were wrong: it walks the AST of `tasks.py` and fails if **any** function opens a pooled `Session(engine)` while another is still held.

Run against the unfixed tree it fails and names both offenders:

```
AssertionError: a pooled Session(engine) is opened while another is still held ...
Offenders (function, outer line, inner line):
  [('execute_json_input_batch_setup', 889, 1014),
   ('execute_s3_batch_setup', 1043, 1359)]
```

It also carries its own controls, so it cannot pass vacuously: a known-bad snippet it must flag, the fixed form of that snippet it must clear, sequential (non-nested) pooled sessions it must **not** flag, and a parse guard so an unreadable `tasks.py` cannot report "no violations".

## Reproduction

No broken credentials needed — make the listing raise anything:

1. Point an `S3Input` graph at a bucket the worker cannot read, or stub `list_json_objects_under_prefix` to raise.
2. Trigger a run on the default local stack.
3. Before this change: the run sits at `running` with `error_message` NULL, and the log shows the real error followed by the `QueuePool` timeout ~30s later. After: the run is marked `failed` and carries the original error.

## Notes for reviewers

**Risk is low.** The change is two `with` statements; `null_pool_session()` disposes its temporary engine in a `finally`, and the handler's logic is untouched.

**Not fixed here, flagged for your call:** because the handler dies before its first write, nothing reaches `error_message` and the failure is invisible outside the worker log. Writing `status` and `error_message` first, then `record_run_terminal_event` / `emit_run_terminal`, would make a run's failure visible even if a later step in the handler fails. That is a behavioural change rather than a bug fix, so it is not in this PR.

**Not run:** `make smoke-fast` / `make smoke`. This path is only reachable when batch setup raises, which neither smoke target exercises, and both need a configured live stack. Happy to run them if you would like the belt and braces.

Found while preparing a 100-article ingest pilot against our own archive at The Baltimore Banner — a run that had actually failed would have been counted as pending rather than surfacing as an error, which is what sent us looking.
